### PR TITLE
feat: implement OSPS-VM-01.01 vulnerability disclosure policy assessment

### DIFF
--- a/evaluation_plans/osps/vuln_management/evaluations.go
+++ b/evaluation_plans/osps/vuln_management/evaluations.go
@@ -21,7 +21,9 @@ func OSPS_VM_01() (evaluation *layer4.ControlEvaluation) {
 			"Maturity Level 3",
 		},
 		[]layer4.AssessmentStep{
-			reusable_steps.NotImplemented,
+			reusable_steps.IsActive,
+			reusable_steps.HasSecurityInsightsFile,
+			hasVulnerabilityDisclosurePolicy,
 		},
 	)
 

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -47,3 +47,16 @@ func sastToolDefined(payloadData interface{}, _ map[string]*layer4.Change) (resu
 
 	return layer4.Failed, "No Static Application Security Testing documented in Security Insights"
 }
+
+func hasVulnerabilityDisclosurePolicy(payloadData any, _ map[string]*layer4.Change) (result layer4.Result, message string) {
+	data, message := reusable_steps.VerifyPayload(payloadData)
+	if message != "" {
+		return layer4.Unknown, message
+	}
+
+	if data.Insights.Project.Vulnerability.SecurityPolicy == "" {
+		return layer4.Failed, "Vulnerability disclosure policy was NOT specified in Security Insights data"
+	}
+
+	return layer4.Passed, "Vulnerability disclosure policy was specified in Security Insights data"
+}


### PR DESCRIPTION
- Add hasVulnerabilityDisclosurePolicy function to check SecurityPolicy field
- Update OSPS-VM-01.01 assessment steps: IsActive -> HasSecurityInsightsFile -> hasVulnerabilityDisclosurePolicy
- Add comprehensive tests for policy present/missing/invalid payload scenarios
- Validates project documentation includes vulnerability reporting policy

Closes #32