### PR TITLE
test: Add mock ghclient to TestCheckFile with dependency injection

### DIFF
--- a/data/rest-data_test.go
+++ b/data/rest-data_test.go
@@ -65,7 +65,12 @@ func TestCheckFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mockClient := mock.NewMockedHTTPClient()
+			ghClient := github.NewClient(mockClient)
 			rest := &RestData{
+				ghClient: ghClient,
+				owner:    "test-owner",
+				repo:     "test-repo",
 				contents: RepoContent{
 					Content: tt.toplevel,
 					SubContent: map[string]RepoContent{


### PR DESCRIPTION
Adds mock GitHub client initialization to TestCheckFile following the same pattern used in TestIsCodeRepo. 


Part of revanite-io/pvtr-github-repo#184