### PR TITLE
fix: Add https:// prefix to PluginUri for valid SARIF URI

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	orchestrator := pluginkit.EvaluationOrchestrator{
 		PluginName:    PluginName,
 		PluginVersion: Version,
-		PluginUri:     "github.com/revanite-io/pvtr-github-repo",
+		PluginUri:     "https://github.com/revanite-io/pvtr-github-repo",
 	}
 	orchestrator.AddLoader(data.Loader)
 


### PR DESCRIPTION
Fixes the SARIF validation warning: 'github.com/revanite-io/pvtr-github-repo' is not a valid URI.

SARIF requires URIs to have a valid scheme (like https://). The PluginUri was missing the https:// prefix, causing the warning in GitHub Code Scanning.

Changes:
- Changed from: `github.com/revanite-io/pvtr-github-repo`
- Changed to: `https://github.com/revanite-io/pvtr-github-repo`