### PR TITLE
feat: filter notrun and fix result types

### DIFF
--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -15,7 +15,7 @@ func OrgRequiresMFA(payloadData any) (result layer4.Result, message string) {
 	required := payload.RepositoryMetadata.IsMFARequiredForAdministrativeActions()
 
 	if required == nil {
-		return layer4.NeedsReview, "Not evaluated. Two-factor authentication evaluation requires a token with org:admin permissions, or manual review"
+		return layer4.NotRun, "Not evaluated. Two-factor authentication evaluation requires a token with org:admin permissions, or manual review"
 	} else if *required {
 		return layer4.Passed, "Two-factor authentication is configured as required by the parent organization"
 	}

--- a/evaluation_plans/osps/access_control/steps_test.go
+++ b/evaluation_plans/osps/access_control/steps_test.go
@@ -54,7 +54,7 @@ func Test_OrgRequiresMFA(t *testing.T) {
 			payload: data.Payload{
 				RepositoryMetadata: stubRepoMetadata(nil),
 			},
-			wantResult:  layer4.NeedsReview,
+			wantResult:  layer4.NotRun,
 			wantMessage: "Not evaluated. Two-factor authentication evaluation requires a token with org:admin permissions, or manual review",
 		},
 	}

--- a/evaluation_plans/osps/legal/steps.go
+++ b/evaluation_plans/osps/legal/steps.go
@@ -125,5 +125,5 @@ func GoodLicense(payloadData any) (result layer4.Result, message string) {
 	if len(badLicenses) > 0 {
 		return layer4.Failed, fmt.Sprintf("These licenses are not OSI or FSF approved: %s", strings.Join(badLicenses, ", "))
 	}
-	return layer4.NeedsReview, "All license found are OSI or FSF approved"
+	return layer4.Passed, "All license found are OSI or FSF approved"
 }

--- a/evaluation_plans/osps/legal/steps_test.go
+++ b/evaluation_plans/osps/legal/steps_test.go
@@ -226,7 +226,7 @@ func TestGoodLicense(t *testing.T) {
 			},
 			apiResponse:     []byte(`{"licenses":[{"licenseId":"MIT","isOsiApproved":true,"isFsfLibre":false}]}`),
 			apiError:        nil,
-			expectedResult:  layer4.NeedsReview,
+			expectedResult:  layer4.Passed,
 			expectedMessage: "All license found are OSI or FSF approved",
 		},
 		{

--- a/evaluation_plans/reusable_steps/steps.go
+++ b/evaluation_plans/reusable_steps/steps.go
@@ -17,7 +17,7 @@ func VerifyPayload(payloadData any) (payload data.Payload, message string) {
 }
 
 func NotImplemented(payloadData any) (result layer4.Result, message string) {
-	return layer4.NeedsReview, "Not implemented"
+	return layer4.NotRun, "Not implemented"
 }
 
 func GithubBuiltIn(payloadData any) (result layer4.Result, message string) {


### PR DESCRIPTION
This PR makes three key changes to improve SARIF output and reduce false alerts in GitHub Code Scanning:

**Changes:**
1. **GoodLicense**: Returns `Passed` instead of `NeedsReview` when licenses are OSI/FSF approved
2. **NotImplemented**: Returns `NotRun` instead of `NeedsReview` 
3. **OrgRequiresMFA**: Returns `NotRun` instead of `NeedsReview` when unable to evaluate (missing org:admin permissions)


**Result:**
- Good licenses show as `Passed` (note level)
- `NotImplemented` assessments return `NotRun` (filtered out, won't appear as alerts)
- MFA evaluation failures return `NotRun` (filtered out, won't appear as alerts)