### PR TITLE
chore: update privateer-sdk to v1.14.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/migueleliasweb/go-github-mock v1.4.0
 	github.com/ossf/gemara v0.14.0
 	github.com/ossf/si-tooling/v2 v2.0.5-0.20250508212737-7ddcc8c43db9
-	github.com/privateerproj/privateer-sdk v1.14.0
+	github.com/privateerproj/privateer-sdk v1.14.1
 	github.com/rhysd/actionlint v1.7.8
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
 	golang.org/x/oauth2 v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/privateerproj/privateer-sdk v1.14.0 h1:czyHj89i9vCV0SDrtVqStvfYNsMeoAzpbEk6IHk1ArE=
-github.com/privateerproj/privateer-sdk v1.14.0/go.mod h1:HrUflc6yJM9ltz2lG+GpAJJ1fzpU/lZ+vEmZiZxXWZ4=
+github.com/privateerproj/privateer-sdk v1.14.1 h1:k31IotTAiGSSt5Z9UkG0YjpD77fWNdfFzK9lOepbyFk=
+github.com/privateerproj/privateer-sdk v1.14.1/go.mod h1:HrUflc6yJM9ltz2lG+GpAJJ1fzpU/lZ+vEmZiZxXWZ4=
 github.com/rhysd/actionlint v1.7.8 h1:3d+N9ourgAxVYG4z2IFxFIk/YiT6V+VnKASfXGwT60E=
 github.com/rhysd/actionlint v1.7.8/go.mod h1:3kiS6egcbXG+vQsJIhFxTz+UKaF1JprsE0SKrpCZKvU=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Updates privateer-sdk to v1.14.0 which includes:
- gemara v0.14.0 with NotRun/NotApplicable filtering from SARIF
- Fixes for SARIF tool name metadata