### PR TITLE
refactor: update module path from revanite-io to ossf

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @revanite-io/coders
+* @ossf/orbit-pvtr-plugin-maintainers

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ coverage.out
 
 # A safe space for keeping local development notes
 TODO.md
+
+.claude/

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -2,16 +2,16 @@ package evaluation_plans
 
 import (
 	"github.com/gemaraproj/go-gemara"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/access_control"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/build_release"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/docs"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/governance"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/legal"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/quality"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/sec_assessment"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/vuln_management"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/access_control"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/build_release"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/docs"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/governance"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/legal"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/quality"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/sec_assessment"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/vuln_management"
 
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 var (

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -3,7 +3,7 @@ package access_control
 import (
 	"github.com/gemaraproj/go-gemara"
 
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 func OrgRequiresMFA(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/access_control/steps_test.go
+++ b/evaluation_plans/osps/access_control/steps_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/revanite-io/pvtr-github-repo/data"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ossf/si-tooling/v2/si"
 	"github.com/rhysd/actionlint"
 
-	"github.com/revanite-io/pvtr-github-repo/data"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 // https://securitylab.github.com/resources/github-actions-untrusted-input/

--- a/evaluation_plans/osps/docs/steps.go
+++ b/evaluation_plans/osps/docs/steps.go
@@ -3,7 +3,7 @@ package docs
 import (
 	"github.com/gemaraproj/go-gemara"
 
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 func HasSupportDocs(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -2,7 +2,7 @@ package governance
 
 import (
 	"github.com/gemaraproj/go-gemara"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 func CoreTeamIsListed(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/legal/steps.go
+++ b/evaluation_plans/osps/legal/steps.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/revanite-io/pvtr-github-repo/data"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 type LicenseList struct {

--- a/evaluation_plans/osps/legal/steps_test.go
+++ b/evaluation_plans/osps/legal/steps_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/privateerproj/privateer-sdk/config"
-	"github.com/revanite-io/pvtr-github-repo/data"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 func RepoIsPublic(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/si-tooling/v2/si"
-	"github.com/revanite-io/pvtr-github-repo/data"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
 func Test_InsightsListsRepositories(t *testing.T) {

--- a/evaluation_plans/osps/sec_assessment/steps.go
+++ b/evaluation_plans/osps/sec_assessment/steps.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gemaraproj/go-gemara"
 
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 // DesignDocFiles are common file names for design/architecture documentation

--- a/evaluation_plans/osps/sec_assessment/steps_test.go
+++ b/evaluation_plans/osps/sec_assessment/steps_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/si-tooling/v2/si"
 
-	"github.com/revanite-io/pvtr-github-repo/data"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
 func ptrTo[T any](v T) *T { return &v }

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gemaraproj/go-gemara"
 
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 func HasSecContact(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/si-tooling/v2/si"
-	"github.com/revanite-io/pvtr-github-repo/data"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/evaluation_plans/reusable_steps/steps.go
+++ b/evaluation_plans/reusable_steps/steps.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gemaraproj/go-gemara"
 
-	"github.com/revanite-io/pvtr-github-repo/data"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
 func VerifyPayload(payloadData any) (payload data.Payload, message string) {

--- a/evaluation_plans/reusable_steps/steps_test.go
+++ b/evaluation_plans/reusable_steps/steps_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/si-tooling/v2/si"
-	"github.com/revanite-io/pvtr-github-repo/data"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/revanite-io/pvtr-github-repo
+module github.com/ossf/pvtr-github-repo-scanner
 
 go 1.25.1
 

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 
 	"os"
 
-	"github.com/revanite-io/pvtr-github-repo/data"
-	"github.com/revanite-io/pvtr-github-repo/evaluation_plans"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans"
 
 	"github.com/privateerproj/privateer-sdk/command"
 	"github.com/privateerproj/privateer-sdk/pluginkit"
@@ -43,7 +43,7 @@ func main() {
 	orchestrator := pluginkit.EvaluationOrchestrator{
 		PluginName:    PluginName,
 		PluginVersion: Version,
-		PluginUri:     "https://github.com/revanite-io/pvtr-github-repo",
+		PluginUri:     "https://github.com/ossf/pvtr-github-repo-scanner",
 	}
 	orchestrator.AddLoader(data.Loader)
 


### PR DESCRIPTION
## What

Update Go module path, all import paths, PluginUri, and CODEOWNERS to reflect the repository move to ossf/pvtr-github-repo-scanner.

## Why

The repository has moved from revanite-io/pvtr-github-repo to ossf/pvtr-github-repo-scanner and all internal references need to match the new location.

## Notes

Consumers of this module will need to update their import paths to github.com/ossf/pvtr-github-repo-scanner.