### PR TITLE
ci: add container image release to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,23 @@ jobs:
       release-config-name: release-drafter.yml
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
+  release_image:
+    needs: release
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    uses: github/ospo-reusable-workflows/.github/workflows/release-image.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
+    with:
+      image-name: ${{ github.repository }}
+      full-tag: ${{ needs.release.outputs.full-tag }}
+      short-tag: ${{ needs.release.outputs.short-tag }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      image-registry: ghcr.io
+      image-registry-username: ${{ github.actor }}
+      image-registry-password: ${{ secrets.GITHUB_TOKEN }}
   goreleaser:
     needs: release
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add a release_image job to the release workflow that builds and pushes a container image to ghcr.io after a release is created, using the github/ospo-reusable-workflows release-image workflow.

## Why

The project needs published container images alongside the existing Go binary releases so consumers can pull and run the scanner directly from a registry.

## Notes

None