### PR TITLE
fix: treat empty and whitespace-only URIs as not insecure (OSPS-BR-03.01)

### DIFF
--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -236,7 +236,8 @@ func getLinks(data data.Payload) []string {
 }
 
 func insecureURI(uri string) bool {
-	if strings.HasPrefix(uri, "https://") ||
+	if strings.TrimSpace(uri) == "" ||
+		strings.HasPrefix(uri, "https://") ||
 		strings.HasPrefix(uri, "ssh:") ||
 		strings.HasPrefix(uri, "git:") ||
 		strings.HasPrefix(uri, "git@") {

--- a/evaluation_plans/osps/build_release/steps_test.go
+++ b/evaluation_plans/osps/build_release/steps_test.go
@@ -124,6 +124,29 @@ func TestMultipleVariables(t *testing.T) {
 
 }
 
+func TestInsecureURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      string
+		expected bool
+	}{
+		{"empty string is not insecure", "", false},
+		{"whitespace string is not insecure", "   ", false},
+		{"https is not insecure", "https://example.com", false},
+		{"ssh is not insecure", "ssh://example.com", false},
+		{"git protocol is not insecure", "git://example.com", false},
+		{"git@ is not insecure", "git@github.com:org/repo.git", false},
+		{"http is insecure", "http://example.com", true},
+		{"ftp is insecure", "ftp://example.com", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, insecureURI(tt.uri), tt.name)
+		})
+	}
+}
+
 func TestUnTrustedVarsRegex(t *testing.T) {
 
 	expression, err := regexp.Compile(untrustedVarsRegex)


### PR DESCRIPTION
## What

Updated insecureURI to return false for empty or whitespace-only strings, and added table-driven tests covering empty, whitespace, secure, and insecure URI cases.

## Why

Empty or absent insight links were being flagged as insecure because they don't match any of the allowed protocol prefixes. A missing link is not an insecure link.

[Example error before](https://github.com/privateerproj/.github/actions/runs/22334678700/job/64624416929#step:3:113):

```bash
Error: -24T02:58:46.469Z [ERROR] OSPS-BR-03.01: The following links do not use HTTPS: ,
```

## Notes

- This affects both EnsureInsightsLinksUseHTTPS and DistributionPointsUseHTTPS since they share the insecureURI function.