### PR TITLE
fix: use file mode to distinguish executable binaries from non-executable ones

### DIFF
--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -23,6 +23,7 @@ type GraphqlRepoTree struct {
 					Name   string
 					Type   string
 					Path   string
+					Mode   int
 					Object *struct {
 						Blob struct {
 							IsBinary    *bool
@@ -33,6 +34,7 @@ type GraphqlRepoTree struct {
 								Name   string
 								Type   string
 								Path   string
+								Mode   int
 								Object *struct {
 									Blob struct {
 										IsBinary    *bool
@@ -43,6 +45,7 @@ type GraphqlRepoTree struct {
 											Name   string
 											Type   string
 											Path   string
+											Mode   int
 											Object *struct {
 												Blob struct {
 													IsBinary    *bool
@@ -69,8 +72,16 @@ type binaryChecker struct {
 	branch     string
 }
 
-func (bc *binaryChecker) check(isBinaryPtr *bool, isTruncated bool, path string) (bool, error) {
+func (bc *binaryChecker) check(isBinaryPtr *bool, isTruncated bool, path string, mode int) (bool, error) {
 	if isBinaryPtr != nil {
+		if *isBinaryPtr && mode&0111 == 0 {
+			// File is binary but lacks any Unix execute permission bits (owner, group, other).
+			// Git only uses mode 100755 for executables, but the bitwise check is more
+			// robust against non-standard modes from other Git implementations.
+			// Non-executable binaries (e.g. PNG, PDF) are not "generated executable artifacts"
+			// per OSPS-QA-05.01 and should not be flagged.
+			return false, nil
+		}
 		return *isBinaryPtr, nil
 	}
 	// If file has a common text extension, assume it's not binary to avoid unnecessary HTTP requests
@@ -162,7 +173,7 @@ func checkTreeForBinaries(tree *GraphqlRepoTree, bc *binaryChecker) (binariesFou
 	}
 	for _, entry := range tree.Repository.Object.Tree.Entries {
 		if entry.Type == "blob" && entry.Object != nil {
-			isBinary, err := bc.check(entry.Object.Blob.IsBinary, entry.Object.Blob.IsTruncated, entry.Path)
+			isBinary, err := bc.check(entry.Object.Blob.IsBinary, entry.Object.Blob.IsTruncated, entry.Path, entry.Mode)
 			if err != nil {
 				return nil, err
 			}
@@ -173,7 +184,7 @@ func checkTreeForBinaries(tree *GraphqlRepoTree, bc *binaryChecker) (binariesFou
 		if entry.Type == "tree" && entry.Object != nil {
 			for _, subEntry := range entry.Object.Tree.Entries {
 				if subEntry.Type == "blob" && subEntry.Object != nil {
-					isBinary, err := bc.check(subEntry.Object.Blob.IsBinary, subEntry.Object.Blob.IsTruncated, subEntry.Path)
+					isBinary, err := bc.check(subEntry.Object.Blob.IsBinary, subEntry.Object.Blob.IsTruncated, subEntry.Path, subEntry.Mode)
 					if err != nil {
 						return nil, err
 					}
@@ -184,7 +195,7 @@ func checkTreeForBinaries(tree *GraphqlRepoTree, bc *binaryChecker) (binariesFou
 				if subEntry.Type == "tree" && subEntry.Object != nil {
 					for _, subSubEntry := range subEntry.Object.Tree.Entries {
 						if subSubEntry.Type == "blob" && subSubEntry.Object != nil {
-							isBinary, err := bc.check(subSubEntry.Object.Blob.IsBinary, subSubEntry.Object.Blob.IsTruncated, subSubEntry.Path)
+							isBinary, err := bc.check(subSubEntry.Object.Blob.IsBinary, subSubEntry.Object.Blob.IsTruncated, subSubEntry.Path, subSubEntry.Mode)
 							if err != nil {
 								return nil, err
 							}

--- a/data/graphql-binary-check_test.go
+++ b/data/graphql-binary-check_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+// Git tree entry file modes (decimal representation of octal values)
+var (
+	modeExecutable    = 33261 // 100755 in octal — file with execute permission
+	modeNonExecutable = 33188 // 100644 in octal — file without execute permission
+)
+
 func boolPtr(b bool) *bool {
 	return &b
 }
@@ -42,29 +48,38 @@ func TestCheckTreeForBinaries(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "binary files are correctly detected",
+			name: "executable binary files are correctly detected",
 			tree: buildTree([]testEntry{
-				{name: "app.jar", isBinary: boolPtr(true)},
+				{name: "app.jar", isBinary: boolPtr(true), mode: modeExecutable},
 				{name: "README.md", isBinary: boolPtr(false)},
 			}),
 			expected: []string{"app.jar"},
 		},
 		{
-			name: "multiple binary files detected",
+			name: "multiple executable binary files detected",
 			tree: buildTree([]testEntry{
-				{name: "app.exe", isBinary: boolPtr(true)},
-				{name: "lib.dll", isBinary: boolPtr(true)},
+				{name: "app.exe", isBinary: boolPtr(true), mode: modeExecutable},
+				{name: "lib.dll", isBinary: boolPtr(true), mode: modeExecutable},
 				{name: "main.go", isBinary: boolPtr(false)},
 			}),
 			expected: []string{"app.exe", "lib.dll"},
 		},
 		{
-			name: "nested binary files detected",
+			name: "nested executable binary files detected",
 			tree: buildTreeWithNested(
 				[]testEntry{{name: "README.md", isBinary: boolPtr(false)}},
-				[]testEntry{{name: "wrapper.jar", isBinary: boolPtr(true)}},
+				[]testEntry{{name: "wrapper.jar", isBinary: boolPtr(true), mode: modeExecutable}},
 			),
 			expected: []string{"wrapper.jar"},
+		},
+		{
+			name: "non-executable binary files not flagged",
+			tree: buildTree([]testEntry{
+				{name: "logo.png", isBinary: boolPtr(true), mode: modeNonExecutable},
+				{name: "diagram.pdf", isBinary: boolPtr(true), mode: modeNonExecutable},
+				{name: "README.md", isBinary: boolPtr(false)},
+			}),
+			expected: nil,
 		},
 		{
 			name: "extensionless text files not flagged",
@@ -107,19 +122,30 @@ func TestCheckTreeForBinaries(t *testing.T) {
 func TestBinaryCheckerIsBinary(t *testing.T) {
 	bc := &binaryChecker{logger: hclog.NewNullLogger()}
 
-	t.Run("isBinary true returns true", func(t *testing.T) {
-		result, err := bc.check(boolPtr(true), false, "any-file")
+	t.Run("isBinary true but non-executable mode returns false", func(t *testing.T) {
+		result, err := bc.check(boolPtr(true), false, "image.png", modeNonExecutable)
+		if err != nil {
+			t.Errorf("check() error = %v", err)
+			return
+		}
+		if result {
+			t.Error("expected non-executable binary (e.g. PNG) to return false")
+		}
+	})
+
+	t.Run("isBinary true with executable mode returns true", func(t *testing.T) {
+		result, err := bc.check(boolPtr(true), false, "app.exe", modeExecutable)
 		if err != nil {
 			t.Errorf("check() error = %v", err)
 			return
 		}
 		if !result {
-			t.Error("expected isBinary=true to return true")
+			t.Error("expected executable binary to return true")
 		}
 	})
 
 	t.Run("isBinary false returns false", func(t *testing.T) {
-		result, err := bc.check(boolPtr(false), false, "any-file")
+		result, err := bc.check(boolPtr(false), false, "any-file", modeNonExecutable)
 		if err != nil {
 			t.Errorf("check() error = %v", err)
 			return
@@ -130,7 +156,7 @@ func TestBinaryCheckerIsBinary(t *testing.T) {
 	})
 
 	t.Run("isBinary false takes precedence over truncated", func(t *testing.T) {
-		result, err := bc.check(boolPtr(false), true, "any-file")
+		result, err := bc.check(boolPtr(false), true, "any-file", modeNonExecutable)
 		if err != nil {
 			t.Errorf("check() error = %v", err)
 			return
@@ -141,7 +167,7 @@ func TestBinaryCheckerIsBinary(t *testing.T) {
 	})
 
 	t.Run("nil isBinary and not truncated returns false", func(t *testing.T) {
-		result, err := bc.check(nil, false, "any-file")
+		result, err := bc.check(nil, false, "any-file", modeNonExecutable)
 		if err != nil {
 			t.Errorf("check() error = %v", err)
 			return
@@ -397,6 +423,7 @@ func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 type testEntry struct {
 	name     string
 	isBinary *bool
+	mode     int
 }
 
 func buildTree(entries []testEntry) *GraphqlRepoTree {
@@ -407,6 +434,7 @@ func buildTree(entries []testEntry) *GraphqlRepoTree {
 			Name   string
 			Type   string
 			Path   string
+			Mode   int
 			Object *struct {
 				Blob struct {
 					IsBinary    *bool
@@ -417,6 +445,7 @@ func buildTree(entries []testEntry) *GraphqlRepoTree {
 						Name   string
 						Type   string
 						Path   string
+						Mode   int
 						Object *struct {
 							Blob struct {
 								IsBinary    *bool
@@ -427,6 +456,7 @@ func buildTree(entries []testEntry) *GraphqlRepoTree {
 									Name   string
 									Type   string
 									Path   string
+									Mode   int
 									Object *struct {
 										Blob struct {
 											IsBinary    *bool
@@ -443,6 +473,7 @@ func buildTree(entries []testEntry) *GraphqlRepoTree {
 			Name: e.name,
 			Type: "blob",
 			Path: e.name,
+			Mode: e.mode,
 		}
 		entry.Object = &struct {
 			Blob struct {
@@ -454,6 +485,7 @@ func buildTree(entries []testEntry) *GraphqlRepoTree {
 					Name   string
 					Type   string
 					Path   string
+					Mode   int
 					Object *struct {
 						Blob struct {
 							IsBinary    *bool
@@ -464,6 +496,7 @@ func buildTree(entries []testEntry) *GraphqlRepoTree {
 								Name   string
 								Type   string
 								Path   string
+								Mode   int
 								Object *struct {
 									Blob struct {
 										IsBinary    *bool
@@ -491,6 +524,7 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 		Name   string
 		Type   string
 		Path   string
+		Mode   int
 		Object *struct {
 			Blob struct {
 				IsBinary    *bool
@@ -501,6 +535,7 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 					Name   string
 					Type   string
 					Path   string
+					Mode   int
 					Object *struct {
 						Blob struct {
 							IsBinary    *bool
@@ -511,6 +546,7 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 								Name   string
 								Type   string
 								Path   string
+								Mode   int
 								Object *struct {
 									Blob struct {
 										IsBinary    *bool
@@ -539,6 +575,7 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 				Name   string
 				Type   string
 				Path   string
+				Mode   int
 				Object *struct {
 					Blob struct {
 						IsBinary    *bool
@@ -549,6 +586,7 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 							Name   string
 							Type   string
 							Path   string
+							Mode   int
 							Object *struct {
 								Blob struct {
 									IsBinary    *bool
@@ -567,6 +605,7 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 			Name   string
 			Type   string
 			Path   string
+			Mode   int
 			Object *struct {
 				Blob struct {
 					IsBinary    *bool
@@ -577,6 +616,7 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 						Name   string
 						Type   string
 						Path   string
+						Mode   int
 						Object *struct {
 							Blob struct {
 								IsBinary    *bool
@@ -590,6 +630,7 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 			Name: e.name,
 			Type: "blob",
 			Path: "subdir/" + e.name,
+			Mode: e.mode,
 		}
 		subEntry.Object = &struct {
 			Blob struct {
@@ -601,6 +642,7 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 					Name   string
 					Type   string
 					Path   string
+					Mode   int
 					Object *struct {
 						Blob struct {
 							IsBinary    *bool


### PR DESCRIPTION
Fixes https://github.com/ossf/pvtr-github-repo-scanner/issues/255

## What

Added the Mode field from GitHub's GraphQL TreeEntry to the repo tree struct and updated the binary check to use Unix execute permission bits (mode & 0111) to determine if a binary file is actually executable.

## Why

OSPS-QA-05.01 targets "generated executable artifacts," not all binary files. Non-executable binaries like PNGs and PDFs were being incorrectly flagged, causing false failures for documentation-heavy repositories.

## Notes

- The bitwise check (`mode & 0111`) is used instead of exact mode comparison (`== 33261`) for robustness against non-standard Git implementations, though standard Git only uses 100755 for executables.
- This changes behavior for the `checkViaPartialFetch` fallback path: when `isBinaryPtr` is nil and the file is fetched via HTTP, the mode check is NOT applied. That path lacks the GraphQL mode data, so it retains the existing MIME-based heuristic. Reviewers should consider whether this is acceptable.