### PR TITLE
chore: Update ospo-reusable-workflows to new GitHub org

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: github/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
     with:
       config-name: release-drafter.yml
     secrets:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,6 +11,6 @@ jobs:
       contents: read
       pull-requests: read
       statuses: write
-    uses: github/ospo-reusable-workflows/.github/workflows/pr-title.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/pr-title.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: github/ospo-reusable-workflows/.github/workflows/release.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
     with:
       publish: true
       release-config-name: release-drafter.yml
@@ -23,7 +23,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-    uses: github/ospo-reusable-workflows/.github/workflows/release-image.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-image.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
     with:
       image-name: ${{ github.repository }}
       full-tag: ${{ needs.release.outputs.full-tag }}


### PR DESCRIPTION
## What
Updated GitHub Actions workflow references from `github/ospo-reusable-workflows` to `github-community-projects/ospo-reusable-workflows`.

## Why
The ospo-reusable-workflows repository has been transferred to the github-community-projects organization.

## Notes
- The SHA pins remain unchanged so the exact same code is referenced