### PR TITLE
feat: implement OSPS-QA-05.02 detect unreviewable binary artifacts

### DIFF
--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -3,13 +3,13 @@ package data
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/gabriel-vasile/mimetype"
 	"github.com/hashicorp/go-hclog"
 	"github.com/privateerproj/privateer-sdk/config"
 	"github.com/shurcooL/githubv4"
@@ -72,6 +72,9 @@ type binaryChecker struct {
 	branch     string
 }
 
+// check determines whether a file is a suspected executable binary per OSPS-QA-05.01.
+// It uses GitHub's IsBinary field combined with Unix execute permission bits to identify
+// generated executable artifacts. Non-executable binaries (e.g. images) are not flagged.
 func (bc *binaryChecker) check(isBinaryPtr *bool, isTruncated bool, path string, mode int) (bool, error) {
 	if isBinaryPtr != nil {
 		if *isBinaryPtr && mode&0111 == 0 {
@@ -98,7 +101,17 @@ func (bc *binaryChecker) check(isBinaryPtr *bool, isTruncated bool, path string,
 	return false, nil
 }
 
+// checkViaPartialFetch fetches the first 512 bytes of a file from raw.githubusercontent.com
+// and uses gabriel-vasile/mimetype for magic-number-based MIME detection to determine
+// if the file is binary. This is a fallback for when GitHub's GraphQL IsBinary field
+// is nil and the file content is truncated.
+//
+// We use gabriel-vasile/mimetype (pure Go, 170+ types, tested against libmagic on ~50k
+// files) rather than libmagic because the Go bindings (rakyll/magicmime) require CGo
+// and a system libmagic-dev dependency at both build and runtime, complicating cross-
+// compilation, CI runners, and the Docker multi-stage build.
 func (bc *binaryChecker) checkViaPartialFetch(path string) (bool, error) {
+	// URL-encode each path segment to handle special characters
 	segments := strings.Split(path, "/")
 	for i, seg := range segments {
 		segments[i] = url.PathEscape(seg)
@@ -114,6 +127,7 @@ func (bc *binaryChecker) checkViaPartialFetch(path string) (bool, error) {
 		return false, err
 	}
 
+	// Request only the first 512 bytes — enough for magic number detection
 	req.Header.Set("Range", "bytes=0-511")
 
 	resp, err := bc.httpClient.Do(req)
@@ -126,33 +140,34 @@ func (bc *binaryChecker) checkViaPartialFetch(path string) (bool, error) {
 		return false, fmt.Errorf("unexpected status: %d", resp.StatusCode)
 	}
 
-	content, err := io.ReadAll(resp.Body)
+	// Detect MIME type directly from response body using magic-number signatures.
+	// Non-text types (e.g. application/*, image/*) are considered binary.
+	mtype, err := mimetype.DetectReader(resp.Body)
 	if err != nil {
 		return false, err
 	}
-	
-	return mimeContentTypeIsBinary(content), nil
+	return !strings.HasPrefix(mtype.String(), "text/"), nil
 }
 
-func mimeContentTypeIsBinary(content []byte) bool {
-    contentType := http.DetectContentType(content)
-
-    switch {
-	case strings.HasPrefix(contentType, "application/"):
-        return true
-    default:
-        return false
-    }
-}
-
-func commonAcceptableFileExtension(path string) bool {
-	// Extract file extension from path
+// fileExtension extracts and lowercases the file extension from a path.
+// Returns an empty string if the path has no extension.
+func fileExtension(path string) string {
 	lastDot := strings.LastIndex(path, ".")
 	if lastDot == -1 || lastDot == len(path)-1 {
-		return false // No extension or extension is empty
+		return ""
 	}
-	ext := strings.ToLower(path[lastDot:])
-	
+	return strings.ToLower(path[lastDot:])
+}
+
+// commonAcceptableFileExtension returns true for file extensions that are known
+// text-based formats. Used as a fast path to skip unnecessary HTTP requests
+// when GitHub's IsBinary field is nil.
+func commonAcceptableFileExtension(path string) bool {
+	ext := fileExtension(path)
+	if ext == "" {
+		return false
+	}
+
 	extensions := []string{
 		".md", ".txt", ".yaml", ".yml", ".json", ".toml", ".ini", ".conf", ".env",
 		".sh", ".bash", ".zsh", ".fish",
@@ -167,40 +182,105 @@ func commonAcceptableFileExtension(path string) bool {
 	return slices.Contains(extensions, ext)
 }
 
-func checkTreeForBinaries(tree *GraphqlRepoTree, bc *binaryChecker) (binariesFound []string, err error) {
+// acceptableBinaryExtension returns true for binary file types that are considered
+// reviewable or acceptable in a repository, such as images, audio, video, and fonts.
+// These are excluded from OSPS-QA-05.02 "unreviewable binary artifacts" checks.
+func acceptableBinaryExtension(path string) bool {
+	ext := fileExtension(path)
+	if ext == "" {
+		return false
+	}
+
+	extensions := []string{
+		// Images
+		".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".webp", ".tiff", ".tif", ".avif",
+		// Audio
+		".mp3", ".wav", ".ogg", ".flac", ".aac", ".wma", ".m4a", ".opus",
+		// Video
+		".mp4", ".avi", ".mkv", ".mov", ".wmv", ".webm", ".flv",
+		// Fonts
+		".ttf", ".otf", ".woff", ".woff2", ".eot",
+		// Documents
+		".pdf",
+	}
+	return slices.Contains(extensions, ext)
+}
+
+// checkUnreviewable determines whether a file is an unreviewable binary artifact
+// per OSPS-QA-05.02. Unlike check(), which only flags executable binaries,
+// this flags all binary files except those with acceptable extensions (images,
+// audio, video, fonts, PDFs) that are legitimately stored in binary format.
+// When isBinaryPtr is nil (GitHub couldn't determine binary status), it falls
+// back to extension checks and partial content fetching for truncated files.
+func (bc *binaryChecker) checkUnreviewable(isBinaryPtr *bool, isTruncated bool, path string) (bool, error) {
+	if isBinaryPtr != nil {
+		if !*isBinaryPtr {
+			return false, nil
+		}
+		// File is binary — check if it has an acceptable binary extension
+		if acceptableBinaryExtension(path) {
+			return false, nil
+		}
+		return true, nil
+	}
+	// If file has a common text extension, assume it's not binary
+	if commonAcceptableFileExtension(path) {
+		return false, nil
+	}
+	if isTruncated {
+		binary, err := bc.checkViaPartialFetch(path)
+		if err != nil {
+			return false, fmt.Errorf("failed to check binary status via partial fetch for %s: %w", path, err)
+		}
+		if binary && acceptableBinaryExtension(path) {
+			return false, nil
+		}
+		return binary, nil
+	}
+	return false, nil
+}
+
+// blobCheckFn inspects a single blob entry and returns whether it should be flagged.
+type blobCheckFn func(isBinary *bool, isTruncated bool, path string, mode int) (bool, error)
+
+// walkTree walks the GraphQL repository tree (up to 3 levels deep) and returns
+// the names of blob entries for which fn returns true.
+// TODO: The current GraphQL query only fetches 3 levels of nesting.
+// Additional API calls will be required for recursion into deeper subtrees.
+func walkTree(tree *GraphqlRepoTree, fn blobCheckFn) (flagged []string, err error) {
 	if tree == nil {
 		return nil, nil
 	}
 	for _, entry := range tree.Repository.Object.Tree.Entries {
 		if entry.Type == "blob" && entry.Object != nil {
-			isBinary, err := bc.check(entry.Object.Blob.IsBinary, entry.Object.Blob.IsTruncated, entry.Path, entry.Mode)
+			ok, err := fn(entry.Object.Blob.IsBinary, entry.Object.Blob.IsTruncated, entry.Path, entry.Mode)
 			if err != nil {
 				return nil, err
 			}
-			if isBinary {
-				binariesFound = append(binariesFound, entry.Name)
+			if ok {
+				flagged = append(flagged, entry.Name)
 			}
 		}
 		if entry.Type == "tree" && entry.Object != nil {
 			for _, subEntry := range entry.Object.Tree.Entries {
 				if subEntry.Type == "blob" && subEntry.Object != nil {
-					isBinary, err := bc.check(subEntry.Object.Blob.IsBinary, subEntry.Object.Blob.IsTruncated, subEntry.Path, subEntry.Mode)
+					ok, err := fn(subEntry.Object.Blob.IsBinary, subEntry.Object.Blob.IsTruncated, subEntry.Path, subEntry.Mode)
 					if err != nil {
 						return nil, err
 					}
-					if isBinary {
-						binariesFound = append(binariesFound, subEntry.Name)
+					if ok {
+						flagged = append(flagged, subEntry.Name)
 					}
 				}
 				if subEntry.Type == "tree" && subEntry.Object != nil {
 					for _, subSubEntry := range subEntry.Object.Tree.Entries {
 						if subSubEntry.Type == "blob" && subSubEntry.Object != nil {
-							isBinary, err := bc.check(subSubEntry.Object.Blob.IsBinary, subSubEntry.Object.Blob.IsTruncated, subSubEntry.Path, subSubEntry.Mode)
+							ok, err := fn(subSubEntry.Object.Blob.IsBinary, subSubEntry.Object.Blob.IsTruncated, subSubEntry.Path, subSubEntry.Mode)
 							if err != nil {
 								return nil, err
 							}
-							if isBinary {
-								binariesFound = append(binariesFound, subSubEntry.Name)
+							if ok {
+								flagged = append(flagged, subSubEntry.Name)
 							}
 						}
 						// TODO: The current GraphQL call stops after 3 levels of depth.
@@ -210,7 +290,19 @@ func checkTreeForBinaries(tree *GraphqlRepoTree, bc *binaryChecker) (binariesFou
 			}
 		}
 	}
-	return binariesFound, nil
+	return flagged, nil
+}
+
+// checkTreeForUnreviewableBinaries returns file names that are unreviewable binary
+// artifacts (OSPS-QA-05.02), excluding acceptable formats like images, audio, and fonts.
+func checkTreeForUnreviewableBinaries(tree *GraphqlRepoTree, bc *binaryChecker) ([]string, error) {
+	return walkTree(tree, func(isBinary *bool, isTruncated bool, path string, _ int) (bool, error) {
+		return bc.checkUnreviewable(isBinary, isTruncated, path)
+	})
+}
+
+func checkTreeForBinaries(tree *GraphqlRepoTree, bc *binaryChecker) ([]string, error) {
+	return walkTree(tree, bc.check)
 }
 
 func fetchGraphqlRepoTree(config *config.Config, client *githubv4.Client, branch string) (tree *GraphqlRepoTree, err error) {

--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -96,8 +96,18 @@ func (bc *binaryChecker) check(isBinaryPtr *bool, isTruncated bool, path string,
 		if err != nil {
 			return false, fmt.Errorf("failed to check binary status via partial fetch for %s: %w", path, err)
 		}
+		// Filter out acceptable binary formats (images, audio, video, fonts, PDFs)
+		// so they are not incorrectly flagged as suspected executable binaries.
+		if binary && acceptableBinaryExtension(path) {
+			return false, nil
+		}
 		return binary, nil
 	}
+	// TODO: When isBinaryPtr is nil and the file is not truncated, we have no
+	// content to inspect and silently return false. A binary artifact in this
+	// state (e.g. a file where GitHub couldn't determine binary status) will
+	// pass undetected. This matches checkUnreviewable() behavior and is a
+	// known limitation.
 	return false, nil
 }
 
@@ -228,15 +238,19 @@ func (bc *binaryChecker) checkUnreviewable(isBinaryPtr *bool, isTruncated bool, 
 		return false, nil
 	}
 	if isTruncated {
+		if acceptableBinaryExtension(path) {
+			return false, nil
+		}
 		binary, err := bc.checkViaPartialFetch(path)
 		if err != nil {
 			return false, fmt.Errorf("failed to check binary status via partial fetch for %s: %w", path, err)
 		}
-		if binary && acceptableBinaryExtension(path) {
-			return false, nil
-		}
 		return binary, nil
 	}
+	// TODO: When isBinaryPtr is nil and the file is not truncated, we have no
+	// content to inspect and silently return false. A binary artifact in this
+	// state (e.g. a file where GitHub couldn't determine binary status) will
+	// pass undetected. This matches check() behavior and is a known limitation.
 	return false, nil
 }
 

--- a/data/graphql-binary-check_test.go
+++ b/data/graphql-binary-check_test.go
@@ -661,3 +661,418 @@ func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *Graph
 
 	return tree
 }
+
+func TestAcceptableBinaryExtension(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{name: "no extension", path: "file", expected: false},
+		{name: "empty extension", path: "file.", expected: false},
+		{name: "go source", path: "main.go", expected: false},
+		{name: "jar file", path: "app.jar", expected: false},
+		{name: "exe file", path: "app.exe", expected: false},
+		{name: "dll file", path: "lib.dll", expected: false},
+		{name: "so file", path: "lib.so", expected: false},
+		// Images — acceptable
+		{name: "png image", path: "logo.png", expected: true},
+		{name: "jpg image", path: "photo.jpg", expected: true},
+		{name: "jpeg image", path: "photo.jpeg", expected: true},
+		{name: "gif image", path: "anim.gif", expected: true},
+		{name: "webp image", path: "image.webp", expected: true},
+		{name: "ico image", path: "favicon.ico", expected: true},
+		{name: "tiff image", path: "scan.tiff", expected: true},
+		{name: "avif image", path: "photo.avif", expected: true},
+		// Audio — acceptable
+		{name: "mp3 audio", path: "song.mp3", expected: true},
+		{name: "wav audio", path: "sound.wav", expected: true},
+		{name: "ogg audio", path: "audio.ogg", expected: true},
+		{name: "flac audio", path: "music.flac", expected: true},
+		// Video — acceptable
+		{name: "mp4 video", path: "clip.mp4", expected: true},
+		{name: "webm video", path: "clip.webm", expected: true},
+		// Fonts — acceptable
+		{name: "ttf font", path: "font.ttf", expected: true},
+		{name: "woff2 font", path: "font.woff2", expected: true},
+		// Documents — acceptable
+		{name: "pdf document", path: "doc.pdf", expected: true},
+		// Case insensitive
+		{name: "upper PNG", path: "logo.PNG", expected: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := acceptableBinaryExtension(tt.path)
+			if result != tt.expected {
+				t.Errorf("acceptableBinaryExtension(%s) = %v, want %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCheckUnreviewable(t *testing.T) {
+	bc := &binaryChecker{logger: hclog.NewNullLogger()}
+
+	t.Run("non-binary file returns false", func(t *testing.T) {
+		result, err := bc.checkUnreviewable(boolPtr(false), false, "main.go")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if result {
+			t.Error("expected non-binary file to return false")
+		}
+	})
+
+	t.Run("binary with acceptable extension returns false", func(t *testing.T) {
+		result, err := bc.checkUnreviewable(boolPtr(true), false, "logo.png")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if result {
+			t.Error("expected binary PNG to return false (acceptable)")
+		}
+	})
+
+	t.Run("binary with unacceptable extension returns true", func(t *testing.T) {
+		result, err := bc.checkUnreviewable(boolPtr(true), false, "app.jar")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if !result {
+			t.Error("expected binary JAR to return true (unreviewable)")
+		}
+	})
+
+	t.Run("binary executable flagged as unreviewable", func(t *testing.T) {
+		result, err := bc.checkUnreviewable(boolPtr(true), false, "app.exe")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if !result {
+			t.Error("expected binary EXE to return true (unreviewable)")
+		}
+	})
+
+	t.Run("binary font file not flagged", func(t *testing.T) {
+		result, err := bc.checkUnreviewable(boolPtr(true), false, "font.woff2")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if result {
+			t.Error("expected binary font to return false (acceptable)")
+		}
+	})
+
+	t.Run("nil isBinary with text extension returns false", func(t *testing.T) {
+		result, err := bc.checkUnreviewable(nil, false, "README.md")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if result {
+			t.Error("expected nil isBinary with text extension to return false")
+		}
+	})
+
+	t.Run("nil isBinary not truncated returns false", func(t *testing.T) {
+		result, err := bc.checkUnreviewable(nil, false, "somefile")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if result {
+			t.Error("expected nil isBinary with not truncated to return false")
+		}
+	})
+
+	t.Run("nil isBinary truncated binary unacceptable extension returns true", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0xcf, 0xfa, 0xed, 0xfe, 0x00, 0x01, 0x02})
+		}))
+		defer server.Close()
+
+		bc := &binaryChecker{
+			httpClient: server.Client(),
+			logger:     hclog.NewNullLogger(),
+			owner:      "test",
+			repo:       "repo",
+			branch:     "main",
+		}
+		bc.httpClient.Transport = &testTransport{baseURL: server.URL, transport: http.DefaultTransport}
+
+		result, err := bc.checkUnreviewable(nil, true, "app.jar")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if !result {
+			t.Error("expected nil isBinary + truncated + binary content + unacceptable extension to return true")
+		}
+	})
+
+	t.Run("nil isBinary truncated binary acceptable extension returns false", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}) // PNG header
+		}))
+		defer server.Close()
+
+		bc := &binaryChecker{
+			httpClient: server.Client(),
+			logger:     hclog.NewNullLogger(),
+			owner:      "test",
+			repo:       "repo",
+			branch:     "main",
+		}
+		bc.httpClient.Transport = &testTransport{baseURL: server.URL, transport: http.DefaultTransport}
+
+		result, err := bc.checkUnreviewable(nil, true, "logo.png")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if result {
+			t.Error("expected nil isBinary + truncated + binary content + acceptable extension (.png) to return false")
+		}
+	})
+
+	t.Run("nil isBinary truncated text content returns false", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte("hello world this is text content"))
+		}))
+		defer server.Close()
+
+		bc := &binaryChecker{
+			httpClient: server.Client(),
+			logger:     hclog.NewNullLogger(),
+			owner:      "test",
+			repo:       "repo",
+			branch:     "main",
+		}
+		bc.httpClient.Transport = &testTransport{baseURL: server.URL, transport: http.DefaultTransport}
+
+		result, err := bc.checkUnreviewable(nil, true, "data.bin")
+		if err != nil {
+			t.Errorf("checkUnreviewable() error = %v", err)
+		}
+		if result {
+			t.Error("expected nil isBinary + truncated + text content to return false")
+		}
+	})
+}
+
+func TestCheckTreeForUnreviewableBinaries(t *testing.T) {
+	bc := &binaryChecker{logger: hclog.NewNullLogger()}
+
+	tests := []struct {
+		name     string
+		tree     *GraphqlRepoTree
+		expected []string
+	}{
+		{
+			name:     "nil tree returns nil",
+			tree:     nil,
+			expected: nil,
+		},
+		{
+			name:     "empty tree returns no binaries",
+			tree:     &GraphqlRepoTree{},
+			expected: nil,
+		},
+		{
+			name: "text files not flagged",
+			tree: buildTree([]testEntry{
+				{name: "README.md", isBinary: boolPtr(false)},
+				{name: "main.go", isBinary: boolPtr(false)},
+			}),
+			expected: nil,
+		},
+		{
+			name: "acceptable binary files not flagged",
+			tree: buildTree([]testEntry{
+				{name: "logo.png", isBinary: boolPtr(true), mode: modeNonExecutable},
+				{name: "icon.ico", isBinary: boolPtr(true), mode: modeNonExecutable},
+				{name: "doc.pdf", isBinary: boolPtr(true), mode: modeNonExecutable},
+			}),
+			expected: nil,
+		},
+		{
+			name: "unreviewable binary files flagged",
+			tree: buildTree([]testEntry{
+				{name: "app.jar", isBinary: boolPtr(true), mode: modeNonExecutable},
+				{name: "lib.dll", isBinary: boolPtr(true), mode: modeNonExecutable},
+				{name: "README.md", isBinary: boolPtr(false)},
+			}),
+			expected: []string{"app.jar", "lib.dll"},
+		},
+		{
+			name: "mix of acceptable and unreviewable binaries",
+			tree: buildTree([]testEntry{
+				{name: "logo.png", isBinary: boolPtr(true), mode: modeNonExecutable},
+				{name: "app.exe", isBinary: boolPtr(true), mode: modeExecutable},
+				{name: "font.woff2", isBinary: boolPtr(true), mode: modeNonExecutable},
+			}),
+			expected: []string{"app.exe"},
+		},
+		{
+			name: "nested unreviewable binary detected",
+			tree: buildTreeWithNested(
+				[]testEntry{{name: "README.md", isBinary: boolPtr(false)}},
+				[]testEntry{{name: "wrapper.jar", isBinary: boolPtr(true), mode: modeNonExecutable}},
+			),
+			expected: []string{"wrapper.jar"},
+		},
+		{
+			name: "level 3 nested unreviewable binary detected",
+			tree: buildTreeWithLevel3(
+				[]testEntry{{name: "README.md", isBinary: boolPtr(false)}},
+				[]testEntry{},
+				[]testEntry{{name: "hidden.dll", isBinary: boolPtr(true), mode: modeNonExecutable}},
+			),
+			expected: []string{"hidden.dll"},
+		},
+		{
+			name: "acceptable binary in nested subtree not flagged",
+			tree: buildTreeWithNested(
+				[]testEntry{},
+				[]testEntry{{name: "photo.jpg", isBinary: boolPtr(true), mode: modeNonExecutable}},
+			),
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := checkTreeForUnreviewableBinaries(tt.tree, bc)
+			if err != nil {
+				t.Errorf("checkTreeForUnreviewableBinaries() error = %v", err)
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("got %d binaries, want %d\ngot: %v\nwant: %v",
+					len(result), len(tt.expected), result, tt.expected)
+				return
+			}
+
+			for i, name := range tt.expected {
+				if result[i] != name {
+					t.Errorf("binary[%d] = %q, want %q", i, result[i], name)
+				}
+			}
+		})
+	}
+}
+
+func buildTreeWithLevel3(rootEntries []testEntry, level2Entries []testEntry, level3Entries []testEntry) *GraphqlRepoTree {
+	tree := buildTreeWithNested(rootEntries, level2Entries)
+
+	// Find the "subdir" tree entry added by buildTreeWithNested
+	for i := range tree.Repository.Object.Tree.Entries {
+		if tree.Repository.Object.Tree.Entries[i].Type == "tree" {
+			// Add a sub-subtree inside it
+			subDirEntry := struct {
+				Name   string
+				Type   string
+				Path   string
+				Mode   int
+				Object *struct {
+					Blob struct {
+						IsBinary    *bool
+						IsTruncated bool
+					} `graphql:"... on Blob"`
+					Tree struct {
+						Entries []struct {
+							Name   string
+							Type   string
+							Path   string
+							Mode   int
+							Object *struct {
+								Blob struct {
+									IsBinary    *bool
+									IsTruncated bool
+								} `graphql:"... on Blob"`
+							} `graphql:"object"`
+						}
+					} `graphql:"... on Tree"`
+				} `graphql:"object"`
+			}{
+				Name: "deep",
+				Type: "tree",
+				Path: "subdir/deep",
+			}
+			subDirEntry.Object = &struct {
+				Blob struct {
+					IsBinary    *bool
+					IsTruncated bool
+				} `graphql:"... on Blob"`
+				Tree struct {
+					Entries []struct {
+						Name   string
+						Type   string
+						Path   string
+						Mode   int
+						Object *struct {
+							Blob struct {
+								IsBinary    *bool
+								IsTruncated bool
+							} `graphql:"... on Blob"`
+						} `graphql:"object"`
+					}
+				} `graphql:"... on Tree"`
+			}{}
+
+			for _, e := range level3Entries {
+				l3Entry := struct {
+					Name   string
+					Type   string
+					Path   string
+					Mode   int
+					Object *struct {
+						Blob struct {
+							IsBinary    *bool
+							IsTruncated bool
+						} `graphql:"... on Blob"`
+					} `graphql:"object"`
+				}{
+					Name: e.name,
+					Type: "blob",
+					Path: "subdir/deep/" + e.name,
+					Mode: e.mode,
+				}
+				l3Entry.Object = &struct {
+					Blob struct {
+						IsBinary    *bool
+						IsTruncated bool
+					} `graphql:"... on Blob"`
+				}{}
+				l3Entry.Object.Blob.IsBinary = e.isBinary
+				subDirEntry.Object.Tree.Entries = append(subDirEntry.Object.Tree.Entries, l3Entry)
+			}
+
+			tree.Repository.Object.Tree.Entries[i].Object.Tree.Entries = append(
+				tree.Repository.Object.Tree.Entries[i].Object.Tree.Entries, subDirEntry)
+			break
+		}
+	}
+	return tree
+}
+
+func TestCheckUnreviewablePartialFetchError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	bc := &binaryChecker{
+		httpClient: server.Client(),
+		logger:     hclog.NewNullLogger(),
+		owner:      "test",
+		repo:       "repo",
+		branch:     "main",
+	}
+	bc.httpClient.Transport = &testTransport{baseURL: server.URL, transport: http.DefaultTransport}
+
+	_, err := bc.checkUnreviewable(nil, true, "unknown.bin")
+	if err == nil {
+		t.Error("expected error when partial fetch returns 500")
+	}
+}

--- a/data/graphql-binary-check_test.go
+++ b/data/graphql-binary-check_test.go
@@ -176,6 +176,58 @@ func TestBinaryCheckerIsBinary(t *testing.T) {
 			t.Error("expected nil isBinary with isTruncated=false to return false")
 		}
 	})
+
+	t.Run("nil isBinary truncated PNG not flagged as executable", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}) // PNG header
+		}))
+		defer server.Close()
+
+		bcWithHTTP := &binaryChecker{
+			httpClient: server.Client(),
+			logger:     hclog.NewNullLogger(),
+			owner:      "test",
+			repo:       "repo",
+			branch:     "main",
+		}
+		bcWithHTTP.httpClient.Transport = &testTransport{baseURL: server.URL, transport: http.DefaultTransport}
+
+		result, err := bcWithHTTP.check(nil, true, "logo.png", modeNonExecutable)
+		if err != nil {
+			t.Errorf("check() error = %v", err)
+			return
+		}
+		if result {
+			t.Error("expected truncated PNG with nil isBinary to not be flagged as suspected executable binary")
+		}
+	})
+
+	t.Run("nil isBinary truncated binary with unacceptable extension flagged", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0xcf, 0xfa, 0xed, 0xfe, 0x00, 0x01, 0x02}) // Mach-O binary
+		}))
+		defer server.Close()
+
+		bcWithHTTP := &binaryChecker{
+			httpClient: server.Client(),
+			logger:     hclog.NewNullLogger(),
+			owner:      "test",
+			repo:       "repo",
+			branch:     "main",
+		}
+		bcWithHTTP.httpClient.Transport = &testTransport{baseURL: server.URL, transport: http.DefaultTransport}
+
+		result, err := bcWithHTTP.check(nil, true, "app.bin", modeExecutable)
+		if err != nil {
+			t.Errorf("check() error = %v", err)
+			return
+		}
+		if !result {
+			t.Error("expected truncated binary with unacceptable extension to be flagged")
+		}
+	})
 }
 
 func TestCommonAcceptableFileExtension(t *testing.T) {
@@ -307,6 +359,20 @@ func TestCheckViaPartialFetch(t *testing.T) {
 			responseStatus: http.StatusInternalServerError,
 			wantBinary:     false,
 			wantErr:        true,
+		},
+		{
+			name:           "PNG magic bytes detected as binary",
+			responseBody:   []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a},
+			responseStatus: http.StatusPartialContent,
+			wantBinary:     true,
+			wantErr:        false,
+		},
+		{
+			name:           "WAV magic bytes detected as binary",
+			responseBody:   []byte{0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45},
+			responseStatus: http.StatusPartialContent,
+			wantBinary:     true,
+			wantErr:        false,
 		},
 	}
 

--- a/data/payload.go
+++ b/data/payload.go
@@ -21,6 +21,7 @@ type Payload struct {
 	SecurityPosture          SecurityPosture
 	client                   *githubv4.Client
 	httpClient               *http.Client
+	cachedTree               *GraphqlRepoTree
 }
 
 func Loader(config *config.Config) (payload any, err error) {
@@ -114,10 +115,24 @@ func (p *Payload) newBinaryChecker() *binaryChecker {
 	}
 }
 
+// getTree lazily fetches and caches the repository tree so that multiple
+// checks (e.g. QA-05.01 and QA-05.02) share a single GraphQL API call.
+func (p *Payload) getTree() (*GraphqlRepoTree, error) {
+	if p.cachedTree != nil {
+		return p.cachedTree, nil
+	}
+	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.Repository.DefaultBranchRef.Name)
+	if err != nil {
+		return nil, err
+	}
+	p.cachedTree = tree
+	return tree, nil
+}
+
 // GetSuspectedBinaries fetches the repository tree and returns file names that
 // appear to be executable binary artifacts per OSPS-QA-05.01.
 func (p *Payload) GetSuspectedBinaries() (suspectedBinaries []string, err error) {
-	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.Repository.DefaultBranchRef.Name)
+	tree, err := p.getTree()
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +144,7 @@ func (p *Payload) GetSuspectedBinaries() (suspectedBinaries []string, err error)
 // GetSuspectedBinaries by flagging all binaries except acceptable content types
 // like images, audio, video, fonts, and PDFs.
 func (p *Payload) GetUnreviewableBinaries() (unreviewableBinaries []string, err error) {
-	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.Repository.DefaultBranchRef.Name)
+	tree, err := p.getTree()
 	if err != nil {
 		return nil, err
 	}

--- a/data/payload.go
+++ b/data/payload.go
@@ -15,7 +15,6 @@ type Payload struct {
 	*GraphqlRepoData
 	*RestData
 	Config                   *config.Config
-	SuspectedBinaries        []string
 	RepositoryMetadata       RepositoryMetadata
 	DependencyManifestsCount int
 	IsCodeRepo               bool
@@ -103,22 +102,36 @@ func getRestData(ghClient *github.Client, config *config.Config) (data *RestData
 	return r, err
 }
 
-func (p *Payload) GetSuspectedBinaries() (suspectedBinaries []string, err error) {
-	branch := p.Repository.DefaultBranchRef.Name
-	tree, err := fetchGraphqlRepoTree(p.Config, p.client, branch)
-	if err != nil {
-		return nil, err
-	}
-	bc := &binaryChecker{
+// newBinaryChecker creates a binaryChecker configured from the payload's
+// repository metadata and HTTP client.
+func (p *Payload) newBinaryChecker() *binaryChecker {
+	return &binaryChecker{
 		httpClient: p.httpClient,
 		logger:     p.Config.Logger,
 		owner:      p.Config.GetString("owner"),
 		repo:       p.Config.GetString("repo"),
-		branch:     branch,
+		branch:     p.Repository.DefaultBranchRef.Name,
 	}
-	binaryFileNames, err := checkTreeForBinaries(tree, bc)
+}
+
+// GetSuspectedBinaries fetches the repository tree and returns file names that
+// appear to be executable binary artifacts per OSPS-QA-05.01.
+func (p *Payload) GetSuspectedBinaries() (suspectedBinaries []string, err error) {
+	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.Repository.DefaultBranchRef.Name)
 	if err != nil {
 		return nil, err
 	}
-	return binaryFileNames, nil
+	return checkTreeForBinaries(tree, p.newBinaryChecker())
+}
+
+// GetUnreviewableBinaries fetches the repository tree and returns file names that
+// are unreviewable binary artifacts per OSPS-QA-05.02. This differs from
+// GetSuspectedBinaries by flagging all binaries except acceptable content types
+// like images, audio, video, fonts, and PDFs.
+func (p *Payload) GetUnreviewableBinaries() (unreviewableBinaries []string, err error) {
+	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.Repository.DefaultBranchRef.Name)
+	if err != nil {
+		return nil, err
+	}
+	return checkTreeForUnreviewableBinaries(tree, p.newBinaryChecker())
 }

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -177,7 +177,7 @@ var (
 			quality.NoBinariesInRepo,
 		},
 		"OSPS-QA-05.02": {
-			reusable_steps.NotImplemented,
+			quality.NoUnreviewableBinariesInRepo,
 		},
 		"OSPS-QA-06.01": {
 			reusable_steps.IsCodeRepo,

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -144,6 +144,28 @@ func NoBinariesInRepo(payloadData any) (result gemara.Result, message string, co
 	return gemara.Failed, fmt.Sprintf("Suspected binaries found in the repository: %s", strings.Join(suspectedBinaries, ", ")), confidence
 }
 
+// NoUnreviewableBinariesInRepo is the assessment step for OSPS-QA-05.02.
+// It checks that the version control system does not contain unreviewable binary
+// artifacts such as compiled executables, shared libraries, or archive binaries.
+// Acceptable binary content (images, audio, video, fonts, PDFs) is not flagged.
+func NoUnreviewableBinariesInRepo(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	data, message := reusable_steps.VerifyPayload(payloadData)
+	if message != "" {
+		return gemara.Unknown, message, confidence
+	}
+
+	unreviewableBinaries, err := data.GetUnreviewableBinaries()
+	if err != nil {
+		data.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for unreviewable binaries: %s", err.Error()))
+		return gemara.Unknown, "Error while scanning repository for unreviewable binaries, potentially due to repo size. See logs for details.", confidence
+	}
+
+	if len(unreviewableBinaries) == 0 {
+		return gemara.Passed, "No unreviewable binary artifacts were found in the repository", confidence
+	}
+	return gemara.Failed, fmt.Sprintf("Unreviewable binary artifacts found in the repository: %s", strings.Join(unreviewableBinaries, ", ")), confidence
+}
+
 func RequiresNonAuthorApproval(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	data, message := reusable_steps.VerifyPayload(payloadData)
 	if message != "" {

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/ossf/si-tooling/v2/si"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/si-tooling/v2/si"
 )
 
 func Test_InsightsListsRepositories(t *testing.T) {
@@ -72,4 +72,16 @@ func Test_InsightsListsRepositories(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_NoUnreviewableBinariesInRepo(t *testing.T) {
+	t.Run("invalid payload returns unknown", func(t *testing.T) {
+		result, msg, _ := NoUnreviewableBinariesInRepo("not a payload")
+		if result != gemara.Unknown {
+			t.Errorf("result = %v, want Unknown", result)
+		}
+		if msg == "" {
+			t.Error("expected non-empty message for invalid payload")
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/defenseunicorns/go-oscal v0.7.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/go-git/go-git/v5 v5.17.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ossf/pvtr-github-repo-scanner
 go 1.25.1
 
 require (
+	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/gemaraproj/go-gemara v0.0.2
 	github.com/goccy/go-yaml v1.19.2
 	github.com/google/go-github/v74 v74.0.0
@@ -24,7 +25,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/defenseunicorns/go-oscal v0.7.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/go-git/go-git/v5 v5.17.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
+github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gemaraproj/go-gemara v0.0.2 h1:XA8HFQK5B6ltU5Xc0Z3eMArATiVuXjfbHR65lDmdTHQ=
 github.com/gemaraproj/go-gemara v0.0.2/go.mod h1:hm4ELSJ9W/L413seDnlFIbHrXbNq6+YJK7DFQHHjNk4=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=


### PR DESCRIPTION
## Summary

Add support for OSPS-QA-05.02, which requires that the version control system does not contain unreviewable binary artifacts. Binary files with acceptable formats (images, audio, video, fonts, PDFs) are excluded from this check, as they are legitimately stored in binary format.

## Known Limitations

- Repository tree scanning is limited to 3 levels of depth (pre-existing limitation, tracked via TODO)

Closes #26
