### PR TITLE
chore: upgrade go to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ ARG PLATFORM=Linux_x86_64  # Change this based on your target system
 RUN wget https://github.com/privateerproj/privateer/releases/download/v${VERSION}/privateer_${PLATFORM}.tar.gz
 RUN tar -xzf privateer_${PLATFORM}.tar.gz
 
-FROM golang:1.26.1-alpine3.22@sha256:07e91d24f6330432729082bb580983181809e0a48f0f38ecde26868d4568c6ac AS plugin
+FROM golang:1.26.2-alpine3.22@sha256:c259ff7ffa06f1fd161a6abfa026573cf00f64cfd959c6d2a9d43e3ff63e8729 AS plugin
 RUN apk add --no-cache make git
 WORKDIR /plugin
 COPY . .
 RUN make binary
 
-FROM golang:1.26.1-alpine3.22@sha256:07e91d24f6330432729082bb580983181809e0a48f0f38ecde26868d4568c6ac
+FROM golang:1.26.2-alpine3.22@sha256:c259ff7ffa06f1fd161a6abfa026573cf00f64cfd959c6d2a9d43e3ff63e8729
 RUN addgroup -g 1001 -S appgroup && adduser -u 1001 -S appuser -G appgroup
 
 RUN mkdir -p /.privateer/bin && chown -R appuser:appgroup /.privateer

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/pvtr-github-repo-scanner
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.13


### PR DESCRIPTION
## What

Upgrade Go from 1.26.1 to 1.26.2 in go.mod and the Dockerfile base images.

## Why

go1.26.2 fixes 4 vulnerabilities in the standard library:

- GO-2026-4947: unexpected work during chain building (crypto/x509)
- GO-2026-4946: inefficient policy validation (crypto/x509)
- GO-2026-4870: unauthenticated TLS 1.3 KeyUpdate DoS (crypto/tls)
- GO-2026-4866: case-sensitive excludedSubtrees auth bypass (crypto/x509)

## Notes

- Dockerfile has two golang base image stages; both digests updated to golang:1.26.2-alpine3.22