### PR TITLE
chore: added typed step to simplify payload verification

### DIFF
--- a/data/payload.go
+++ b/data/payload.go
@@ -121,6 +121,9 @@ func (p *Payload) getTree() (*GraphqlRepoTree, error) {
 	if p.cachedTree != nil {
 		return p.cachedTree, nil
 	}
+	if p.GraphqlRepoData == nil || p.Config == nil {
+		return nil, fmt.Errorf("payload missing required repository data")
+	}
 	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.Repository.DefaultBranchRef.Name)
 	if err != nil {
 		return nil, err

--- a/data/repository_metadata_test.go
+++ b/data/repository_metadata_test.go
@@ -36,7 +36,7 @@ func TestLoadRepositoryMetadata(t *testing.T) {
 				mock.WithRequestMatch(
 					mock.GetOrgsByOrg,
 					github.Organization{
-						Login:                       github.Ptr("test-owner"),
+						Login: github.Ptr("test-owner"),
 					},
 				),
 			},
@@ -59,7 +59,7 @@ func TestLoadRepositoryMetadata(t *testing.T) {
 			_, repoMetadata, err := loadRepositoryMetadata(ghClient, testCase.owner, testCase.repo)
 			if testCase.expectedRepoError {
 				assert.Error(t, err)
-		} else {
+			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, repoMetadata)
 				assert.True(t, repoMetadata.IsActive())

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -1,7 +1,6 @@
 package evaluation_plans
 
 import (
-	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/access_control"
 	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/build_release"
 	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/osps/docs"
@@ -18,7 +17,7 @@ var (
 	// OSPS contains assessment step implementations for OSPS Baseline controls.
 	// Each catalog YAML defines which IDs are active for that version,
 	// so the SDK only runs the relevant subset.
-	OSPS = map[string][]gemara.AssessmentStep{
+	OSPS = map[string][]TypedStep{
 		"OSPS-AC-01.01": {
 			reusable_steps.GithubBuiltIn,
 		},
@@ -245,23 +244,3 @@ var (
 		},
 	}
 )
-
-// AllSteps merges all step maps into a single map for registration with the SDK.
-// Assessment IDs are unique across catalogs (e.g., OSPS-* vs CRA-*), so the
-// catalog YAML naturally filters to the correct subset at evaluation time.
-// To add a new catalog family, define its step map and include it here.
-//
-// A single shared map is safe across catalog versions because the OSPS
-// maintenance policy (https://github.com/ossf/security-baseline/blob/main/docs/maintenance.md#identifiers)
-// guarantees that substantive changes to a control result in a new identifier.
-// This means implementations for a given assessment ID will not diverge between
-// versions, so all versions can share the same step function for the same key.
-func AllSteps() map[string][]gemara.AssessmentStep {
-	merged := make(map[string][]gemara.AssessmentStep, len(OSPS))
-	for id, steps := range OSPS {
-		merged[id] = steps
-	}
-	// Add additional catalog step maps here, e.g.:
-	// for id, steps := range CRA { merged[id] = steps }
-	return merged
-}

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -3,14 +3,10 @@ package access_control
 import (
 	"github.com/gemaraproj/go-gemara"
 
-	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
-func BranchProtectionRestrictsPushes(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	payload, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
+func BranchProtectionRestrictsPushes(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	protectionData := payload.Repository.DefaultBranchRef.BranchProtectionRule
 
 	if protectionData.RestrictsPushes {
@@ -34,12 +30,7 @@ func BranchProtectionRestrictsPushes(payloadData any) (result gemara.Result, mes
 	return result, message, confidence
 }
 
-func BranchProtectionPreventsDeletion(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	payload, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func BranchProtectionPreventsDeletion(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	branchProtectionAllowsDeletion := payload.Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions
 	deletionRule := payload.RepositoryMetadata.IsDefaultBranchProtectedFromDeletion()
 	branchRulesAllowDeletion := deletionRule == nil || !*deletionRule
@@ -58,12 +49,7 @@ func BranchProtectionPreventsDeletion(payloadData any) (result gemara.Result, me
 	return result, message, confidence
 }
 
-func WorkflowDefaultReadPermissions(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	payload, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func WorkflowDefaultReadPermissions(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	permissions := payload.WorkflowPermissions
 	if !payload.WorkflowsEnabled {
 		return gemara.NeedsReview, "GitHub Actions is disabled for this repository; manual review required.", confidence

--- a/evaluation_plans/osps/access_control/steps_test.go
+++ b/evaluation_plans/osps/access_control/steps_test.go
@@ -14,9 +14,9 @@ type FakeRepositoryMetadata struct {
 
 type FakeBranchRuleMetadata struct {
 	data.RepositoryMetadata
-	defaultBranchProtected     *bool
-	requiresPRReviews          *bool
-	protectedFromDeletion      *bool
+	defaultBranchProtected *bool
+	requiresPRReviews      *bool
+	protectedFromDeletion  *bool
 }
 
 func (f *FakeBranchRuleMetadata) IsDefaultBranchProtected() *bool {
@@ -133,7 +133,7 @@ func Test_BranchProtectionRestrictsPushes(t *testing.T) {
 		{
 			name: "branch protection restricts pushes",
 			payload: data.Payload{
-				GraphqlRepoData: &data.GraphqlRepoData{},
+				GraphqlRepoData:    &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{},
 			},
 			wantResult:  gemara.Passed,
@@ -142,7 +142,7 @@ func Test_BranchProtectionRestrictsPushes(t *testing.T) {
 		{
 			name: "branch protection requires approving reviews",
 			payload: data.Payload{
-				GraphqlRepoData: &data.GraphqlRepoData{},
+				GraphqlRepoData:    &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{},
 			},
 			wantResult:  gemara.Passed,
@@ -151,7 +151,7 @@ func Test_BranchProtectionRestrictsPushes(t *testing.T) {
 		{
 			name: "no branch protection but ruleset protects default branch",
 			payload: data.Payload{
-				GraphqlRepoData:    &data.GraphqlRepoData{},
+				GraphqlRepoData: &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{
 					defaultBranchProtected: &trueVal,
 				},
@@ -162,7 +162,7 @@ func Test_BranchProtectionRestrictsPushes(t *testing.T) {
 		{
 			name: "no branch protection but ruleset requires PR reviews",
 			payload: data.Payload{
-				GraphqlRepoData:    &data.GraphqlRepoData{},
+				GraphqlRepoData: &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{
 					defaultBranchProtected: &falseVal,
 					requiresPRReviews:      &trueVal,
@@ -174,7 +174,7 @@ func Test_BranchProtectionRestrictsPushes(t *testing.T) {
 		{
 			name: "no branch protection and no ruleset protection",
 			payload: data.Payload{
-				GraphqlRepoData:    &data.GraphqlRepoData{},
+				GraphqlRepoData: &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{
 					defaultBranchProtected: &falseVal,
 					requiresPRReviews:      &falseVal,

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rhysd/actionlint"
 
 	"github.com/ossf/pvtr-github-repo-scanner/data"
-	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 // Pre-compiled patterns used by workflow security checks.
@@ -55,14 +54,11 @@ var (
 
 // checkAllWorkflows verifies the payload, iterates over all workflow files, and
 // applies checkWorkflow to each parsed workflow. passMessage is returned when all files pass.
-func checkAllWorkflows(payloadData any, checkWorkflow func(*actionlint.Workflow) (bool, string), passMessage string) (gemara.Result, string, gemara.ConfidenceLevel) {
+func checkAllWorkflows(payload data.Payload, checkWorkflow func(*actionlint.Workflow) (bool, string), passMessage string) (gemara.Result, string, gemara.ConfidenceLevel) {
 	var confidence gemara.ConfidenceLevel
+	var message string
 
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-	workflows, err := data.GetDirectoryContent(".github/workflows")
+	workflows, err := payload.GetDirectoryContent(".github/workflows")
 	if len(workflows) == 0 {
 		if err != nil {
 			message = err.Error()
@@ -100,13 +96,13 @@ func checkAllWorkflows(payloadData any, checkWorkflow func(*actionlint.Workflow)
 	return gemara.Passed, passMessage, confidence
 }
 
-func CicdSanitizedInputParameters(payloadData any) (gemara.Result, string, gemara.ConfidenceLevel) {
-	return checkAllWorkflows(payloadData, checkWorkflowFileForUntrustedInputs,
+func CicdSanitizedInputParameters(payload data.Payload) (gemara.Result, string, gemara.ConfidenceLevel) {
+	return checkAllWorkflows(payload, checkWorkflowFileForUntrustedInputs,
 		"GitHub Workflows variables do not contain untrusted inputs")
 }
 
-func CicdBranchNameSanitized(payloadData any) (gemara.Result, string, gemara.ConfidenceLevel) {
-	return checkAllWorkflows(payloadData, checkWorkflowFileForBranchNameUsage,
+func CicdBranchNameSanitized(payload data.Payload) (gemara.Result, string, gemara.ConfidenceLevel) {
+	return checkAllWorkflows(payload, checkWorkflowFileForBranchNameUsage,
 		"GitHub Workflows do not use unsanitized branch names in run steps")
 }
 
@@ -236,17 +232,12 @@ func pullVariablesFromScript(script string) []string {
 
 }
 
-func ReleaseHasUniqueIdentifier(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func ReleaseHasUniqueIdentifier(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	var noNameCount int
 	var sameNameFound []string
 	var releaseNames = make(map[string]int)
 
-	for _, release := range data.Releases {
+	for _, release := range payload.Releases {
 		if release.Name == "" {
 			noNameCount++
 		} else if _, ok := releaseNames[release.Name]; ok {
@@ -266,8 +257,8 @@ func ReleaseHasUniqueIdentifier(payloadData any) (result gemara.Result, message 
 	return gemara.Passed, "All releases found have a unique name", confidence
 }
 
-func getLinks(data data.Payload) []string {
-	ins := data.Insights
+func getLinks(payload data.Payload) []string {
+	ins := payload.Insights
 	var links []string
 
 	addURL := func(u si.URL) { links = append(links, string(u)) }
@@ -293,8 +284,8 @@ func getLinks(data data.Payload) []string {
 	addURL(ins.Repository.License.Url)
 	addURLPtr(ins.Repository.SecurityPosture.Assessments.Self.Evidence)
 
-	if data.RepositoryMetadata.OrganizationBlogURL() != nil {
-		links = append(links, *data.RepositoryMetadata.OrganizationBlogURL())
+	if payload.RepositoryMetadata.OrganizationBlogURL() != nil {
+		links = append(links, *payload.RepositoryMetadata.OrganizationBlogURL())
 	}
 	for _, repo := range ins.Project.Repositories {
 		addURL(repo.Url)
@@ -327,13 +318,8 @@ func insecureURI(uri string) bool {
 	return true
 }
 
-func EnsureInsightsLinksUseHTTPS(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	links := getLinks(data)
+func EnsureInsightsLinksUseHTTPS(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	links := getLinks(payload)
 	var badURIs []string
 	for _, link := range links {
 		if insecureURI(link) {
@@ -346,26 +332,16 @@ func EnsureInsightsLinksUseHTTPS(payloadData any) (result gemara.Result, message
 	return gemara.Passed, "All links use HTTPS", confidence
 }
 
-func EnsureLatestReleaseHasChangelog(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	releaseDescription := data.Repository.LatestRelease.Description
+func EnsureLatestReleaseHasChangelog(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	releaseDescription := payload.Repository.LatestRelease.Description
 	if strings.Contains(releaseDescription, "Change Log") || strings.Contains(releaseDescription, "Changelog") {
 		return gemara.Passed, "Mention of a changelog found in the latest release", confidence
 	}
 	return gemara.Failed, "The latest release does not have mention of a changelog: \n" + releaseDescription, confidence
 }
 
-func InsightsHasSlsaAttestation(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	attestations := data.Insights.Repository.ReleaseDetails.Attestations
+func InsightsHasSlsaAttestation(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	attestations := payload.Insights.Repository.ReleaseDetails.Attestations
 
 	for _, attestation := range attestations {
 		if attestation.PredicateURI == "https://slsa.dev/provenance/v1" {
@@ -375,13 +351,8 @@ func InsightsHasSlsaAttestation(payloadData any) (result gemara.Result, message 
 	return gemara.Failed, "No SLSA attestation found in security insights", confidence
 }
 
-func DistributionPointsUseHTTPS(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	distributionPoints := data.Insights.Repository.ReleaseDetails.DistributionPoints
+func DistributionPointsUseHTTPS(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	distributionPoints := payload.Insights.Repository.ReleaseDetails.DistributionPoints
 
 	if len(distributionPoints) == 0 {
 		return gemara.NotApplicable, "No official distribution points found in Security Insights data", confidence
@@ -399,15 +370,10 @@ func DistributionPointsUseHTTPS(payloadData any) (result gemara.Result, message 
 	return gemara.Passed, "All distribution points use HTTPS", confidence
 }
 
-func SecretScanningInUse(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.SecurityPosture.PreventsPushingSecrets() && data.SecurityPosture.ScansForSecrets() {
+func SecretScanningInUse(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.SecurityPosture.PreventsPushingSecrets() && payload.SecurityPosture.ScansForSecrets() {
 		return gemara.Passed, "Secret scanning is enabled and prevents pushing secrets", confidence
-	} else if data.SecurityPosture.PreventsPushingSecrets() || data.SecurityPosture.ScansForSecrets() {
+	} else if payload.SecurityPosture.PreventsPushingSecrets() || payload.SecurityPosture.ScansForSecrets() {
 		return gemara.Failed, "Secret scanning is only partially enabled", confidence
 	} else {
 		return gemara.Failed, "Secret scanning is not enabled", confidence

--- a/evaluation_plans/osps/build_release/steps_test.go
+++ b/evaluation_plans/osps/build_release/steps_test.go
@@ -99,16 +99,16 @@ func TestCicdSanitizedInputParameters(t *testing.T) {
 func TestVariableExtraction(t *testing.T) {
 
 	var testScript = `echo ${{github.event.issue.title }}
-		if ${{ github.event.commits.arbitrary.data.message}} -ne 0
+		if ${{ github.event.commits.arbitrary.payload.message}} -ne 0
 		then
-			echo "Checkout report image" ${{ githubnodotevent.commits.arbitrary.data.message}}
+			echo "Checkout report image" ${{ githubnodotevent.commits.arbitrary.payload.message}}
 			run: docker pull the pvt-r-github-repo image
 		fi`
 
 	varNames := pullVariablesFromScript(testScript)
 
 	assert.Equal(t, slices.Contains(varNames, "github.event.issue.title"), true, "Variable extraction failed")
-	assert.Equal(t, slices.Contains(varNames, "github.event.commits.arbitrary.data.message"), true, "Variable extraction failed")
+	assert.Equal(t, slices.Contains(varNames, "github.event.commits.arbitrary.payload.message"), true, "Variable extraction failed")
 
 }
 
@@ -148,7 +148,7 @@ func TestInsecureURI(t *testing.T) {
 func TestUnTrustedVarsRegex(t *testing.T) {
 
 	assert.True(t, untrustedVars.Match([]byte("github.event.issue.title")), "regex match failed")
-	assert.True(t, untrustedVars.Match([]byte("github.event.commits.arbitrary.data.message")), "regex match failed")
+	assert.True(t, untrustedVars.Match([]byte("github.event.commits.arbitrary.payload.message")), "regex match failed")
 }
 
 var branchNameBadWorkflowFile = `name: Deploy on push

--- a/evaluation_plans/osps/docs/steps.go
+++ b/evaluation_plans/osps/docs/steps.go
@@ -2,17 +2,11 @@ package docs
 
 import (
 	"github.com/gemaraproj/go-gemara"
-
-	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
-func HasSupportDocs(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.HasSupportMarkdown() {
+func HasSupportDocs(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.HasSupportMarkdown() {
 		return gemara.Passed, "A support.md file or support statements in the readme.md was found", confidence
 
 	}
@@ -20,65 +14,40 @@ func HasSupportDocs(payloadData any) (result gemara.Result, message string, conf
 	return gemara.Failed, "A support.md file or support statements in the readme.md was NOT found", confidence
 }
 
-func HasUserGuides(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.Insights.Project.Documentation.DetailedGuide == nil {
+func HasUserGuides(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Insights.Project.Documentation.DetailedGuide == nil {
 		return gemara.Failed, "User guide was NOT specified in Security Insights data", confidence
 	}
 
 	return gemara.Passed, "User guide was specified in Security Insights data", confidence
 }
 
-func AcceptsVulnReports(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.Insights.Project.VulnerabilityReporting.ReportsAccepted {
+func AcceptsVulnReports(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Insights.Project.VulnerabilityReporting.ReportsAccepted {
 		return gemara.Passed, "Repository accepts vulnerability reports", confidence
 	}
 
 	return gemara.Failed, "Repository does not accept vulnerability reports", confidence
 }
 
-func HasSignatureVerificationGuide(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.Insights.Project.Documentation.SignatureVerification == nil {
+func HasSignatureVerificationGuide(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Insights.Project.Documentation.SignatureVerification == nil {
 		return gemara.Failed, "Signature verification guide was NOT specified in Security Insights data", confidence
 	}
 
 	return gemara.Passed, "Signature verification guide was specified in Security Insights data", confidence
 }
 
-func HasDependencyManagementPolicy(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.Insights.Repository.Documentation.DependencyManagementPolicy == nil {
+func HasDependencyManagementPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Insights.Repository.Documentation.DependencyManagementPolicy == nil {
 		return gemara.Failed, "Dependency management policy was NOT specified in Security Insights data", confidence
 	}
 
 	return gemara.Passed, "Dependency management policy was specified in Security Insights data", confidence
 }
 
-func HasIdentityVerificationGuide(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.Insights.Project.Documentation.SignatureVerification == nil {
+func HasIdentityVerificationGuide(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Insights.Project.Documentation.SignatureVerification == nil {
 		return gemara.Failed, "Identity verification guide was NOT specified in Security Insights data (checked signature-verification field)", confidence
 	}
 

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -2,78 +2,54 @@ package governance
 
 import (
 	"github.com/gemaraproj/go-gemara"
-	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
-func CoreTeamIsListed(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if len(data.Insights.Repository.CoreTeam) == 0 {
+func CoreTeamIsListed(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if len(payload.Insights.Repository.CoreTeam) == 0 {
 		return gemara.Failed, "Core team was NOT specified in Security Insights data", confidence
 	}
 
 	return gemara.Passed, "Core team was specified in Security Insights data", confidence
 }
 
-func ProjectAdminsListed(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if len(data.Insights.Project.Administrators) == 0 {
+func ProjectAdminsListed(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if len(payload.Insights.Project.Administrators) == 0 {
 		return gemara.Failed, "Project admins were NOT specified in Security Insights data", confidence
 	}
 
 	return gemara.Passed, "Project admins were specified in Security Insights data", confidence
 }
 
-func HasRolesAndResponsibilities(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.Insights.Repository.Documentation.Governance == nil {
+func HasRolesAndResponsibilities(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Insights.Repository.Documentation.Governance == nil {
 		return gemara.Failed, "Roles and responsibilities were NOT specified in Security Insights data", confidence
 	}
 
 	return gemara.Passed, "Roles and responsibilities were specified in Security Insights data", confidence
 }
 
-func HasContributionGuide(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.Insights.Project.Documentation.CodeOfConduct != nil && data.Insights.Repository.Documentation.ContributingGuide != nil {
+func HasContributionGuide(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Insights.Project.Documentation.CodeOfConduct != nil && payload.Insights.Repository.Documentation.ContributingGuide != nil {
 		return gemara.Passed, "Contributing guide specified in Security Insights data (Bonus: code of conduct location also specified)", confidence
 	}
 
-	if data.Repository.ContributingGuidelines.Body != "" && data.Insights.Project.Documentation.CodeOfConduct != nil {
+	if payload.Repository.ContributingGuidelines.Body != "" && payload.Insights.Project.Documentation.CodeOfConduct != nil {
 		return gemara.Passed, "Contributing guide was found via GitHub API (Bonus: code of conduct was specified in Security Insights data)", confidence
 	}
 
-	if data.Repository.ContributingGuidelines.Body != "" {
+	if payload.Repository.ContributingGuidelines.Body != "" {
 		return gemara.NeedsReview, "Contributing guide was found via GitHub API (Recommendation: Add code of conduct location to Security Insights data)", confidence
 	}
 
 	return gemara.Failed, "Contribution guide not found in Security Insights data or via GitHub API", confidence
 }
 
-func HasContributionReviewPolicy(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-	if !data.IsCodeRepo {
+func HasContributionReviewPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if !payload.IsCodeRepo {
 		return gemara.NotApplicable, "Repository contains no code - skipping code contribution policy check", confidence
 	}
-	if data.Insights.Repository.Documentation.ReviewPolicy != nil {
+	if payload.Insights.Repository.Documentation.ReviewPolicy != nil {
 		return gemara.Passed, "Code review guide was specified in Security Insights data", confidence
 	}
 

--- a/evaluation_plans/osps/legal/steps.go
+++ b/evaluation_plans/osps/legal/steps.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
-	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 type LicenseList struct {
@@ -23,10 +22,10 @@ type License struct {
 
 const spdxURL = "https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json"
 
-func getLicenseList(data data.Payload, makeApiCall func(string, bool) ([]byte, error)) (LicenseList, string) {
+func getLicenseList(payload data.Payload, makeApiCall func(string, bool) ([]byte, error)) (LicenseList, string) {
 	GoodLicenseList := LicenseList{}
 	if makeApiCall == nil {
-		makeApiCall = data.MakeApiCall
+		makeApiCall = payload.MakeApiCall
 	}
 	response, err := makeApiCall(spdxURL, false)
 	if err != nil {
@@ -51,46 +50,32 @@ func splitSpdxExpression(expression string) (spdx_ids []string) {
 	return
 }
 
-func FoundLicense(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-	if data.Repository.LicenseInfo.Url == "" {
+func FoundLicense(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Repository.LicenseInfo.Url == "" {
 		return gemara.Failed, "License was not found in a well known location via the GitHub API", confidence
 	}
 	return gemara.Passed, "License was found in a well known location via the GitHub API", confidence
 }
 
-func ReleasesLicensed(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if len(data.Releases) == 0 {
+func ReleasesLicensed(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if len(payload.Releases) == 0 {
 		return gemara.NotApplicable, "No releases found", confidence
 	}
-	if data.Repository.LicenseInfo.Url == "" {
+	if payload.Repository.LicenseInfo.Url == "" {
 		return gemara.Failed, "License was not found in a well known location via the GitHub API", confidence
 	}
 	return gemara.Passed, "GitHub releases include the license(s) in the released source code.", confidence
 }
 
-func GoodLicense(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	licenses, errString := getLicenseList(data, nil)
+func GoodLicense(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	licenses, errString := getLicenseList(payload, nil)
 
 	if errString != "" {
 		return gemara.Unknown, errString, confidence
 	}
 
-	apiInfo := data.Repository.LicenseInfo.SpdxId
-	siInfo := data.Insights.Repository.License.Expression
+	apiInfo := payload.Repository.LicenseInfo.SpdxId
+	siInfo := payload.Insights.Repository.License.Expression
 	if apiInfo == "" && siInfo == "" {
 		return gemara.Failed, "License SPDX identifier was not found in Security Insights data or via GitHub API", confidence
 	}
@@ -117,9 +102,9 @@ func GoodLicense(payloadData any) (result gemara.Result, message string, confide
 		}
 	}
 	approvedLicenses := strings.Join(spdx_ids, ", ")
-	if data.Config.Logger != nil {
-		data.Config.Logger.Trace(fmt.Sprintf("Requested licenses: %s", approvedLicenses))
-		data.Config.Logger.Trace(fmt.Sprintf("Non-approved licenses: %s", badLicenses))
+	if payload.Config.Logger != nil {
+		payload.Config.Logger.Trace(fmt.Sprintf("Requested licenses: %s", approvedLicenses))
+		payload.Config.Logger.Trace(fmt.Sprintf("Non-approved licenses: %s", badLicenses))
 	}
 
 	if len(badLicenses) > 0 {

--- a/evaluation_plans/osps/legal/steps_test.go
+++ b/evaluation_plans/osps/legal/steps_test.go
@@ -198,11 +198,6 @@ func TestGoodLicense(t *testing.T) {
 		expectedMessage string
 	}{
 		{
-			name:            "Invalid payload",
-			expectedResult:  gemara.Unknown,
-			expectedMessage: "Malformed assessment: expected payload type data.Payload, got string (invalid)",
-		},
-		{
 			name: "No license identifiers found",
 			payload: data.Payload{
 				GraphqlRepoData: &data.GraphqlRepoData{},

--- a/evaluation_plans/osps/legal/steps_test.go
+++ b/evaluation_plans/osps/legal/steps_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/privateerproj/privateer-sdk/config"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/privateerproj/privateer-sdk/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,13 +27,13 @@ func stubGraphqlRepo(licenseUrl string) *data.GraphqlRepoData {
 func TestReleasesLicensed(t *testing.T) {
 	tests := []struct {
 		name            string
-		payloadData     any
+		payload         data.Payload
 		expectedResult  gemara.Result
 		expectedMessage string
 	}{
 		{
 			name: "No releases found",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Releases: []data.ReleaseData{},
 				},
@@ -43,7 +43,7 @@ func TestReleasesLicensed(t *testing.T) {
 		},
 		{
 			name: "No licenses found",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Releases: []data.ReleaseData{
 						{
@@ -58,7 +58,7 @@ func TestReleasesLicensed(t *testing.T) {
 		},
 		{
 			name: "Has releases and license",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Releases: []data.ReleaseData{
 						{
@@ -75,7 +75,7 @@ func TestReleasesLicensed(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, message, _ := ReleasesLicensed(test.payloadData)
+			result, message, _ := ReleasesLicensed(test.payload)
 			assert.Equal(t, test.expectedResult, result)
 			assert.Equal(t, test.expectedMessage, message)
 		})
@@ -191,7 +191,7 @@ func TestSplitSpdxExpression(t *testing.T) {
 func TestGoodLicense(t *testing.T) {
 	tests := []struct {
 		name            string
-		payloadData     any
+		payload         data.Payload
 		apiResponse     []byte
 		apiError        error
 		expectedResult  gemara.Result
@@ -199,13 +199,12 @@ func TestGoodLicense(t *testing.T) {
 	}{
 		{
 			name:            "Invalid payload",
-			payloadData:     "invalid",
 			expectedResult:  gemara.Unknown,
 			expectedMessage: "Malformed assessment: expected payload type data.Payload, got string (invalid)",
 		},
 		{
 			name: "No license identifiers found",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				GraphqlRepoData: &data.GraphqlRepoData{},
 				Config:          &config.Config{},
 			},
@@ -216,7 +215,7 @@ func TestGoodLicense(t *testing.T) {
 		},
 		{
 			name: "OSI approved license (MIT)",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				GraphqlRepoData: func() *data.GraphqlRepoData {
 					repo := stubGraphqlRepo("")
 					repo.Repository.LicenseInfo.SpdxId = "MIT"
@@ -231,7 +230,7 @@ func TestGoodLicense(t *testing.T) {
 		},
 		{
 			name: "Non-approved license",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				GraphqlRepoData: func() *data.GraphqlRepoData {
 					repo := stubGraphqlRepo("")
 					repo.Repository.LicenseInfo.SpdxId = "BadLicense"
@@ -246,7 +245,7 @@ func TestGoodLicense(t *testing.T) {
 		},
 		{
 			name: "Multiple licenses with mixed approval",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				GraphqlRepoData: func() *data.GraphqlRepoData {
 					repo := stubGraphqlRepo("")
 					repo.Repository.LicenseInfo.SpdxId = "MIT AND BadLicense"
@@ -261,7 +260,7 @@ func TestGoodLicense(t *testing.T) {
 		},
 		{
 			name: "Unknown license ID",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				GraphqlRepoData: func() *data.GraphqlRepoData {
 					repo := stubGraphqlRepo("")
 					repo.Repository.LicenseInfo.SpdxId = "UnknownLicense"
@@ -278,12 +277,10 @@ func TestGoodLicense(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if payload, ok := test.payloadData.(data.Payload); ok {
-				payload = data.NewPayloadWithHTTPMock(payload, test.apiResponse, 200, test.apiError)
-				test.payloadData = payload
-			}
+			data := data.NewPayloadWithHTTPMock(test.payload, test.apiResponse, 200, test.apiError)
+			test.payload = data
 
-			result, message, _ := GoodLicense(test.payloadData)
+			result, message, _ := GoodLicense(test.payload)
 			assert.Equal(t, test.expectedResult, result)
 			assert.Equal(t, test.expectedMessage, message)
 		})

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -127,7 +127,9 @@ func NoBinariesInRepo(payload data.Payload) (result gemara.Result, message strin
 func NoUnreviewableBinariesInRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	unreviewableBinaries, err := payload.GetUnreviewableBinaries()
 	if err != nil {
-		payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for unreviewable binaries: %s", err.Error()))
+		if payload.Config != nil && payload.Config.Logger != nil {
+			payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for unreviewable binaries: %s", err.Error()))
+		}
 		return gemara.Unknown, "Error while scanning repository for unreviewable binaries, potentially due to repo size. See logs for details.", confidence
 	}
 

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -5,42 +5,28 @@ import (
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
-func RepoIsPublic(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-	if data.RepositoryMetadata.IsPublic() {
+func RepoIsPublic(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.RepositoryMetadata.IsPublic() {
 		return gemara.Passed, "Repository is public", confidence
 	}
 	return gemara.Failed, "Repository is private", confidence
 }
 
-func InsightsListsRepositories(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if len(data.Insights.Project.Repositories) > 0 {
+func InsightsListsRepositories(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if len(payload.Insights.Project.Repositories) > 0 {
 		return gemara.Passed, "Insights contains a list of repositories", confidence
 	}
 
 	return gemara.Failed, "Insights does not contain a list of repositories", confidence
 }
 
-func StatusChecksAreRequiredByRulesets(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func StatusChecksAreRequiredByRulesets(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// get the name of all status checks that were run
 	var statusChecks []string
-	for _, check := range data.Repository.DefaultBranchRef.Target.Commit.AssociatedPullRequests.Nodes {
+	for _, check := range payload.Repository.DefaultBranchRef.Target.Commit.AssociatedPullRequests.Nodes {
 		for _, run := range check.StatusCheckRollup.Commit.CheckSuites.Nodes {
 			for _, checkRun := range run.CheckRuns.Nodes {
 				statusChecks = append(statusChecks, checkRun.Name)
@@ -49,14 +35,14 @@ func StatusChecksAreRequiredByRulesets(payloadData any) (result gemara.Result, m
 	}
 
 	// get the rules that apply to the default branch
-	rules := data.GetRulesets(data.Repository.DefaultBranchRef.Name)
+	rules := payload.GetRulesets(payload.Repository.DefaultBranchRef.Name)
 	if len(rules) == 0 {
 		return gemara.Passed, "No rulesets found for default branch, continuing to evaluate branch protection", confidence
 	}
 
 	// get the name of all required status checks
 	var requiredChecks []string
-	for _, rule := range data.Rulesets {
+	for _, rule := range payload.Rulesets {
 		for _, requiredCheck := range rule.Parameters.RequiredChecks {
 			requiredChecks = append(requiredChecks, requiredCheck.Context)
 		}
@@ -84,15 +70,10 @@ func StatusChecksAreRequiredByRulesets(payloadData any) (result gemara.Result, m
 	return gemara.Passed, "No status checks were run that are not required by the rules", confidence
 }
 
-func StatusChecksAreRequiredByBranchProtection(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func StatusChecksAreRequiredByBranchProtection(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// get the name of all status checks that were run
 	var statusChecks []string
-	for _, check := range data.Repository.DefaultBranchRef.Target.Commit.AssociatedPullRequests.Nodes {
+	for _, check := range payload.Repository.DefaultBranchRef.Target.Commit.AssociatedPullRequests.Nodes {
 		for _, run := range check.StatusCheckRollup.Commit.CheckSuites.Nodes {
 			for _, checkRun := range run.CheckRuns.Nodes {
 				statusChecks = append(statusChecks, checkRun.Name)
@@ -100,7 +81,7 @@ func StatusChecksAreRequiredByBranchProtection(payloadData any) (result gemara.R
 		}
 	}
 
-	requiredChecks := data.Repository.DefaultBranchRef.BranchProtectionRule.RequiredStatusCheckContexts
+	requiredChecks := payload.Repository.DefaultBranchRef.BranchProtectionRule.RequiredStatusCheckContexts
 
 	// check whether all executed checks are required
 	missingChecks := []string{}
@@ -124,17 +105,12 @@ func StatusChecksAreRequiredByBranchProtection(payloadData any) (result gemara.R
 	return gemara.Passed, "No status checks were run that are not required by branch protection", confidence
 }
 
-func NoBinariesInRepo(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func NoBinariesInRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// TODO: This only checks the top 3 levels of the repository tree
 	// for common binary file extensions and it fails on very large repositories.
-	suspectedBinaries, err := data.GetSuspectedBinaries()
+	suspectedBinaries, err := payload.GetSuspectedBinaries()
 	if err != nil {
-		data.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for binaries: %s", err.Error()))
+		payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for binaries: %s", err.Error()))
 		return gemara.Unknown, "Error while scanning repository for binaries, potentially due to repo size. See logs for details.", confidence
 	}
 
@@ -148,15 +124,10 @@ func NoBinariesInRepo(payloadData any) (result gemara.Result, message string, co
 // It checks that the version control system does not contain unreviewable binary
 // artifacts such as compiled executables, shared libraries, or archive binaries.
 // Acceptable binary content (images, audio, video, fonts, PDFs) is not flagged.
-func NoUnreviewableBinariesInRepo(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	unreviewableBinaries, err := data.GetUnreviewableBinaries()
+func NoUnreviewableBinariesInRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	unreviewableBinaries, err := payload.GetUnreviewableBinaries()
 	if err != nil {
-		data.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for unreviewable binaries: %s", err.Error()))
+		payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for unreviewable binaries: %s", err.Error()))
 		return gemara.Unknown, "Error while scanning repository for unreviewable binaries, potentially due to repo size. See logs for details.", confidence
 	}
 
@@ -166,18 +137,14 @@ func NoUnreviewableBinariesInRepo(payloadData any) (result gemara.Result, messag
 	return gemara.Failed, fmt.Sprintf("Unreviewable binary artifacts found in the repository: %s", strings.Join(unreviewableBinaries, ", ")), confidence
 }
 
-func RequiresNonAuthorApproval(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-	protection := data.Repository.DefaultBranchRef.BranchProtectionRule
+func RequiresNonAuthorApproval(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	protection := payload.Repository.DefaultBranchRef.BranchProtectionRule
 
 	if !protection.RequiresApprovingReviews {
 		return gemara.Failed, "Branch protection rule does not require reviews", confidence
 	}
 
-	reviewCount := data.Repository.DefaultBranchRef.RefUpdateRule.RequiredApprovingReviewCount
+	reviewCount := payload.Repository.DefaultBranchRef.RefUpdateRule.RequiredApprovingReviewCount
 	if reviewCount < 1 {
 		return gemara.Failed, "Branch protection rule requires 0 approving reviews", confidence
 	}
@@ -189,15 +156,10 @@ func RequiresNonAuthorApproval(payloadData any) (result gemara.Result, message s
 	return gemara.Passed, fmt.Sprintf("Branch protection requires %d approving reviews and re-approval after new commits", reviewCount), confidence
 }
 
-func HasOneOrMoreStatusChecks(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func HasOneOrMoreStatusChecks(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// get the name of all status checks that were run
 	var statusChecks []string
-	for _, check := range data.Repository.DefaultBranchRef.Target.Commit.AssociatedPullRequests.Nodes {
+	for _, check := range payload.Repository.DefaultBranchRef.Target.Commit.AssociatedPullRequests.Nodes {
 		for _, run := range check.StatusCheckRollup.Commit.CheckSuites.Nodes {
 			for _, checkRun := range run.CheckRuns.Nodes {
 				statusChecks = append(statusChecks, checkRun.Name)
@@ -212,49 +174,30 @@ func HasOneOrMoreStatusChecks(payloadData any) (result gemara.Result, message st
 	return gemara.Failed, "No status checks were run", confidence
 }
 
-func VerifyDependencyManagement(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func VerifyDependencyManagement(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// Validate required fields
-	if data.Repository.Name == "" || data.Repository.DefaultBranchRef.Name == "" ||
-		data.Repository.DefaultBranchRef.Target.OID == "" {
+	if payload.Repository.Name == "" || payload.Repository.DefaultBranchRef.Name == "" ||
+		payload.Repository.DefaultBranchRef.Target.OID == "" {
 		return gemara.Unknown, "Missing required repository data", confidence
 	}
 
 	// Check dependency manifests
 	// TODO: Do a quality check on the dependency manifests
-	return countDependencyManifests(data)
+	return countDependencyManifests(payload)
 }
 
-func countDependencyManifests(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	manifestsCount := data.DependencyManifestsCount
+func countDependencyManifests(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	manifestsCount := payload.DependencyManifestsCount
 	if manifestsCount > 0 {
 		return gemara.Passed, fmt.Sprintf("Found %d dependency manifests from GitHub API", manifestsCount), confidence
 	}
 	return gemara.NeedsReview, "No dependency manifests found in the GitHub dependency graph API. Review project to ensure dependencies are managed.", confidence
 }
 
-func DocumentsTestExecution(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	_, message = reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func DocumentsTestExecution(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	return gemara.NeedsReview, "Review project documentation to ensure it explains when and how tests are run", confidence
 }
 
-func DocumentsTestMaintenancePolicy(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	_, message = reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
+func DocumentsTestMaintenancePolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	return gemara.NeedsReview, "Review project documentation to ensure it contains a clear policy for maintaining tests", confidence
 }

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -76,7 +76,7 @@ func Test_InsightsListsRepositories(t *testing.T) {
 
 func Test_NoUnreviewableBinariesInRepo(t *testing.T) {
 	t.Run("invalid payload returns unknown", func(t *testing.T) {
-		result, msg, _ := NoUnreviewableBinariesInRepo("not a payload")
+		result, msg, _ := NoUnreviewableBinariesInRepo(data.Payload{})
 		if result != gemara.Unknown {
 			t.Errorf("result = %v, want Unknown", result)
 		}

--- a/evaluation_plans/osps/sec_assessment/steps.go
+++ b/evaluation_plans/osps/sec_assessment/steps.go
@@ -4,8 +4,7 @@ import (
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
-
-	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
 // DesignDocFiles are common file names for design/architecture documentation
@@ -20,25 +19,20 @@ var DesignDocFiles = []string{
 
 // DesignDocDirectories are common directory names that typically contain design documentation
 var DesignDocDirectories = []string{
-    "adr",
-    "adrs",
+	"adr",
+	"adrs",
 	"architecture",
 	"design",
 	"docs",
 	"doc",
 }
 
-func HasDesignDocumentation(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func HasDesignDocumentation(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	var foundDirectories []string
 
 	// Check for design documentation files and directories in repository root
-	if data.GraphqlRepoData != nil {
-		for _, entry := range data.Repository.Object.Tree.Entries {
+	if payload.GraphqlRepoData != nil {
+		for _, entry := range payload.Repository.Object.Tree.Entries {
 			// Check for design doc files (blobs only)
 			if entry.Type == "blob" {
 				for _, designFile := range DesignDocFiles {
@@ -65,7 +59,7 @@ func HasDesignDocumentation(payloadData any) (result gemara.Result, message stri
 	}
 
 	// Fallback: check if DetailedGuide is specified in Security Insights
-	if data.RestData != nil && data.Insights.Project.Documentation.DetailedGuide != nil {
+	if payload.RestData != nil && payload.Insights.Project.Documentation.DetailedGuide != nil {
 		return gemara.NeedsReview, "No design documentation file found, but detailed guide specified in Security Insights - manual review needed to confirm design documentation with actions and actors", confidence
 	}
 

--- a/evaluation_plans/osps/sec_assessment/steps_test.go
+++ b/evaluation_plans/osps/sec_assessment/steps_test.go
@@ -19,11 +19,6 @@ func Test_HasDesignDocumentation(t *testing.T) {
 		wantMsg    string
 	}{
 		{
-			name:       "malformed payload",
-			wantResult: gemara.Unknown,
-			wantMsg:    "",
-		},
-		{
 			name: "nil data returns failed",
 			payload: data.Payload{
 				GraphqlRepoData: nil,

--- a/evaluation_plans/osps/sec_assessment/steps_test.go
+++ b/evaluation_plans/osps/sec_assessment/steps_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/ossf/si-tooling/v2/si"
-
 	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/si-tooling/v2/si"
 )
 
 func ptrTo[T any](v T) *T { return &v }
@@ -15,13 +14,12 @@ func ptrTo[T any](v T) *T { return &v }
 func Test_HasDesignDocumentation(t *testing.T) {
 	tests := []struct {
 		name       string
-		payload    any
+		payload    data.Payload
 		wantResult gemara.Result
 		wantMsg    string
 	}{
 		{
 			name:       "malformed payload",
-			payload:    "not a payload",
 			wantResult: gemara.Unknown,
 			wantMsg:    "",
 		},

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -4,22 +4,16 @@ import (
 	"slices"
 
 	"github.com/gemaraproj/go-gemara"
-
-	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
-func HasSecContact(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func HasSecContact(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// TODO: Check for a contact email in SECURITY.md
 
-	if data.Insights.Project.VulnerabilityReporting.Contact.Email != nil {
+	if payload.Insights.Project.VulnerabilityReporting.Contact.Email != nil {
 		return gemara.Passed, "Security contacts were specified in Security Insights data", confidence
 	}
-	for _, champion := range data.Insights.Repository.SecurityPosture.Champions {
+	for _, champion := range payload.Insights.Repository.SecurityPosture.Champions {
 		if champion.Email != nil {
 			return gemara.Passed, "Security contacts were specified in Security Insights data", confidence
 		}
@@ -28,13 +22,8 @@ func HasSecContact(payloadData any) (result gemara.Result, message string, confi
 	return gemara.Failed, "Security contacts were not specified in Security Insights data", confidence
 }
 
-func SastToolDefined(payloadData interface{}) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	for _, tool := range data.Insights.Repository.SecurityPosture.Tools {
+func SastToolDefined(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	for _, tool := range payload.Insights.Repository.SecurityPosture.Tools {
 		if tool.Type == "SAST" {
 
 			enabled := []bool{tool.Integration.Adhoc, tool.Integration.Ci, tool.Integration.Release}
@@ -48,34 +37,24 @@ func SastToolDefined(payloadData interface{}) (result gemara.Result, message str
 	return gemara.Failed, "No Static Application Security Testing documented in Security Insights", confidence
 }
 
-func HasVulnerabilityDisclosurePolicy(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.Insights.Project.VulnerabilityReporting.Policy == nil {
+func HasVulnerabilityDisclosurePolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Insights.Project.VulnerabilityReporting.Policy == nil {
 		return gemara.Failed, "Vulnerability disclosure policy was NOT specified in Security Insights data", confidence
 	}
 
 	return gemara.Passed, "Vulnerability disclosure policy was specified in Security Insights data", confidence
 }
 
-func HasPrivateVulnerabilityReporting(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := reusable_steps.VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if !data.Insights.Project.VulnerabilityReporting.ReportsAccepted {
+func HasPrivateVulnerabilityReporting(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if !payload.Insights.Project.VulnerabilityReporting.ReportsAccepted {
 		return gemara.Failed, "Project does not accept vulnerability reports according to Security Insights data", confidence
 	}
 
-	if data.Insights.Project.VulnerabilityReporting.Contact.Email != nil {
+	if payload.Insights.Project.VulnerabilityReporting.Contact.Email != nil {
 		return gemara.Passed, "Private vulnerability reporting available via dedicated contact email in Security Insights data", confidence
 	}
 
-	for _, champion := range data.Insights.Repository.SecurityPosture.Champions {
+	for _, champion := range payload.Insights.Repository.SecurityPosture.Champions {
 		if champion.Email != nil {
 			return gemara.Passed, "Private vulnerability reporting available via security champions contact in Security Insights data", confidence
 		}

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -146,11 +146,6 @@ func TestHasVulnerabilityDisclosurePolicy(t *testing.T) {
 				GraphqlRepoData: &data.GraphqlRepoData{},
 			},
 		},
-		{
-			name:            "Invalid payload",
-			expectedResult:  gemara.Unknown,
-			expectedMessage: "Malformed assessment: expected payload type data.Payload, got string (invalid_payload)",
-		},
 	}
 
 	for _, test := range tests {
@@ -263,11 +258,6 @@ func TestHasPrivateVulnerabilityReporting(t *testing.T) {
 				},
 				GraphqlRepoData: &data.GraphqlRepoData{},
 			},
-		},
-		{
-			name:            "Invalid payload",
-			expectedResult:  gemara.Unknown,
-			expectedMessage: "Malformed assessment: expected payload type data.Payload, got string (invalid_payload)",
 		},
 	}
 

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/ossf/si-tooling/v2/si"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/si-tooling/v2/si"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +14,7 @@ func ptrTo[T any](v T) *T { return &v }
 type testingData struct {
 	expectedResult   gemara.Result
 	expectedMessage  string
-	payloadData      interface{}
+	payload          data.Payload
 	assertionMessage string
 }
 
@@ -25,7 +25,7 @@ func TestSastToolDefined(t *testing.T) {
 			expectedResult:   gemara.Passed,
 			expectedMessage:  "Static Application Security Testing documented in Security Insights",
 			assertionMessage: "Test for SAST integration enabled",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -48,7 +48,7 @@ func TestSastToolDefined(t *testing.T) {
 			expectedResult:   gemara.Failed,
 			expectedMessage:  "No Static Application Security Testing documented in Security Insights",
 			assertionMessage: "Test for SAST integration present but not explicitly enabled",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -68,7 +68,7 @@ func TestSastToolDefined(t *testing.T) {
 			expectedResult:   gemara.Failed,
 			expectedMessage:  "No Static Application Security Testing documented in Security Insights",
 			assertionMessage: "Test for Non SAST tool defined",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -88,7 +88,7 @@ func TestSastToolDefined(t *testing.T) {
 			expectedResult:   gemara.Failed,
 			expectedMessage:  "No Static Application Security Testing documented in Security Insights",
 			assertionMessage: "Test for no tools defined",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -101,7 +101,7 @@ func TestSastToolDefined(t *testing.T) {
 	}
 
 	for _, test := range testData {
-		result, message, _ := SastToolDefined(test.payloadData)
+		result, message, _ := SastToolDefined(test.payload)
 
 		assert.Equal(t, test.expectedResult, result, test.assertionMessage)
 		assert.Equal(t, test.expectedMessage, message, test.assertionMessage)
@@ -112,7 +112,7 @@ func TestSastToolDefined(t *testing.T) {
 func TestHasVulnerabilityDisclosurePolicy(t *testing.T) {
 	tests := []struct {
 		name            string
-		payloadData     any
+		payload         data.Payload
 		expectedResult  gemara.Result
 		expectedMessage string
 	}{
@@ -120,7 +120,7 @@ func TestHasVulnerabilityDisclosurePolicy(t *testing.T) {
 			name:            "Vulnerability disclosure policy present",
 			expectedResult:  gemara.Passed,
 			expectedMessage: "Vulnerability disclosure policy was specified in Security Insights data",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Project: &si.Project{
@@ -137,7 +137,7 @@ func TestHasVulnerabilityDisclosurePolicy(t *testing.T) {
 			name:            "Vulnerability disclosure policy missing",
 			expectedResult:  gemara.Failed,
 			expectedMessage: "Vulnerability disclosure policy was NOT specified in Security Insights data",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Project: &si.Project{},
@@ -150,13 +150,12 @@ func TestHasVulnerabilityDisclosurePolicy(t *testing.T) {
 			name:            "Invalid payload",
 			expectedResult:  gemara.Unknown,
 			expectedMessage: "Malformed assessment: expected payload type data.Payload, got string (invalid_payload)",
-			payloadData:     "invalid_payload",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, message, _ := HasVulnerabilityDisclosurePolicy(test.payloadData)
+			result, message, _ := HasVulnerabilityDisclosurePolicy(test.payload)
 			assert.Equal(t, test.expectedResult, result)
 			assert.Equal(t, test.expectedMessage, message)
 		})
@@ -166,7 +165,7 @@ func TestHasVulnerabilityDisclosurePolicy(t *testing.T) {
 func TestHasPrivateVulnerabilityReporting(t *testing.T) {
 	tests := []struct {
 		name            string
-		payloadData     any
+		payload         data.Payload
 		expectedResult  gemara.Result
 		expectedMessage string
 	}{
@@ -174,7 +173,7 @@ func TestHasPrivateVulnerabilityReporting(t *testing.T) {
 			name:            "Private reporting via vulnerability contact email",
 			expectedResult:  gemara.Passed,
 			expectedMessage: "Private vulnerability reporting available via dedicated contact email in Security Insights data",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Project: &si.Project{
@@ -194,7 +193,7 @@ func TestHasPrivateVulnerabilityReporting(t *testing.T) {
 			name:            "Private reporting via security champions",
 			expectedResult:  gemara.Passed,
 			expectedMessage: "Private vulnerability reporting available via security champions contact in Security Insights data",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Project: &si.Project{
@@ -222,7 +221,7 @@ func TestHasPrivateVulnerabilityReporting(t *testing.T) {
 			name:            "Reports not accepted",
 			expectedResult:  gemara.Failed,
 			expectedMessage: "Project does not accept vulnerability reports according to Security Insights data",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Project: &si.Project{
@@ -242,7 +241,7 @@ func TestHasPrivateVulnerabilityReporting(t *testing.T) {
 			name:            "No contact methods available",
 			expectedResult:  gemara.Failed,
 			expectedMessage: "No private vulnerability reporting contact method found in Security Insights data",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Project: &si.Project{
@@ -269,13 +268,12 @@ func TestHasPrivateVulnerabilityReporting(t *testing.T) {
 			name:            "Invalid payload",
 			expectedResult:  gemara.Unknown,
 			expectedMessage: "Malformed assessment: expected payload type data.Payload, got string (invalid_payload)",
-			payloadData:     "invalid_payload",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, message, _ := HasPrivateVulnerabilityReporting(test.payloadData)
+			result, message, _ := HasPrivateVulnerabilityReporting(test.payload)
 			assert.Equal(t, test.expectedResult, result)
 			assert.Equal(t, test.expectedMessage, message)
 		})

--- a/evaluation_plans/reusable_steps/steps.go
+++ b/evaluation_plans/reusable_steps/steps.go
@@ -4,40 +4,22 @@ import (
 	"fmt"
 
 	"github.com/gemaraproj/go-gemara"
-
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
-func VerifyPayload(payloadData any) (payload data.Payload, message string) {
-	payload, ok := payloadData.(data.Payload)
-	if !ok {
-		message = fmt.Sprintf("Malformed assessment: expected payload type %T, got %T (%v)", data.Payload{}, payloadData, payloadData)
-	}
-	return
-}
-
-func NotImplemented(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+func NotImplemented(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	return gemara.NotRun, "Not implemented", confidence
 }
 
-func GithubBuiltIn(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	_, message = VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func GithubBuiltIn(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	return gemara.Passed, "This control is enforced by GitHub for all projects", confidence
 }
 
-func GithubTermsOfService(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+func GithubTermsOfService(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	return gemara.Passed, "This control is satisfied by the GitHub Terms of Service", confidence
 }
 
-func HasSecurityInsightsFile(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	payload, message := VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
+func HasSecurityInsightsFile(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if payload.InsightsError {
 		return gemara.NeedsReview, "An error was encountered while parsing Security Insights content", confidence
 	}
@@ -48,12 +30,7 @@ func HasSecurityInsightsFile(payloadData any) (result gemara.Result, message str
 	return gemara.Passed, "Security insights file found", confidence
 }
 
-func HasMadeReleases(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	payload, message := VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func HasMadeReleases(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if len(payload.Releases) == 0 {
 		return gemara.NotApplicable, "No releases found", confidence
 	}
@@ -61,12 +38,7 @@ func HasMadeReleases(payloadData any) (result gemara.Result, message string, con
 	return gemara.Passed, fmt.Sprintf("Found %v releases", len(payload.Releases)), confidence
 }
 
-func IsActive(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	payload, message := VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func IsActive(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if payload.Insights.Repository.Status == "active" {
 		result = gemara.Passed
 	} else {
@@ -76,30 +48,20 @@ func IsActive(payloadData any) (result gemara.Result, message string, confidence
 	return result, fmt.Sprintf("Repo Status is %s", payload.Insights.Repository.Status), confidence
 }
 
-func HasIssuesOrDiscussionsEnabled(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	data, message := VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
-	if data.Repository.HasDiscussionsEnabled && data.Repository.HasIssuesEnabled {
+func HasIssuesOrDiscussionsEnabled(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Repository.HasDiscussionsEnabled && payload.Repository.HasIssuesEnabled {
 		return gemara.Passed, "Both issues and discussions are enabled for the repository", confidence
 	}
-	if data.Repository.HasDiscussionsEnabled {
+	if payload.Repository.HasDiscussionsEnabled {
 		return gemara.Passed, "Discussions are enabled for the repository", confidence
 	}
-	if data.Repository.HasIssuesEnabled {
+	if payload.Repository.HasIssuesEnabled {
 		return gemara.Passed, "Issues are enabled for the repository", confidence
 	}
 	return gemara.Failed, "Both issues and discussions are disabled for the repository", confidence
 }
 
-func HasDependencyManagementPolicy(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	payload, message := VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func HasDependencyManagementPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if payload.Insights.Repository.Documentation.DependencyManagementPolicy != nil {
 		return gemara.Passed, "Found dependency management policy in documentation", confidence
 	}
@@ -107,12 +69,7 @@ func HasDependencyManagementPolicy(payloadData any) (result gemara.Result, messa
 	return gemara.Failed, "No dependency management file found", confidence
 }
 
-func IsCodeRepo(payloadData any) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	payload, message := VerifyPayload(payloadData)
-	if message != "" {
-		return gemara.Unknown, message, confidence
-	}
-
+func IsCodeRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if !payload.IsCodeRepo {
 		return gemara.NotApplicable, "Repository does not contain code", confidence
 	}

--- a/evaluation_plans/reusable_steps/steps_test.go
+++ b/evaluation_plans/reusable_steps/steps_test.go
@@ -100,12 +100,6 @@ func TestIsCodeRepo(t *testing.T) {
 			expectedMessage:  "Repository does not contain code",
 			assertionMessage: "Should be not applicable when IsCodeRepo is false",
 		},
-		{
-			name:             "Malformed payload type",
-			expectedResult:   gemara.Unknown,
-			expectedMessage:  "Malformed assessment: expected payload type data.Payload, got string (not a payload)",
-			assertionMessage: "Should return Unknown for wrong payload type",
-		},
 	}
 
 	for _, tt := range tests {
@@ -151,12 +145,6 @@ func TestHasSecurityInsightsFile(t *testing.T) {
 			expectedResult:   gemara.NeedsReview,
 			expectedMessage:  "Security insights required for this assessment, but file not found",
 			assertionMessage: "Should need review when security insights file URL is empty",
-		},
-		{
-			name:             "Malformed payload type",
-			expectedResult:   gemara.Unknown,
-			expectedMessage:  "Malformed assessment: expected payload type data.Payload, got string (not a payload)",
-			assertionMessage: "Should return Unknown for wrong payload type",
 		},
 	}
 
@@ -218,12 +206,6 @@ func TestIsActive(t *testing.T) {
 			expectedResult:   gemara.NotApplicable,
 			expectedMessage:  "Repo Status is ",
 			assertionMessage: "Should be not applicable when repository status is empty",
-		},
-		{
-			name:             "Malformed payload type",
-			expectedResult:   gemara.Unknown,
-			expectedMessage:  "Malformed assessment: expected payload type data.Payload, got string (not a payload)",
-			assertionMessage: "Should return Unknown for wrong payload type",
 		},
 	}
 

--- a/evaluation_plans/reusable_steps/steps_test.go
+++ b/evaluation_plans/reusable_steps/steps_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
-	"github.com/ossf/si-tooling/v2/si"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/si-tooling/v2/si"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +14,7 @@ func ptrTo[T any](v T) *T { return &v }
 type testingData struct {
 	expectedResult   gemara.Result
 	expectedMessage  string
-	payloadData      any
+	payload          data.Payload
 	assertionMessage string
 }
 
@@ -24,7 +24,7 @@ func TestHasDependencyManagementPolicy(t *testing.T) {
 		{
 			expectedResult:  gemara.Passed,
 			expectedMessage: "Found dependency management policy in documentation",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -40,7 +40,7 @@ func TestHasDependencyManagementPolicy(t *testing.T) {
 		{
 			expectedResult:  gemara.Failed,
 			expectedMessage: "No dependency management file found",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -54,7 +54,7 @@ func TestHasDependencyManagementPolicy(t *testing.T) {
 		{
 			expectedResult:  gemara.Failed,
 			expectedMessage: "No dependency management file found",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -68,7 +68,7 @@ func TestHasDependencyManagementPolicy(t *testing.T) {
 	}
 
 	for _, test := range testData {
-		result, message, _ := HasDependencyManagementPolicy(test.payloadData)
+		result, message, _ := HasDependencyManagementPolicy(test.payload)
 		assert.Equal(t, test.expectedResult, result, test.assertionMessage)
 		assert.Equal(t, test.expectedMessage, message, test.assertionMessage)
 	}
@@ -77,14 +77,14 @@ func TestHasDependencyManagementPolicy(t *testing.T) {
 func TestIsCodeRepo(t *testing.T) {
 	tests := []struct {
 		name             string
-		payloadData      any
+		payload          data.Payload
 		expectedResult   gemara.Result
 		expectedMessage  string
 		assertionMessage string
 	}{
 		{
 			name: "Repository contains code",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				IsCodeRepo: true,
 			},
 			expectedResult:   gemara.Passed,
@@ -93,7 +93,7 @@ func TestIsCodeRepo(t *testing.T) {
 		},
 		{
 			name: "Repository does not contain code",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				IsCodeRepo: false,
 			},
 			expectedResult:   gemara.NotApplicable,
@@ -102,7 +102,6 @@ func TestIsCodeRepo(t *testing.T) {
 		},
 		{
 			name:             "Malformed payload type",
-			payloadData:      "not a payload",
 			expectedResult:   gemara.Unknown,
 			expectedMessage:  "Malformed assessment: expected payload type data.Payload, got string (not a payload)",
 			assertionMessage: "Should return Unknown for wrong payload type",
@@ -110,7 +109,7 @@ func TestIsCodeRepo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, message, _ := IsCodeRepo(tt.payloadData)
+		result, message, _ := IsCodeRepo(tt.payload)
 		assert.Equal(t, tt.expectedResult, result, tt.assertionMessage)
 		assert.Equal(t, tt.expectedMessage, message, tt.assertionMessage)
 	}
@@ -118,14 +117,14 @@ func TestIsCodeRepo(t *testing.T) {
 func TestHasSecurityInsightsFile(t *testing.T) {
 	tests := []struct {
 		name             string
-		payloadData      any
+		payload          data.Payload
 		expectedResult   gemara.Result
 		expectedMessage  string
 		assertionMessage string
 	}{
 		{
 			name: "Security insights file found",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Header: si.Header{
@@ -140,7 +139,7 @@ func TestHasSecurityInsightsFile(t *testing.T) {
 		},
 		{
 			name: "Security insights file not found",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Header: si.Header{
@@ -155,7 +154,6 @@ func TestHasSecurityInsightsFile(t *testing.T) {
 		},
 		{
 			name:             "Malformed payload type",
-			payloadData:      "not a payload",
 			expectedResult:   gemara.Unknown,
 			expectedMessage:  "Malformed assessment: expected payload type data.Payload, got string (not a payload)",
 			assertionMessage: "Should return Unknown for wrong payload type",
@@ -163,7 +161,7 @@ func TestHasSecurityInsightsFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, message, _ := HasSecurityInsightsFile(tt.payloadData)
+		result, message, _ := HasSecurityInsightsFile(tt.payload)
 		assert.Equal(t, tt.expectedResult, result, tt.assertionMessage)
 		assert.Equal(t, tt.expectedMessage, message, tt.assertionMessage)
 	}
@@ -171,14 +169,14 @@ func TestHasSecurityInsightsFile(t *testing.T) {
 func TestIsActive(t *testing.T) {
 	tests := []struct {
 		name             string
-		payloadData      any
+		payload          data.Payload
 		expectedResult   gemara.Result
 		expectedMessage  string
 		assertionMessage string
 	}{
 		{
 			name: "Active repository",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -193,7 +191,7 @@ func TestIsActive(t *testing.T) {
 		},
 		{
 			name: "Inactive repository",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -208,7 +206,7 @@ func TestIsActive(t *testing.T) {
 		},
 		{
 			name: "Empty status",
-			payloadData: data.Payload{
+			payload: data.Payload{
 				RestData: &data.RestData{
 					Insights: si.SecurityInsights{
 						Repository: &si.Repository{
@@ -223,7 +221,6 @@ func TestIsActive(t *testing.T) {
 		},
 		{
 			name:             "Malformed payload type",
-			payloadData:      "not a payload",
 			expectedResult:   gemara.Unknown,
 			expectedMessage:  "Malformed assessment: expected payload type data.Payload, got string (not a payload)",
 			assertionMessage: "Should return Unknown for wrong payload type",
@@ -231,7 +228,7 @@ func TestIsActive(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, message, _ := IsActive(tt.payloadData)
+		result, message, _ := IsActive(tt.payload)
 		assert.Equal(t, tt.expectedResult, result, tt.assertionMessage)
 		assert.Equal(t, tt.expectedMessage, message, tt.assertionMessage)
 	}

--- a/evaluation_plans/typed_step.go
+++ b/evaluation_plans/typed_step.go
@@ -1,0 +1,49 @@
+package evaluation_plans
+
+import (
+	"fmt"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+)
+
+// TypedStep is the signature every step in this plugin uses: it receives a
+// fully-typed data.Payload instead of an untyped any. AsAssessmentStep adapts
+// it to gemara.AssessmentStep so the SDK can invoke it; the type assertion
+// replaces the per-step VerifyPayload guard that used to live in every step.
+type TypedStep func(data.Payload) (gemara.Result, string, gemara.ConfidenceLevel)
+
+func (s TypedStep) AsAssessmentStep() gemara.AssessmentStep {
+	return func(p any) (gemara.Result, string, gemara.ConfidenceLevel) {
+		payload, ok := p.(data.Payload)
+		if !ok {
+			return gemara.Unknown,
+				fmt.Sprintf("expected %T, got %T", data.Payload{}, p), 0
+		}
+		return s(payload)
+	}
+}
+
+// AllSteps merges all step maps into a single map for registration with the SDK.
+// Assessment IDs are unique across catalogs (e.g., OSPS-* vs CRA-*), so the
+// catalog YAML naturally filters to the correct subset at evaluation time.
+// To add a new catalog family, define its step map and include it here.
+//
+// A single shared map is safe across catalog versions because the OSPS
+// maintenance policy (https://github.com/ossf/security-baseline/blob/main/docs/maintenance.md#identifiers)
+// guarantees that substantive changes to a control result in a new identifier.
+// This means implementations for a given assessment ID will not diverge between
+// versions, so all versions can share the same step function for the same key.
+func AllSteps() map[string][]gemara.AssessmentStep {
+	merged := make(map[string][]gemara.AssessmentStep, len(OSPS))
+	for id, steps := range OSPS {
+		for _, s := range steps {
+			merged[id] = append(merged[id], s.AsAssessmentStep())
+		}
+	}
+	// Add additional catalog step maps here, e.g.:
+	// for id, steps := range CRA {
+	//     for _, s := range steps { merged[id] = append(merged[id], s.AsAssessmentStep()) }
+	// }
+	return merged
+}


### PR DESCRIPTION
this removes all the extra checks we had for payload verification

[evaluation_plans/typed_step.go](https://github.com/ossf/pvtr-github-repo-scanner/pull/302/changes#diff-56884b24f5fb1d71cbf770f6303c1f7ea4471eb3dbe62d45cfe1a9f3d32a41aaR14-R25) has the functional changes that make the rest of the edits possible.