### PR TITLE
ci: align release workflow with ospo-reusable-workflows v1.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,92 +8,19 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc
+      contents: write       # create_release, publish_release: tag + release
+      pull-requests: read   # create_release: read PR labels for release-drafter
+      id-token: write       # release_goreleaser, release_image: attestation OIDC
+      attestations: write   # release_goreleaser, release_image: build provenance
+      packages: write       # release_image: push container image
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true
       release-config-name: release-drafter.yml
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-  release_image:
-    needs: release
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-image.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc
-    with:
+      goreleaser-config-path: .goreleaser.yaml
+      go-version-file: go.mod
+      create-attestation: true
       image-name: ${{ github.repository }}
-      full-tag: ${{ needs.release.outputs.full-tag }}
-      short-tag: ${{ needs.release.outputs.short-tag }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-      image-registry: ghcr.io
-      image-registry-username: ${{ github.actor }}
       image-registry-password: ${{ secrets.GITHUB_TOKEN }}
-  goreleaser:
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-    outputs:
-      attestation_matrix: ${{ steps.generate_matrix.outputs.matrix }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
-        with:
-          syft-version: v1.33.0
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
-        with:
-          subject-checksums: dist/checksums.txt
-      - name: Generate attestation matrix
-        id: generate_matrix
-        run: |
-          matrix=$(ls dist/*.spdx.json | jq -R '{"sbom": ., "archive": sub("\\.spdx\\.json$"; "")}' | jq -s -c '{"include": .}')
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
-      - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: dist
-          path: dist
-  attest-sboms:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      id-token: write
-    strategy:
-      matrix: ${{ fromJson(needs.goreleaser.outputs.attestation_matrix) }}
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: dist
-          path: dist
-      - name: Attest SBOM
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e
-        with:
-          subject-path: "${{ matrix.archive }}"
-          sbom-path: "${{ matrix.sbom }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,12 +13,19 @@ before:
     - go mod tidy
 
 builds:
-  - env:
+  - binary: github-repo
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
       - windows
       - darwin
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.VersionPostfix=
+      - -X main.GitCommitHash={{.Commit}}
+      - -X main.BuiltAt={{.Date}}
 
 archives:
   - formats: ["tar.gz"]
@@ -35,18 +42,16 @@ archives:
       - goos: windows
         formats: ["zip"]
 
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-
 checksum:
   name_template: "checksums.txt"
 
+# release-drafter (via the ospo-reusable-workflows release.yaml) owns the
+# GitHub release and changelog. GoReleaser only builds and uploads artifacts.
 release:
-  prerelease: auto
+  disable: true
+
+changelog:
+  disable: true
 
 sboms:
   - # ID of the sbom config, must be unique.
@@ -56,16 +61,6 @@ sboms:
 
     # List of names of the SBOM documents created at this step
     # (relative to the dist dir).
-    #
-    # Each element configured is made available as variables. For example:
-    #   documents: ["foo", "bar"]
-    #
-    # would make the following variables that can be referenced as template keys:
-    #   document0: "foo"
-    #   document1: "bar"
-    #
-    # Note that multiple sbom values are only allowed if the value of
-    # "artifacts" is "any".
     #
     # Default:
     #   When "binary":   ["{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom.json"]
@@ -81,12 +76,6 @@ sboms:
     #
     # Default: 'syft'.
     cmd: syft
-
-    # Command line arguments for the command
-    #
-    # Default: ["$artifact", "--output", "spdx-json=$document", "--enrich", "all"].
-    # Templates: allowed.
-    # args: ["$artifact", "--output", "cyclonedx-json=$document"]
 
     # Which artifacts to catalog.
     #
@@ -105,3 +94,7 @@ sboms:
 
 universal_binaries:
   - replace: true
+    # Without name_template, replace: true would rename the universal binary
+    # to the ProjectName (pvtr-github-repo-scanner), breaking plugin discovery
+    # which expects the binary to be named "github-repo".
+    name_template: github-repo


### PR DESCRIPTION
## What

Disable GoReleaser's release/changelog so release-drafter (run by the ospo-reusable-workflows release.yaml) is the sole owner of the GitHub release, and pin the binary name plus version ldflags. Collapse the standalone goreleaser, attest-sboms, and release_image jobs into a single invocation of the unified reusable workflow.

## Why

v1.0.1 of ospo-reusable-workflows runs goreleaser, build provenance attestation, and image build/push internally when handed `goreleaser-config-path` and `image-name`. It also validates that `.release.disable` is `true` so it does not race the draft release that release-drafter creates. Mirroring privateerproj/privateer's setup removes ~70 lines of duplicated CI plumbing and keeps the release pipeline maintained upstream.

## Notes

- SBOM attestation now uses `attest-build-provenance` on `dist/*.spdx.json` rather than `actions/attest-sbom` pairing each SBOM with its archive; same behavior as privateerproj but different from what we had.
- `universal_binaries.replace: true` defaults the darwin universal name to `ProjectName` (`pvtr-github-repo-scanner`), so `name_template` is set explicitly to `github-repo` to keep plugin discovery working.
- Image build now runs in parallel with goreleaser (both gated on `create_release`) instead of serially after it.
- `image-registry` and `image-registry-username` moved from secrets to inputs in v1.0.1; defaults (`ghcr.io`, `github.actor`) are kept implicit.

## Testing

- `go vet ./...` and `go test ./...` pass.
- `golangci-lint run ./...` clean.
- `actionlint .github/workflows/release.yml` clean.
- `yq '.release.disable' .goreleaser.yaml` returns `true`, which is what the reusable workflow's validation step checks for.
- End-to-end release run is not exercised here; first tagged release after merge will be the real verification.