### PR TITLE
fix: consolidate release workflow onto reusable v1.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,66 +8,41 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
+      contents: write       # Create/publish release, push tags
+      pull-requests: read   # release-drafter reads PR labels
+      packages: write       # Push container image to ghcr.io
+      id-token: write       # Federate identity for attestations
+      attestations: write   # Create build provenance attestations
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc
     with:
       publish: true
       release-config-name: release-drafter.yml
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-  release_image:
-    needs: release
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-image.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc
-    with:
+      goreleaser-config-path: .goreleaser.yaml
+      go-version-file: go.mod
       image-name: ${{ github.repository }}
-      full-tag: ${{ needs.release.outputs.full-tag }}
-      short-tag: ${{ needs.release.outputs.short-tag }}
+      image-registry: ghcr.io
+      image-platforms: linux/amd64,linux/arm64
+      create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-      image-registry: ghcr.io
-      image-registry-username: ${{ github.actor }}
       image-registry-password: ${{ secrets.GITHUB_TOKEN }}
-  goreleaser:
+  prepare_sbom_attestations:
     needs: release
+    if: needs.release.outputs.full-tag != ''
     runs-on: ubuntu-latest
     permissions:
-      attestations: write
-      contents: write
-      id-token: write
+      contents: read
     outputs:
-      attestation_matrix: ${{ steps.generate_matrix.outputs.matrix }}
+      matrix: ${{ steps.generate_matrix.outputs.matrix }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
-        with:
-          syft-version: v1.33.0
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
+      - name: Download release assets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
-        with:
-          subject-checksums: dist/checksums.txt
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist
+          gh release download "${{ needs.release.outputs.full-tag }}" \
+            --repo "${{ github.repository }}" \
+            --dir dist
       - name: Generate attestation matrix
         id: generate_matrix
         run: |
@@ -79,13 +54,13 @@ jobs:
           name: dist
           path: dist
   attest-sboms:
-    needs: goreleaser
+    needs: prepare_sbom_attestations
     runs-on: ubuntu-latest
     permissions:
       attestations: write
       id-token: write
     strategy:
-      matrix: ${{ fromJson(needs.goreleaser.outputs.attestation_matrix) }}
+      matrix: ${{ fromJson(needs.prepare_sbom_attestations.outputs.matrix) }}
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,17 +36,13 @@ archives:
         formats: ["zip"]
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  disable: true
 
 checksum:
   name_template: "checksums.txt"
 
 release:
-  prerelease: auto
+  disable: true
 
 sboms:
   - # ID of the sbom config, must be unique.


### PR DESCRIPTION
## What

Expand the caller permissions on the `release` job and pass goreleaser and image inputs so the v1.0.1 reusable workflow handles draft creation, goreleaser artifact upload, image build, and publishing inline. Remove the now-redundant local `goreleaser` and `release_image` jobs. Re-source the SBOM attestation matrix from `gh release download` against the published release instead of from the deleted goreleaser job's output. `.goreleaser.yaml` now sets `release: disable: true` and `changelog: disable: true` so release-drafter owns both, as required by the reusable's draft-first contract.

## Why

After the v1.0.1 bump of `ospo-reusable-workflows/release.yaml` landed (9e78838), every release run has been failing with `startup_failure` — see runs [25861824131](https://github.com/ossf/pvtr-github-repo-scanner/actions/runs/25861824131), [25862395056](https://github.com/ossf/pvtr-github-repo-scanner/actions/runs/25862395056), and [25862423385](https://github.com/ossf/pvtr-github-repo-scanner/actions/runs/25862423385). v1.0.1 declares jobs (`release_goreleaser`, `release_image`, `release_discussion`) that require `id-token:write`, `attestations:write`, `packages:write`, and `discussions:write` — permissions the caller never granted. GitHub validates the permission graph at workflow startup and aborted before any job could run. Granting the perms unblocks the pipeline; folding the local goreleaser and image jobs into the reusable's built-in equivalents in the same change removes duplicated logic rather than papering over the broken state.

## Notes

- First release that will attest the container image — the prior local `release_image` call didn't pass `create-attestation: true`.
- Artifact provenance shape changes: prior local goreleaser emitted one attestation over `dist/checksums.txt`; v1.0.1's reusable emits one attestation per file in `dist/`. Same artifacts, more attestation entries.
- The `release-image.yaml` reusable goes from v0.6.0 → v1.0.1 implicitly — we stop calling it directly, but the consolidated `release.yaml` v1.0.1 uses it internally.
- `attest-sboms` now downloads from a *published* release; verify that `prepare_sbom_attestations` runs only after `publish_release` completes (it does, via `needs: release` and the reusable's job chain).
- "No release labels = no release" behavior preserved: when the merged PR has none of `breaking`/`feature`/`vuln`/`release`, the reusable's `create_release` skips, `release.outputs.full-tag` is empty, and `prepare_sbom_attestations` short-circuits via its `if:` guard.

## Testing

- `actionlint .github/workflows/release.yml` — only two pre-existing info-level shellcheck warnings on the matrix-generation `ls dist/*.spdx.json` block, preserved verbatim from the prior `goreleaser` job (no regression).
- `goreleaser check --config .goreleaser.yaml` — config valid; release pipe correctly skipped (`reason=release is disabled`).
- Caller permissions verified against the [upstream `docs/release.md`](https://github.com/github-community-projects/ospo-reusable-workflows/blob/e92cb6053ace495fe40a5f185988557afcdcecbc/docs/release.md) — we now grant the documented superset minus `discussions:write` (not enabling discussions).
- End-to-end validation requires a real release trigger (workflow_dispatch on `main` or a merged PR with a release-triggering label). Recommend dispatching manually after merge to confirm: draft release is created, tags are pushed, goreleaser artifacts + SBOMs upload, container image builds and pushes, attestations are generated for both artifacts and image, draft publishes, and the local `attest-sboms` matrix successfully links each archive to its `.spdx.json`.