### PR TITLE
fix: grant discussions:write and add Breaking Changes drafter category

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       id-token: write       # release_goreleaser, release_image: attestation OIDC
       attestations: write   # release_goreleaser, release_image: build provenance
       packages: write       # release_image: push container image
+      discussions: write    # release_discussion: declared by reusable even when skipped
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true


### PR DESCRIPTION
## What

Add `discussions: write` to the `release` calling job's permissions block, and add a top-level `💥 Breaking Changes` category (`breaking` label) to `.github/release-drafter.yml`.

## Why

The v1.0.1 reusable release workflow declares `discussions: write` on its `release_discussion` job. GitHub validates the permission graph at caller startup, so omitting the grant fails the run with `startup_failure` even though we don't pass `create-discussion: true` and the discussion job would otherwise be skipped. Every release run since the v1.0.1 bump has failed with `startup_failure` — most recently [run 26095684642](https://github.com/ossf/pvtr-github-repo-scanner/actions/runs/26095684642) on the codeql bump merge today. Granting the permission unblocks the pipeline.

The release-drafter category gives `breaking`-labeled PRs their own callout in generated release notes. The `breaking` label already drives a major version bump via the existing `version-resolver`, but it wasn't surfaced in the rendered changelog.

## Notes

- We grant `discussions: write` even though `create-discussion` defaults to false. The skipped job's permission declaration still gates workflow startup — same root cause as the missing `id-token`/`attestations`/`packages` perms that #317 addressed.
- The Breaking Changes category is placed first so it surfaces above Features/Fixes in the rendered notes.

## Testing

- `actionlint .github/workflows/release.yml` clean.
- YAML parses cleanly for both files.
- End-to-end validation requires the next PR merge or a manual `workflow_dispatch` on `main`. With this change, the reusable workflow should pass startup validation; whether it then runs the release job depends on the merged PR's labels per the existing `if:` guard (`breaking`/`feature`/`vuln`/`release`).