### PR TITLE
feat: add AI-assisted OSPS-QA-06.02 evaluation

### DIFF
--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -1,12 +1,45 @@
 package quality
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
+	sdkai "github.com/privateerproj/privateer-sdk/ai"
 )
+
+const documentsTestExecutionFallbackMessage = "Review project documentation to ensure it explains when and how tests are run"
+
+var documentsTestExecutionSchema = &sdkai.Schema{
+	Name:        "documents_test_execution_assessment",
+	Description: "Structured assessment of whether repository documentation explains when and how tests are run.",
+	Strict:      true,
+	Value: json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"verdict": {"type": "string", "enum": ["pass", "fail"]},
+			"confidence": {"type": "number"},
+			"reasoning": {"type": "string"},
+			"evidence_location": {"type": "string"}
+		},
+		"required": ["verdict", "confidence", "reasoning", "evidence_location"],
+		"additionalProperties": false
+	}`),
+}
+
+var newAIClientFromConfig = sdkai.NewClientFromConfig
+var loadDocumentsTestExecutionEvidence = documentsTestExecutionEvidence
+
+type documentsTestExecutionAssessment struct {
+	Verdict          string  `json:"verdict"`
+	Confidence       float64 `json:"confidence"`
+	Reasoning        string  `json:"reasoning"`
+	EvidenceLocation string  `json:"evidence_location"`
+}
 
 func RepoIsPublic(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if payload.RepositoryMetadata.IsPublic() {
@@ -197,9 +230,201 @@ func countDependencyManifests(payload data.Payload) (result gemara.Result, messa
 }
 
 func DocumentsTestExecution(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	return gemara.NeedsReview, "Review project documentation to ensure it explains when and how tests are run", confidence
+	logger := documentsTestExecutionLogger(payload)
+
+	client, err := documentsTestExecutionClient(payload)
+	if err != nil {
+		logger.Warn("OSPS-QA-06.02: AI client construction failed", "err", err)
+		return gemara.NeedsReview, documentsTestExecutionFallbackMessage, confidence
+	}
+	if client == nil {
+		logger.Warn("OSPS-QA-06.02: AI is not configured (ai_provider/ai_api_key missing); falling back")
+		return gemara.NeedsReview, documentsTestExecutionFallbackMessage, confidence
+	}
+
+	evidence, err := loadDocumentsTestExecutionEvidence(payload)
+	if err != nil {
+		logger.Warn("OSPS-QA-06.02: failed to load README/CONTRIBUTING evidence", "err", err)
+		return gemara.NeedsReview, documentsTestExecutionFallbackMessage, confidence
+	}
+	if strings.TrimSpace(evidence) == "" {
+		logger.Warn("OSPS-QA-06.02: no README or CONTRIBUTING content available in payload")
+		return gemara.NeedsReview, documentsTestExecutionFallbackMessage, confidence
+	}
+
+	response, err := client.Analyze(context.Background(), documentsTestExecutionPrompt(), evidence, documentsTestExecutionSchema)
+	if err != nil {
+		logger.Warn("OSPS-QA-06.02: AI provider call failed", "err", err)
+		return gemara.NeedsReview, documentsTestExecutionFallbackMessage, confidence
+	}
+
+	assessment, err := parseDocumentsTestExecutionAssessment(response)
+	if err != nil {
+		logger.Warn("OSPS-QA-06.02: AI response failed schema validation", "err", err)
+		return gemara.NeedsReview, documentsTestExecutionFallbackMessage, confidence
+	}
+
+	result, ok := documentsTestExecutionResult(assessment.Verdict)
+	if !ok {
+		logger.Warn("OSPS-QA-06.02: AI returned unknown verdict", "verdict", assessment.Verdict)
+		return gemara.NeedsReview, documentsTestExecutionFallbackMessage, confidence
+	}
+
+	logger.Info("OSPS-QA-06.02: AI verdict received",
+		"verdict", assessment.Verdict,
+		"confidence", assessment.Confidence,
+		"evidence_location", assessment.EvidenceLocation,
+	)
+
+	message = fmt.Sprintf(
+		"[AI-Assisted] verdict=%s confidence=%.2f\nreasoning: %s\nevidence_location: %s",
+		assessment.Verdict, assessment.Confidence,
+		assessment.Reasoning, assessment.EvidenceLocation,
+	)
+	return result, message, mapAIConfidence(assessment.Confidence)
+}
+
+// documentsTestExecutionLogger returns the payload's logger, or a no-op
+// logger when one is not wired through. The logger is only used for
+// diagnostic breadcrumbs along the early-exit paths.
+func documentsTestExecutionLogger(payload data.Payload) hclog.Logger {
+	if payload.Config != nil && payload.Config.Logger != nil {
+		return payload.Config.Logger
+	}
+	return hclog.NewNullLogger()
+}
+
+// mapAIConfidence converts the model's 0..1 confidence score into a gemara
+// ConfidenceLevel bucket. A zero score is treated as Undetermined so callers
+// that omit confidence don't get misreported as Low.
+func mapAIConfidence(score float64) gemara.ConfidenceLevel {
+	switch {
+	case score <= 0:
+		return gemara.Undetermined
+	case score < 0.5:
+		return gemara.Low
+	case score < 0.8:
+		return gemara.Medium
+	default:
+		return gemara.High
+	}
 }
 
 func DocumentsTestMaintenancePolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	return gemara.NeedsReview, "Review project documentation to ensure it contains a clear policy for maintaining tests", confidence
+}
+
+func documentsTestExecutionClient(payload data.Payload) (sdkai.Client, error) {
+	if payload.Config == nil {
+		return nil, nil
+	}
+	return newAIClientFromConfig(*payload.Config)
+}
+
+func documentsTestExecutionEvidence(payload data.Payload) (string, error) {
+	parts := []string{}
+
+	if readme := strings.TrimSpace(documentsTestExecutionReadmeContent(payload)); readme != "" {
+		parts = append(parts, "README\n"+readme)
+	}
+
+	if payload.GraphqlRepoData != nil {
+		if contributing := strings.TrimSpace(payload.Repository.ContributingGuidelines.Body); contributing != "" {
+			parts = append(parts, "CONTRIBUTING\n"+contributing)
+		}
+	}
+
+	if len(parts) == 0 {
+		return "", fmt.Errorf("no README or CONTRIBUTING content available")
+	}
+
+	return strings.Join(parts, "\n\n"), nil
+}
+
+func documentsTestExecutionReadmeContent(payload data.Payload) string {
+	if payload.GraphqlRepoData == nil || payload.RestData == nil {
+		return ""
+	}
+
+	readmePath := ""
+	for _, entry := range payload.Repository.Object.Tree.Entries {
+		if entry.Type != "blob" {
+			continue
+		}
+		if documentsTestExecutionReadmeName(entry.Name) {
+			readmePath = entry.Path
+			break
+		}
+	}
+	if readmePath == "" {
+		return ""
+	}
+
+	content, err := payload.RestData.GetFileContent(readmePath)
+	if err != nil || content == nil {
+		return ""
+	}
+
+	readme, err := content.GetContent()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(readme)
+}
+
+func documentsTestExecutionReadmeName(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	return lower == "readme" || strings.HasPrefix(lower, "readme.")
+}
+
+func documentsTestExecutionPrompt() string {
+	return strings.TrimSpace(`You are assessing OSPS-QA-06.02: the project's documentation MUST clearly document WHEN and HOW tests are run. This is a contributor-facing requirement.
+
+Use only the supplied README and CONTRIBUTING content as evidence.
+
+Return verdict "pass" only when BOTH of the following are clearly explained:
+  - WHEN tests run (e.g. on every pull request, before merge, on a schedule, locally before commit).
+  - HOW tests are run (concrete commands to run tests locally AND/OR a description of how they run in CI/CD).
+
+A pass is stronger when the documentation also explains what the tests cover and how to interpret results, but those are not strictly required.
+
+Return verdict "fail" when any of the following hold:
+  - The documentation is missing or only implies that tests exist.
+  - It covers WHEN but not HOW, or HOW but not WHEN.
+  - Instructions are vague (e.g. "run the tests" with no command or workflow reference).
+  - The only test discussion is aimed at end users, not contributors.
+
+Cite the most relevant section header or quoted snippet in evidence_location.`)
+}
+
+func parseDocumentsTestExecutionAssessment(response *sdkai.AnalyzeResponse) (*documentsTestExecutionAssessment, error) {
+	if response == nil || len(response.JSON) == 0 {
+		return nil, fmt.Errorf("ai response did not include structured output")
+	}
+
+	var assessment documentsTestExecutionAssessment
+	if err := json.Unmarshal(response.JSON, &assessment); err != nil {
+		return nil, err
+	}
+
+	assessment.Verdict = strings.ToLower(strings.TrimSpace(assessment.Verdict))
+	assessment.Reasoning = strings.TrimSpace(assessment.Reasoning)
+	assessment.EvidenceLocation = strings.TrimSpace(assessment.EvidenceLocation)
+	if assessment.Reasoning == "" || assessment.EvidenceLocation == "" {
+		return nil, fmt.Errorf("ai response missing reasoning or evidence location")
+	}
+
+	return &assessment, nil
+}
+
+func documentsTestExecutionResult(verdict string) (gemara.Result, bool) {
+	switch strings.ToLower(strings.TrimSpace(verdict)) {
+	case "pass":
+		return gemara.Passed, true
+	case "fail":
+		return gemara.Failed, true
+	default:
+		return gemara.NeedsReview, false
+	}
 }

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -1,11 +1,15 @@
 package quality
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/ossf/si-tooling/v2/si"
+	sdkai "github.com/privateerproj/privateer-sdk/ai"
+	sdkconfig "github.com/privateerproj/privateer-sdk/config"
 )
 
 func Test_InsightsListsRepositories(t *testing.T) {
@@ -84,4 +88,133 @@ func Test_NoUnreviewableBinariesInRepo(t *testing.T) {
 			t.Error("expected non-empty message for invalid payload")
 		}
 	})
+}
+
+type stubAIClient struct {
+	response *sdkai.AnalyzeResponse
+	err      error
+}
+
+func (s stubAIClient) Analyze(ctx context.Context, prompt, content string, schema *sdkai.Schema) (*sdkai.AnalyzeResponse, error) {
+	return s.response, s.err
+}
+
+func TestDocumentsTestExecution(t *testing.T) {
+	originalFactory := newAIClientFromConfig
+	originalEvidenceLoader := loadDocumentsTestExecutionEvidence
+	t.Cleanup(func() {
+		newAIClientFromConfig = originalFactory
+		loadDocumentsTestExecutionEvidence = originalEvidenceLoader
+	})
+
+	payload := data.Payload{Config: &sdkconfig.Config{}}
+	loadDocumentsTestExecutionEvidence = func(payload data.Payload) (string, error) {
+		return "README\nRun `go test ./...` before opening a PR.", nil
+	}
+
+	t.Run("no AI config preserves legacy behavior", func(t *testing.T) {
+		newAIClientFromConfig = func(cfg sdkconfig.Config) (sdkai.Client, error) {
+			return nil, nil
+		}
+
+		result, msg, _ := DocumentsTestExecution(payload)
+		if result != gemara.NeedsReview {
+			t.Fatalf("result = %v, want NeedsReview", result)
+		}
+		if msg != documentsTestExecutionFallbackMessage {
+			t.Fatalf("message = %q, want %q", msg, documentsTestExecutionFallbackMessage)
+		}
+	})
+
+	t.Run("partial live AI config falls back to needs review", func(t *testing.T) {
+		newAIClientFromConfig = sdkai.NewClientFromConfig
+
+		partialPayload := data.Payload{Config: &sdkconfig.Config{Vars: map[string]interface{}{
+			"ai_provider": "openai",
+			"ai_model":    "gpt-4o-mini",
+		}}}
+
+		result, msg, _ := DocumentsTestExecution(partialPayload)
+		if result != gemara.NeedsReview {
+			t.Fatalf("result = %v, want NeedsReview", result)
+		}
+		if msg != documentsTestExecutionFallbackMessage {
+			t.Fatalf("message = %q, want %q", msg, documentsTestExecutionFallbackMessage)
+		}
+	})
+
+	t.Run("ai returns pass verdict", func(t *testing.T) {
+		newAIClientFromConfig = func(cfg sdkconfig.Config) (sdkai.Client, error) {
+			return stubAIClient{response: &sdkai.AnalyzeResponse{JSON: []byte(`{"verdict":"pass","confidence":0.91,"reasoning":"README explains that contributors run go test before opening a PR.","evidence_location":"README#testing"}`)}}, nil
+		}
+
+		result, msg, _ := DocumentsTestExecution(payload)
+		if result != gemara.Passed {
+			t.Fatalf("result = %v, want Passed", result)
+		}
+		if msg == "" || msg[:13] != "[AI-Assisted]" {
+			t.Fatalf("expected AI-assisted message, got %q", msg)
+		}
+	})
+
+	t.Run("ai returns fail verdict", func(t *testing.T) {
+		newAIClientFromConfig = func(cfg sdkconfig.Config) (sdkai.Client, error) {
+			return stubAIClient{response: &sdkai.AnalyzeResponse{JSON: []byte(`{"verdict":"fail","confidence":0.84,"reasoning":"The docs mention tests exist but never explain when or how to run them.","evidence_location":"README#development"}`)}}, nil
+		}
+
+		result, _, _ := DocumentsTestExecution(payload)
+		if result != gemara.Failed {
+			t.Fatalf("result = %v, want Failed", result)
+		}
+	})
+
+	t.Run("invalid AI response falls back to needs review", func(t *testing.T) {
+		newAIClientFromConfig = func(cfg sdkconfig.Config) (sdkai.Client, error) {
+			return stubAIClient{response: &sdkai.AnalyzeResponse{JSON: []byte(`{"verdict":"pass","confidence":0.84,"reasoning":"","evidence_location":"README#development"}`)}}, nil
+		}
+
+		result, msg, _ := DocumentsTestExecution(payload)
+		if result != gemara.NeedsReview || msg != documentsTestExecutionFallbackMessage {
+			t.Fatalf("got (%v, %q), want legacy fallback", result, msg)
+		}
+	})
+
+	t.Run("ai timeout falls back to needs review", func(t *testing.T) {
+		newAIClientFromConfig = func(cfg sdkconfig.Config) (sdkai.Client, error) {
+			return stubAIClient{err: context.DeadlineExceeded}, nil
+		}
+
+		result, msg, _ := DocumentsTestExecution(payload)
+		if result != gemara.NeedsReview || msg != documentsTestExecutionFallbackMessage {
+			t.Fatalf("got (%v, %q), want legacy fallback", result, msg)
+		}
+	})
+
+	t.Run("ai provider error falls back to needs review", func(t *testing.T) {
+		newAIClientFromConfig = func(cfg sdkconfig.Config) (sdkai.Client, error) {
+			return stubAIClient{err: errors.New("provider unavailable")}, nil
+		}
+
+		result, msg, _ := DocumentsTestExecution(payload)
+		if result != gemara.NeedsReview || msg != documentsTestExecutionFallbackMessage {
+			t.Fatalf("got (%v, %q), want legacy fallback", result, msg)
+		}
+	})
+}
+
+func TestDocumentsTestExecutionEvidence(t *testing.T) {
+	if !documentsTestExecutionReadmeName("README.md") || !documentsTestExecutionReadmeName("README.rst") || documentsTestExecutionReadmeName("NOTES.md") {
+		t.Fatal("unexpected readme name matching behavior")
+	}
+
+	payload := data.Payload{GraphqlRepoData: &data.GraphqlRepoData{}}
+	payload.Repository.ContributingGuidelines.Body = "Use the documented test workflow before requesting review."
+
+	evidence, err := documentsTestExecutionEvidence(payload)
+	if err != nil {
+		t.Fatalf("unexpected evidence error: %v", err)
+	}
+	if evidence != "CONTRIBUTING\nUse the documented test workflow before requesting review." {
+		t.Fatalf("unexpected evidence payload: %q", evidence)
+	}
 }


### PR DESCRIPTION
## Summary

This change adds AI-assisted evaluation for OSPS-QA-06.02.

When AI is configured, the scanner evaluates whether the repository's supporting documentation explains how tests are executed. For this control, the evaluator uses README and CONTRIBUTING content as evidence. When AI is not configured, or the AI response is invalid or unavailable, the existing fallback behavior is preserved.

Fixes #318.

## Dependency

This PR depends on the AI module landing in the SDK first. The scanner-side implementation here relies on the provider-neutral AI client foundation introduced in:

- privateerproj/privateer-sdk#218

Until the SDK AI module is available in a published SDK version consumed by this repo, the expected build/lint failures on this PR are due to that missing dependency rather than a scanner-only defect.

## Reviewer validation

To validate the end-to-end AI path locally, run the GitHub repo scanner through `pvtr` with a valid OpenAI API key and a Maturity Level 3 config.

Example config:

```yaml
name: ai-validation

policies:
  - policy: osps
    version: dev
    level: 3

repositories:
  - name: docker-cli
    url: https://github.com/docker/cli

ai_provider: openai
ai_model: <an OpenAI chat model available in your account>
ai_api_key: <your-openai-api-key>
```

Example run flow:

```bash
go build -o pvtr-github-repo ./pvtr-github-repo-scanner
pvtr install --local ./pvtr-github-repo
pvtr run --config /path/to/config.yml
```

Expected behavior:
- OSPS-QA-06.02 should produce an AI-assisted verdict when valid AI config is present.
- This verdict is based on whether README and CONTRIBUTING provide enough test-execution guidance to satisfy the requirement.
- If AI is not configured, or the AI response cannot be used, the scan should continue via the existing fallback path rather than failing the run.

## Reference repos from local validation

The following public repos were used during local validation of this specific control:

- `radius-project/radius`: OSPS-QA-06.02 failed in local validation because the supporting documentation reviewed for this check did not provide sufficient test-execution instructions.
- `docker/cli`: OSPS-QA-06.02 passed in local validation because the supporting documentation reviewed for this check did provide sufficient test-execution instructions.

Use `radius-project/radius` as a likely negative example and `docker/cli` as a likely positive example when validating the AI-assisted verdict path.
