### PR TITLE
ci: sync go.mod with Dockerfile Go version on PRs

### DIFF
--- a/.github/workflows/sync-go-version.yaml
+++ b/.github/workflows/sync-go-version.yaml
@@ -1,0 +1,68 @@
+---
+name: Sync go.mod with Dockerfile
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  sync:
+    name: Sync go.mod
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Push the go.mod sync commit back to dependabot branches when they diverge
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      # Check out the PR head branch (not the merge ref) so any sync commit lands on it.
+      # persist-credentials is required so the subsequent git push uses GITHUB_TOKEN.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: true
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Verify or sync go directive against Dockerfile
+        env:
+          IS_DEPENDABOT: ${{ github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/docker/golang') }}
+        run: |
+          set -euo pipefail
+
+          DOCKERFILE_GO=$(grep -oE 'golang:[0-9]+\.[0-9]+\.[0-9]+' Dockerfile | head -1 | cut -d: -f2)
+          if [ -z "$DOCKERFILE_GO" ]; then
+            echo "::error::Could not extract Go version from Dockerfile"
+            exit 1
+          fi
+
+          GOMOD_GO=$(go mod edit -json | jq -r '.Go')
+
+          if [ "$DOCKERFILE_GO" = "$GOMOD_GO" ]; then
+            echo "go.mod and Dockerfile both at Go $GOMOD_GO"
+            exit 0
+          fi
+
+          if [ "$IS_DEPENDABOT" != "true" ]; then
+            echo "::error file=go.mod::Dockerfile is on Go $DOCKERFILE_GO but go.mod is on $GOMOD_GO. Run: go mod edit -go=$DOCKERFILE_GO"
+            exit 1
+          fi
+
+          echo "Bumping go.mod from $GOMOD_GO to $DOCKERFILE_GO"
+          go mod edit -go="$DOCKERFILE_GO"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add go.mod
+          git commit -m "chore(deps): sync go.mod to Go $DOCKERFILE_GO"
+          git push


### PR DESCRIPTION
## What

Adds `.github/workflows/sync-go-version.yaml`, ported from privateerproj/privateer. On any PR that touches the Dockerfile, it compares the `golang:x.y.z` base image tag against the `go` directive in `go.mod`. For dependabot Docker bumps it auto-commits the matching `go.mod` update onto the PR branch; for everyone else it fails the check.

## Why

PR #330 (golang 1.26.3 → 1.26.4 Docker bump) is the immediate driver, but the broader problem is that dependabot does not keep the Dockerfile Go base image and the `go.mod` go directive in sync. Without this, every Go patch bump produces a PR that quietly drifts the two out of alignment until someone notices.

## Notes

- `persist-credentials: true` on checkout is intentional (the job pushes a sync commit back to the PR branch) and `contents: write` is scoped to this job only, not the workflow.
- The sync push uses `GITHUB_TOKEN`. Pushes from `GITHUB_TOKEN` do not retrigger workflows on the same PR, so the sync commit will not loop.
- The actor check is `github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/docker/golang')`. Manual Dockerfile edits will fail the check rather than be auto-rewritten, which is the safer default.
- The Dockerfile has two `golang:1.26.3-alpine3.22` stages. `grep ... | head -1` only reads the first, but dependabot bumps both stages together so they stay in lockstep. If a future change introduces stage version drift on purpose, this assumption breaks.
- This will not fix PR #330 retroactively. After merge, the PR will need `@dependabot recreate` (or rebase) so the workflow runs against the new base.