### PR TITLE
fix(OSPS-BR-07.01): consult Security Insights when security_and_analysis is null

### DIFF
--- a/data/security-posture.go
+++ b/data/security-posture.go
@@ -20,17 +20,20 @@ type RepoSecurityPosture struct {
 }
 
 func buildSecurityPosture(repository *github.Repository, rd RestData) (SecurityPosture, error) {
+	insightsClaimsSecretsTooling := insightsClaimsSecretsTooling(rd.Insights)
 	securityConfig := repository.GetSecurityAndAnalysis()
 	if securityConfig == nil {
 		return &RepoSecurityPosture{
-			restData: rd,
+			restData:              rd,
+			preventsSecretPushing: insightsClaimsSecretsTooling,
+			scansForSecrets:       insightsClaimsSecretsTooling,
 		}, nil
 	}
 	secretsScanningStatus := securityConfig.GetSecretScanning().GetStatus()
-	insightsClaimsSecretsTooling := insightsClaimsSecretsTooling(rd.Insights)
+	pushProtectionStatus := securityConfig.GetSecretScanningPushProtection().GetStatus()
 	return &RepoSecurityPosture{
 		restData:              rd,
-		preventsSecretPushing: secretsScanningStatus == "enabled" || insightsClaimsSecretsTooling,
+		preventsSecretPushing: pushProtectionStatus == "enabled" || insightsClaimsSecretsTooling,
 		scansForSecrets:       secretsScanningStatus == "enabled" || insightsClaimsSecretsTooling,
 		// TODO: consider if SecurityInsights should have a policy doc field in ProjectDocumentation to handle this
 		// definesPolicyForHandlingSecrets: rd.SecurityInsights != nil && ....
@@ -38,7 +41,7 @@ func buildSecurityPosture(repository *github.Repository, rd RestData) (SecurityP
 }
 
 func insightsClaimsSecretsTooling(insights si.SecurityInsights) bool {
-	if insights.Repository.SecurityPosture.Tools == nil {
+	if insights.Repository == nil || insights.Repository.SecurityPosture.Tools == nil {
 		return false
 	}
 	for _, tool := range insights.Repository.SecurityPosture.Tools {

--- a/data/security-posture_test.go
+++ b/data/security-posture_test.go
@@ -37,6 +37,9 @@ func TestBuildSecurityPosture_SecretScanningEnabled(t *testing.T) {
 			SecretScanning: &github.SecretScanning{
 				Status: github.Ptr("enabled"),
 			},
+			SecretScanningPushProtection: &github.SecretScanningPushProtection{
+				Status: github.Ptr("enabled"),
+			},
 		},
 	}
 	rd := RestData{
@@ -48,6 +51,47 @@ func TestBuildSecurityPosture_SecretScanningEnabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, sp.PreventsPushingSecrets())
 	assert.True(t, sp.ScansForSecrets())
+}
+
+func TestBuildSecurityPosture_NilSecurityConfig_WithInsightsSecretScanning(t *testing.T) {
+	repo := &github.Repository{}
+	rd := RestData{
+		Insights: si.SecurityInsights{
+			Repository: &si.Repository{
+				SecurityPosture: si.SecurityPosture{
+					Tools: []si.SecurityTool{
+						{Type: "secret-scanning"},
+					},
+				},
+			},
+		},
+	}
+	sp, err := buildSecurityPosture(repo, rd)
+	assert.NoError(t, err)
+	assert.True(t, sp.PreventsPushingSecrets())
+	assert.True(t, sp.ScansForSecrets())
+}
+
+func TestBuildSecurityPosture_ScanningEnabledPushProtectionDisabled(t *testing.T) {
+	repo := &github.Repository{
+		SecurityAndAnalysis: &github.SecurityAndAnalysis{
+			SecretScanning: &github.SecretScanning{
+				Status: github.Ptr("enabled"),
+			},
+			SecretScanningPushProtection: &github.SecretScanningPushProtection{
+				Status: github.Ptr("disabled"),
+			},
+		},
+	}
+	rd := RestData{
+		Insights: si.SecurityInsights{
+			Repository: &si.Repository{},
+		},
+	}
+	sp, err := buildSecurityPosture(repo, rd)
+	assert.NoError(t, err)
+	assert.True(t, sp.ScansForSecrets())
+	assert.False(t, sp.PreventsPushingSecrets())
 }
 
 func TestBuildSecurityPosture_SecretScanningDisabledButInsightsTooling(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #354

Two bugs caused `OSPS-BR-07.01` to false-fail for unprivileged scans (e.g. LFX Insights) on repos that enable Secret Scanning via Terraform and declare `type: secret-scanning` in `.github/security-insights.yml`:

- **Early return skipped Security Insights fallback.** `buildSecurityPosture` returned an empty struct when `security_and_analysis` was `null` (GitHub only returns this field to admins/org owners/security managers), so the `insightsClaimsSecretsTooling` check was never reached for unprivileged tokens.
- **Push protection inferred from wrong field.** Both `preventsSecretPushing` and `scansForSecrets` derived from `secret_scanning.status`; `secret_scanning_push_protection.status` was never read.

## Changes

- `data/security-posture.go` — evaluate `insightsClaimsSecretsTooling` before the `nil` guard and populate both fields in the nil branch; read `SecretScanningPushProtection.GetStatus()` for `preventsSecretPushing`; guard against `nil` `insights.Repository` in `insightsClaimsSecretsTooling`.
- `data/security-posture_test.go` — update existing enabled-status test; add regression tests for both bugs.

## Test plan

- [ ] `go test ./data/... -v -run TestBuildSecurityPosture` — all cases pass
- [ ] `go test ./...` — full suite green
- [ ] End-to-end: run against `open-telemetry/opentelemetry-dotnet` with an unprivileged token → `OSPS-BR-07.01` now `Passed`
- [ ] Regression: privileged token on repo with scanning on / push protection off → `OSPS-BR-07.01` now `Failed` (partially enabled) instead of wrongly `Passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)