### PR TITLE
fix(deps): bump gomarkdown/markdown to patch CVE-2026-40890

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ TODO.md
 
 # ignore ci testing folder
 tmp/
+
+# ignore local git worktrees
+.worktrees/

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b
+	github.com/gomarkdown/markdown v0.0.0-20260411013819-759bbc3e3207
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8J
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b h1:EY/KpStFl60qA17CptGXhwfZ+k1sFNJIUNR8DdbcuUk=
-github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20260411013819-759bbc3e3207 h1:p7t34F7K4OCRQblcDhNJnP46Uaarz3z2cLcvOZYxWn8=
+github.com/gomarkdown/markdown v0.0.0-20260411013819-759bbc3e3207/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=


### PR DESCRIPTION
## What/Why
Bump `github.com/gomarkdown/markdown` to `v0.0.0-20260411013819-759bbc3e3207` to resolve Dependabot alert #10 (GHSA-77fj-vx54-gvh7 / CVE-2026-40890), a high-severity out-of-bounds read / panic in `SmartypantsRenderer` triggerable by malformed input (`<` with no following `>`).

## Proof it works
`go build ./...` succeeds and `go test ./...` passes (all packages green). `go mod tidy` run to keep `go.mod`/`go.sum` consistent.

## Risk + AI role
Low — a transitive-facing dependency version bump with no source changes. Only patched-version metadata (`go.mod`/`go.sum`) plus a `.gitignore` entry for local worktrees. AI-generated: the version bump, gitignore entry, and this description.

## Review focus
Confirm the pinned version `v0.0.0-20260411013819-759bbc3e3207` is the intended patched revision and that no other module in the tree pins an older `gomarkdown/markdown`.