### PR TITLE
feat: bump SDK to implement benchmarking

### DIFF
--- a/data/payload.go
+++ b/data/payload.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-github/v74/github"
 	"github.com/privateerproj/privateer-sdk/config"
+	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
@@ -14,6 +15,8 @@ import (
 type Payload struct {
 	*GraphqlRepoData
 	*RestData
+	*pluginkit.APICallCounter // Enable Privateer benchmarking for API calls
+
 	Config                   *config.Config
 	RepositoryMetadata       RepositoryMetadata
 	DependencyManifestsCount int
@@ -25,14 +28,18 @@ type Payload struct {
 }
 
 func Loader(config *config.Config) (payload any, err error) {
-	graphql, client, httpClient, err := getGraphqlRepoData(config)
+	// Count every request the GitHub clients make through this transport
+	callCounter := &pluginkit.APICallCounter{}
+	httpClient := callCounter.WrapClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: config.GetString("token")},
+	)))
+
+	graphql, client, err := getGraphqlRepoData(config, httpClient)
 	if err != nil {
 		return nil, err
 	}
 
-	ghClient := github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: config.GetString("token")},
-	)))
+	ghClient := github.NewClient(httpClient)
 
 	repo, repositoryMetadata, err := loadRepositoryMetadata(ghClient, config.GetString("owner"), config.GetString("repo"))
 	if err != nil {
@@ -44,7 +51,7 @@ func Loader(config *config.Config) (payload any, err error) {
 		return nil, err
 	}
 
-	rest, err := getRestData(ghClient, config)
+	rest, err := getRestData(ghClient, httpClient, config)
 	if err != nil {
 		return nil, err
 	}
@@ -68,15 +75,12 @@ func Loader(config *config.Config) (payload any, err error) {
 		IsCodeRepo:               isCodeRepo,
 		client:                   client,
 		httpClient:               httpClient,
+		APICallCounter:           callCounter,
 		SecurityPosture:          securityPosture,
 	}), nil
 }
 
-func getGraphqlRepoData(config *config.Config) (data *GraphqlRepoData, client *githubv4.Client, httpClient *http.Client, err error) {
-	src := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: config.GetString("token")},
-	)
-	httpClient = oauth2.NewClient(context.Background(), src)
+func getGraphqlRepoData(config *config.Config, httpClient *http.Client) (data *GraphqlRepoData, client *githubv4.Client, err error) {
 	client = githubv4.NewClient(httpClient)
 
 	variables := map[string]any{
@@ -91,13 +95,17 @@ func getGraphqlRepoData(config *config.Config) (data *GraphqlRepoData, client *g
 	if err != nil {
 		config.Logger.Error(fmt.Sprintf("Error querying GitHub GraphQL API: %s", err.Error()))
 	}
-	return data, client, httpClient, err
+	return data, client, err
 }
 
-func getRestData(ghClient *github.Client, config *config.Config) (data *RestData, err error) {
+// getRestData builds the REST accessor on the shared httpClient so its raw
+// endpoint fetches are counted too; left nil, RestData falls back to its own
+// uncounted client and the API-call tally silently undercounts.
+func getRestData(ghClient *github.Client, httpClient *http.Client, config *config.Config) (data *RestData, err error) {
 	r := &RestData{
-		ghClient: ghClient,
-		Config:   config,
+		ghClient:   ghClient,
+		HttpClient: httpClient,
+		Config:     config,
 	}
 	err = r.Setup()
 	return r, err

--- a/evaluation_plans/typed_step.go
+++ b/evaluation_plans/typed_step.go
@@ -1,28 +1,21 @@
 package evaluation_plans
 
 import (
-	"fmt"
-
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
 // TypedStep is the signature every step in this plugin uses: it receives a
-// fully-typed data.Payload instead of an untyped any. AsAssessmentStep adapts
-// it to gemara.AssessmentStep so the SDK can invoke it; the type assertion
-// replaces the per-step VerifyPayload guard that used to live in every step.
+// fully-typed data.Payload instead of an untyped any. The SDK adapts it to
+// gemara.AssessmentStep at registration time (see
+// pluginkit.AddEvaluationSuiteTypedForAllCatalogs in main.go), performing the
+// payload type assertion that used to live in a per-step VerifyPayload guard.
+//
+// Registration must go through the SDK's typed helper rather than a local
+// adapter: adapting here would capture every step into one closure literal,
+// collapsing all steps to a single symbol and erasing their names from the
+// benchmark report and evaluation log.
 type TypedStep func(data.Payload) (gemara.Result, string, gemara.ConfidenceLevel)
-
-func (s TypedStep) AsAssessmentStep() gemara.AssessmentStep {
-	return func(p any) (gemara.Result, string, gemara.ConfidenceLevel) {
-		payload, ok := p.(data.Payload)
-		if !ok {
-			return gemara.Unknown,
-				fmt.Sprintf("expected %T, got %T", data.Payload{}, p), 0
-		}
-		return s(payload)
-	}
-}
 
 // AllSteps merges all step maps into a single map for registration with the SDK.
 // Assessment IDs are unique across catalogs (e.g., OSPS-* vs CRA-*), so the
@@ -34,16 +27,15 @@ func (s TypedStep) AsAssessmentStep() gemara.AssessmentStep {
 // guarantees that substantive changes to a control result in a new identifier.
 // This means implementations for a given assessment ID will not diverge between
 // versions, so all versions can share the same step function for the same key.
-func AllSteps() map[string][]gemara.AssessmentStep {
-	merged := make(map[string][]gemara.AssessmentStep, len(OSPS))
+//
+// Every family merged here must consume data.Payload; a family taking a
+// different payload type needs its own registration call.
+func AllSteps() map[string][]TypedStep {
+	merged := make(map[string][]TypedStep, len(OSPS))
 	for id, steps := range OSPS {
-		for _, s := range steps {
-			merged[id] = append(merged[id], s.AsAssessmentStep())
-		}
+		merged[id] = append(merged[id], steps...)
 	}
 	// Add additional catalog step maps here, e.g.:
-	// for id, steps := range CRA {
-	//     for _, s := range steps { merged[id] = append(merged[id], s.AsAssessmentStep()) }
-	// }
+	// for id, steps := range CRA { merged[id] = append(merged[id], steps...) }
 	return merged
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-github/v74 v74.0.0
 	github.com/migueleliasweb/go-github-mock v1.5.0
 	github.com/ossf/si-tooling/v2 v2.2.0
-	github.com/privateerproj/privateer-sdk v1.31.3
+	github.com/privateerproj/privateer-sdk v1.32.0
 	github.com/rhysd/actionlint v1.7.12
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
 	golang.org/x/oauth2 v0.36.0
@@ -159,7 +159,7 @@ require (
 )
 
 // Uncomment if you're working on a dependency locally
-// replace github.com/privateerproj/privateer-sdk => ../../privateer-sdk
+// replace github.com/privateerproj/privateer-sdk => ../privateer-sdk
 
 // replace github.com/gemaraproj/go-gemara => ../../gemaraproj/go-gemara
 

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/privateerproj/privateer-sdk v1.31.3 h1:D5LIui/8fk7M/8VqejSsNwvF/WfNyChGSZzt1CXjnOU=
-github.com/privateerproj/privateer-sdk v1.31.3/go.mod h1:6LGlecl5jzpY4iJ5YI9erBN/qfz25qPp6/heY1Ip8EU=
+github.com/privateerproj/privateer-sdk v1.32.0 h1:nynNyU2CyxI4MZXCm1o9Qbg2MdjOOYjL8Y68miMZZuI=
+github.com/privateerproj/privateer-sdk v1.32.0/go.mod h1:6LGlecl5jzpY4iJ5YI9erBN/qfz25qPp6/heY1Ip8EU=
 github.com/revanite-io/grc-store-protocol v0.5.0 h1:u/CvDAQef6wQQpcDajGY+AhY8ETbh0Uu05wj5PeWRYw=
 github.com/revanite-io/grc-store-protocol v0.5.0/go.mod h1:naeWSRGJ9dtyzndHdsA4jrENlSmSlIgLQDAKRSpPhwU=
 github.com/rhysd/actionlint v1.7.12 h1:vQ4GeJN86C0QH+gTUQcs8McmK62OLT3kmakPMtEWYnY=

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	orchestrator.AddRequiredVars(RequiredVars)
 
-	err = orchestrator.AddEvaluationSuiteForAllCatalogs(nil, evaluation_plans.AllSteps())
+	err = pluginkit.AddEvaluationSuiteTypedForAllCatalogs(&orchestrator, nil, evaluation_plans.AllSteps())
 	if err != nil {
 		fmt.Printf("Error adding evaluation suites: %v\n", err)
 		os.Exit(shared.InternalError)


### PR DESCRIPTION
Fairly light touch addition which will enable the `pvtr benchmark` capability. This will be useful for optimizing our plugin's runtime, since every millisecond can cascade out to 30+ minutes of runtime for users.
 
<details><summary>Example output</summary>

```
› ./pvtr benchmark ./github-repo --service=vexa-core
2026-07-18T11:37:39.455-0500 [INFO]  OSPS-AC-01.01: This control is enforced by GitHub for all projects
2026-07-18T11:37:39.455-0500 [INFO]  OSPS-AC-02.01: This control is enforced by GitHub for all projects
2026-07-18T11:37:39.455-0500 [ERROR] OSPS-AC-03.01: Default branch is not protected
2026-07-18T11:37:39.455-0500 [WARN]  OSPS-AC-04.01: GitHub Actions is disabled for this repository; manual review required.
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-BR-01.01: GitHub Workflows variables do not contain untrusted inputs
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-BR-01.02: GitHub Workflows do not use unsanitized branch names in run steps
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-BR-02.01: All releases found have a unique name
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-BR-03.01: All links use HTTPS
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-BR-03.02: All distribution points use HTTPS
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-BR-04.01: Mention of a changelog found in the latest release
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-BR-06.01: Found SLSA attestation in security insights
2026-07-18T11:37:40.970-0500 [ERROR] OSPS-BR-07.01: Secret scanning is not enabled
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-DO-01.01: User guide was specified in Security Insights data
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-DO-02.01: Repository accepts vulnerability reports
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-DO-06.01: Dependency management policy was specified in Security Insights data
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-GV-01.01: Project admins were specified in Security Insights data
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-GV-01.02: Roles and responsibilities were specified in Security Insights data
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-GV-02.01: Issues are enabled for the repository
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-GV-03.01: Contributing guide specified in Security Insights data (Bonus: code of conduct location also specified)
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-GV-03.02: Code review guide was specified in Security Insights data
2026-07-18T11:37:40.970-0500 [INFO]  OSPS-LE-01.01: This control is satisfied by the GitHub Terms of Service
2026-07-18T11:37:41.146-0500 [INFO]  OSPS-LE-02.01: All license found are OSI or FSF approved
2026-07-18T11:37:41.146-0500 [INFO]  OSPS-LE-02.02: All license found are OSI or FSF approved
2026-07-18T11:37:41.146-0500 [INFO]  OSPS-LE-03.01: License was found in a well known location via the GitHub API
2026-07-18T11:37:41.146-0500 [INFO]  OSPS-LE-03.02: GitHub releases include the license(s) in the released source code.
2026-07-18T11:37:41.146-0500 [INFO]  OSPS-QA-01.01: Repository is public
2026-07-18T11:37:41.146-0500 [INFO]  OSPS-QA-01.02: This control is enforced by GitHub for all projects
2026-07-18T11:37:41.146-0500 [INFO]  OSPS-QA-02.01: Found 32 dependency manifests from GitHub API
2026-07-18T11:37:41.343-0500 [ERROR] OSPS-QA-03.01: Some executed status checks are not mandatory but all should be: GitGuardian Security Checks, Mintlify Deployment, gates, gates
2026-07-18T11:37:41.344-0500 [INFO]  OSPS-QA-04.01: Insights contains a list of repositories
2026-07-18T11:37:44.313-0500 [INFO]  OSPS-QA-05.01: No common binary file extensions were found in the repository
2026-07-18T11:37:44.313-0500 [INFO]  OSPS-QA-05.02: No unreviewable binary artifacts were found in the repository
2026-07-18T11:37:44.313-0500 [INFO]  OSPS-QA-06.01: 4 status checks were run
2026-07-18T11:37:44.313-0500 [INFO]  OSPS-SA-01.01: Design documentation found: ARCHITECTURE.md
2026-07-18T11:37:44.313-0500 [INFO]  OSPS-VM-01.01: Vulnerability disclosure policy was specified in Security Insights data
2026-07-18T11:37:44.313-0500 [INFO]  OSPS-VM-02.01: Security contacts were specified in Security Insights data
2026-07-18T11:37:44.313-0500 [INFO]  OSPS-VM-03.01: Private vulnerability reporting available via dedicated contact email in Security Insights data
2026-07-18T11:37:44.313-0500 [ERROR] > vexa-core_osps-baseline-2026-02: 25 Passed, 1 Warnings, 3 Failed, 40 Possible
2026-07-18T11:37:44.327-0500 [INFO]  benchmark: plugin process exited: plugin=/Users/home/dev/ossf/pvtr-github-repo-scanner/github-repo id=65769
Benchmark: github-repo (0.0.0-dev) service=vexa-core
Wall clock 10.53s; plugin total 9.19s; exit code 1; results in /var/folders/t5/xt0w4gx57477k5r4m8nql46c0000gn/T/pvtr-benchmark-2462180429
API calls reported by payload: 15

SEGMENT                                     FUNCTION                                          DURATION SHARE
payload retrieval (orchestrator)            data.Loader                                       4.32s    47.0%
OSPS-QA-05.01                               quality.NoBinariesInRepo                          1.57s    17.1%
OSPS-QA-05.02                               quality.NoUnreviewableBinariesInRepo              1.4s     15.2%
OSPS-BR-01.01                               build_release.CicdSanitizedInputParameters        1.11s    12.0%
OSPS-BR-01.02                               build_release.CicdBranchNameSanitized             409.3ms  4.5%
OSPS-QA-03.01                               quality.StatusChecksAreRequiredByRulesets         197.3ms  2.1%
OSPS-LE-02.01 step[1]                       legal.GoodLicense                                 142.4ms  1.6%
OSPS-LE-02.02 step[1]                       legal.GoodLicense                                 32.7ms   0.4%
evaluation overhead (osps-baseline-2026-02) applicability, aggregation, logging               1.7ms    0.0%
OSPS-QA-03.01 step[1]                       quality.StatusChecksAreRequiredByBranchProtection 26µs     0.0%
OSPS-BR-02.01                               reusable_steps.HasMadeReleases                    6µs      0.0%
OSPS-BR-03.01 step[1]                       build_release.EnsureInsightsLinksUseHTTPS         6µs      0.0%
OSPS-QA-04.01 step[2]                       reusable_steps.IsActive                           4µs      0.0%
OSPS-BR-04.01 step[1]                       build_release.EnsureLatestReleaseHasChangelog     3µs      0.0%
OSPS-QA-06.01 step[1]                       quality.HasOneOrMoreStatusChecks                  2µs      0.0%
OSPS-QA-02.01                               quality.VerifyDependencyManagement                2µs      0.0%
OSPS-QA-04.01                               reusable_steps.IsCodeRepo                         2µs      0.0%
OSPS-SA-01.01 step[1]                       sec_assessment.HasDesignDocumentation             2µs      0.0%
OSPS-LE-02.02                               legal.ReleasesLicensed                            2µs      0.0%
OSPS-BR-07.01                               build_release.SecretScanningInUse                 1µs      0.0%
OSPS-QA-01.01                               quality.RepoIsPublic                              1µs      0.0%
OSPS-AC-03.01                               access_control.BranchProtectionRestrictsPushes    1µs      0.0%
OSPS-AC-01.01                               reusable_steps.GithubBuiltIn                      1µs      0.0%
OSPS-BR-02.01 step[1]                       build_release.ReleaseHasUniqueIdentifier          1µs      0.0%
OSPS-BR-03.02                               build_release.DistributionPointsUseHTTPS          1µs      0.0%
OSPS-GV-01.01 step[1]                       reusable_steps.IsActive                           1µs      0.0%
OSPS-BR-06.01 step[2]                       build_release.InsightsHasSlsaAttestation          1µs      0.0%
OSPS-SA-01.01                               reusable_steps.HasMadeReleases                    1µs      0.0%
OSPS-QA-06.01                               reusable_steps.IsCodeRepo                         1µs      0.0%
OSPS-BR-03.01                               reusable_steps.HasSecurityInsightsFile            834ns    0.0%
OSPS-GV-01.01 step[3]                       governance.ProjectAdminsListed                    750ns    0.0%
OSPS-QA-01.02                               reusable_steps.GithubBuiltIn                      708ns    0.0%
OSPS-GV-03.02 step[2]                       reusable_steps.IsActive                           666ns    0.0%
OSPS-BR-04.01                               reusable_steps.HasMadeReleases                    625ns    0.0%
OSPS-QA-04.01 step[3]                       quality.InsightsListsRepositories                 625ns    0.0%
OSPS-VM-01.01                               reusable_steps.IsActive                           584ns    0.0%
OSPS-DO-01.01                               reusable_steps.HasMadeReleases                    583ns    0.0%
OSPS-QA-04.01 step[1]                       reusable_steps.HasSecurityInsightsFile            542ns    0.0%
OSPS-LE-02.01                               legal.FoundLicense                                500ns    0.0%
OSPS-LE-03.01                               legal.FoundLicense                                500ns    0.0%
OSPS-VM-02.01 step[1]                       vuln_management.HasSecContact                     500ns    0.0%
OSPS-DO-02.01                               reusable_steps.HasMadeReleases                    458ns    0.0%
OSPS-DO-06.01 step[1]                       reusable_steps.HasMadeReleases                    334ns    0.0%
OSPS-AC-04.01                               access_control.WorkflowDefaultReadPermissions     333ns    0.0%
OSPS-BR-06.01                               reusable_steps.HasMadeReleases                    333ns    0.0%
OSPS-VM-03.01                               reusable_steps.IsActive                           333ns    0.0%
OSPS-SA-02.01                               reusable_steps.NotImplemented                     291ns    0.0%
OSPS-AC-02.01                               reusable_steps.GithubBuiltIn                      250ns    0.0%
OSPS-GV-03.02                               reusable_steps.IsCodeRepo                         250ns    0.0%
OSPS-BR-05.01                               reusable_steps.NotImplemented                     166ns    0.0%
OSPS-GV-02.01                               reusable_steps.HasIssuesOrDiscussionsEnabled      166ns    0.0%
OSPS-GV-03.01                               governance.HasContributionGuide                   166ns    0.0%
OSPS-DO-01.01 step[2]                       docs.HasUserGuides                                125ns    0.0%
OSPS-DO-02.01 step[1]                       reusable_steps.HasIssuesOrDiscussionsEnabled      125ns    0.0%
OSPS-LE-01.01                               reusable_steps.GithubTermsOfService               125ns    0.0%
OSPS-LE-03.02                               legal.ReleasesLicensed                            125ns    0.0%
OSPS-BR-06.01 step[1]                       reusable_steps.HasSecurityInsightsFile            84ns     0.0%
OSPS-DO-01.01 step[1]                       reusable_steps.HasSecurityInsightsFile            84ns     0.0%
OSPS-DO-06.01                               reusable_steps.IsCodeRepo                         84ns     0.0%
OSPS-GV-01.01                               reusable_steps.HasSecurityInsightsFile            84ns     0.0%
OSPS-GV-01.01 step[2]                       governance.CoreTeamIsListed                       84ns     0.0%
OSPS-GV-03.02 step[3]                       governance.HasContributionReviewPolicy            84ns     0.0%
OSPS-VM-03.01 step[1]                       reusable_steps.HasSecurityInsightsFile            84ns     0.0%
OSPS-VM-04.01                               reusable_steps.NotImplemented                     84ns     0.0%
OSPS-DO-06.01 step[2]                       reusable_steps.HasSecurityInsightsFile            83ns     0.0%
OSPS-DO-06.01 step[3]                       docs.HasDependencyManagementPolicy                83ns     0.0%
OSPS-GV-03.02 step[1]                       reusable_steps.HasSecurityInsightsFile            83ns     0.0%
OSPS-VM-02.01                               reusable_steps.IsCodeRepo                         83ns     0.0%
OSPS-SA-03.01                               reusable_steps.NotImplemented                     42ns     0.0%
OSPS-VM-01.01 step[2]                       vuln_management.HasVulnerabilityDisclosurePolicy  42ns     0.0%
OSPS-VM-03.01 step[2]                       vuln_management.HasPrivateVulnerabilityReporting  42ns     0.0%
OSPS-DO-02.01 step[2]                       docs.AcceptsVulnReports                           41ns     0.0%
OSPS-GV-01.02                               governance.HasRolesAndResponsibilities            41ns     0.0%
OSPS-VM-01.01 step[1]                       reusable_steps.HasSecurityInsightsFile            41ns     0.0%
unattributed                                config, catalog parsing, result writing           9.6ms    0.1%
```