### PR TITLE
fix: report unevaluated workflows as NeedsReview, not Failed

### DIFF
--- a/data/graphql-workflows.go
+++ b/data/graphql-workflows.go
@@ -46,10 +46,15 @@ type WorkflowBlob struct {
 }
 
 // WorkflowFile is a single workflow definition with its contents already decoded.
+//
+// Truncated marks a file GitHub declined to return in full. It is reported
+// rather than dropped so callers can tell "inspected and clean" apart from
+// "never inspected" — see checkAllWorkflows.
 type WorkflowFile struct {
-	Name    string
-	Path    string
-	Content string
+	Name      string
+	Path      string
+	Content   string
+	Truncated bool
 }
 
 // fetchWorkflowFiles returns the decoded contents of every file directly inside
@@ -77,8 +82,9 @@ func fetchWorkflowFiles(cfg *config.Config, client *githubv4.Client, branch, dir
 	return workflowFilesFromQuery(query, cfg.Logger), nil
 }
 
-// workflowFilesFromQuery maps a directory listing onto WorkflowFiles, dropping
-// entries whose contents cannot be evaluated.
+// workflowFilesFromQuery maps a directory listing onto WorkflowFiles. Entries
+// that are not workflow definitions are dropped; entries that are definitions we
+// could not read are kept and marked Truncated.
 func workflowFilesFromQuery(query GraphqlWorkflowFiles, logger hclog.Logger) []WorkflowFile {
 	var files []WorkflowFile
 	for _, entry := range query.Repository.Object.Tree.Entries {
@@ -94,10 +100,12 @@ func workflowFilesFromQuery(query GraphqlWorkflowFiles, logger hclog.Logger) []W
 			logger.Debug(fmt.Sprintf("skipping symlink, not an executable workflow: %s", entry.Path))
 			continue
 		}
-		// GitHub truncates very large blobs. Parsing a partial workflow would
-		// produce misleading results, so skip it and say so.
+		// GitHub truncates very large blobs, and returns no text at all for
+		// blobs that are not valid UTF-8. Either way the contents cannot be
+		// parsed, so mark the file rather than silently omitting it.
 		if entry.Object.Blob.IsTruncated {
-			logger.Warn(fmt.Sprintf("skipping truncated file, too large to evaluate: %s", entry.Path))
+			logger.Warn(fmt.Sprintf("workflow too large to retrieve in full, cannot evaluate: %s", entry.Path))
+			files = append(files, WorkflowFile{Name: entry.Name, Path: entry.Path, Truncated: true})
 			continue
 		}
 		files = append(files, WorkflowFile{

--- a/data/graphql-workflows_test.go
+++ b/data/graphql-workflows_test.go
@@ -53,19 +53,19 @@ func TestWorkflowFilesFromQuery(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "truncated blobs are skipped rather than partially parsed",
+			name: "truncated blobs are reported without their partial contents",
 			entries: []WorkflowTreeEntry{
 				{Name: "huge.yml", Path: ".github/workflows/huge.yml", Type: "blob", Object: blob("on: pu", true)},
 				{Name: "ci.yml", Path: ".github/workflows/ci.yml", Type: "blob", Object: blob("on: push", false)},
 			},
 			expected: []WorkflowFile{
+				{Name: "huge.yml", Path: ".github/workflows/huge.yml", Truncated: true},
 				{Name: "ci.yml", Path: ".github/workflows/ci.yml", Content: "on: push"},
 			},
 		},
 		{
 			// Git stores a symlink as a blob holding the target path, so only
-			// the mode distinguishes it from a workflow definition. Left in, its
-			// contents reach actionlint and fail the whole control.
+			// the mode distinguishes it from a workflow definition.
 			name: "symlinks are skipped despite being blobs",
 			entries: []WorkflowTreeEntry{
 				{

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -51,36 +51,60 @@ var (
 		`github\.ref_name).*`)
 )
 
-// checkAllWorkflows verifies the payload, iterates over all workflow files, and
-// applies checkWorkflow to each parsed workflow. passMessage is returned when all files pass.
+// checkAllWorkflows fetches the repository's workflow files and evaluates each
+// one with checkWorkflow. passMessage is returned when all files pass.
 func checkAllWorkflows(payload data.Payload, checkWorkflow func(*actionlint.Workflow) (bool, string), passMessage string) (gemara.Result, string, gemara.ConfidenceLevel) {
 	var confidence gemara.ConfidenceLevel
-	var message string
 
 	workflows, err := payload.GetWorkflowFiles()
 	if len(workflows) == 0 {
+		message := "No workflows found in .github/workflows directory"
 		if err != nil {
 			message = err.Error()
-		} else {
-			message = "No workflows found in .github/workflows directory"
 		}
 		return gemara.NotApplicable, message, confidence
 	}
+
+	return evaluateWorkflows(workflows, checkWorkflow, passMessage)
+}
+
+// evaluateWorkflows applies checkWorkflow to each parsed workflow.
+//
+// A file we could not retrieve or parse is reported as NeedsReview, not Failed.
+// Failed asserts that the repository violates the control, which we have not
+// observed for a file we never read; NeedsReview says so honestly and puts it in
+// front of a human. An actual violation in a file we did parse still wins, so
+// unreadable siblings can never mask a real finding.
+func evaluateWorkflows(workflows []data.WorkflowFile, checkWorkflow func(*actionlint.Workflow) (bool, string), passMessage string) (gemara.Result, string, gemara.ConfidenceLevel) {
+	var confidence gemara.ConfidenceLevel
+	var uninspected []string
 
 	for _, file := range workflows {
 		if !strings.HasSuffix(file.Name, ".yml") && !strings.HasSuffix(file.Name, ".yaml") {
 			continue
 		}
 
+		if file.Truncated {
+			uninspected = append(uninspected, fmt.Sprintf("%s (too large to retrieve)", file.Path))
+			continue
+		}
+
 		workflow, actionError := actionlint.Parse([]byte(file.Content))
 		if actionError != nil {
-			return gemara.Failed, fmt.Sprintf("Error parsing workflow: %v (%s)", actionError, file.Path), confidence
+			uninspected = append(uninspected, fmt.Sprintf("%s (%v)", file.Path, actionError))
+			continue
 		}
 
 		ok, message := checkWorkflow(workflow)
 		if !ok {
 			return gemara.Failed, message, confidence
 		}
+	}
+
+	if len(uninspected) > 0 {
+		return gemara.NeedsReview, fmt.Sprintf(
+			"Unable to evaluate %d of %d workflow files, manual review required: %s",
+			len(uninspected), len(workflows), strings.Join(uninspected, "; ")), confidence
 	}
 
 	return gemara.Passed, passMessage, confidence

--- a/evaluation_plans/osps/build_release/steps_test.go
+++ b/evaluation_plans/osps/build_release/steps_test.go
@@ -4,8 +4,11 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/gemaraproj/go-gemara"
 	"github.com/rhysd/actionlint"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
 var goodWorkflowFile = `name: OSPS Baseline Scan
@@ -307,4 +310,79 @@ func TestPullRequestOnlyUnsafeBranchVarsRegex(t *testing.T) {
 	assert.False(t, pullRequestOnlyUnsafeBranchVars.Match([]byte("github.ref_type")), "github.ref_type should not match")
 	assert.False(t, pullRequestOnlyUnsafeBranchVars.Match([]byte("github.ref_protected")), "github.ref_protected should not match")
 	assert.False(t, pullRequestOnlyUnsafeBranchVars.Match([]byte("github.workspace")), "github.workspace should not match")
+}
+
+// alwaysPasses and alwaysFails stand in for the real per-workflow checks so
+// these cases exercise only how evaluateWorkflows combines their results.
+func alwaysPasses(*actionlint.Workflow) (bool, string) { return true, "" }
+func alwaysFails(*actionlint.Workflow) (bool, string)  { return false, "violation found" }
+
+func TestEvaluateWorkflows(t *testing.T) {
+	testCases := []struct {
+		name           string
+		workflows      []data.WorkflowFile
+		checkWorkflow  func(*actionlint.Workflow) (bool, string)
+		expectedResult gemara.Result
+	}{
+		{
+			name:           "all files parse and pass",
+			workflows:      []data.WorkflowFile{{Name: "ci.yml", Path: "p/ci.yml", Content: goodWorkflowFile}},
+			checkWorkflow:  alwaysPasses,
+			expectedResult: gemara.Passed,
+		},
+		{
+			name:           "a violation in a parsed file fails",
+			workflows:      []data.WorkflowFile{{Name: "ci.yml", Path: "p/ci.yml", Content: goodWorkflowFile}},
+			checkWorkflow:  alwaysFails,
+			expectedResult: gemara.Failed,
+		},
+		{
+			// Previously returned Failed, asserting a violation in a file that
+			// was never successfully parsed.
+			name:           "an unparseable file needs review rather than failing",
+			workflows:      []data.WorkflowFile{{Name: "ci.yml", Path: "p/ci.yml", Content: "this is not a workflow"}},
+			checkWorkflow:  alwaysPasses,
+			expectedResult: gemara.NeedsReview,
+		},
+		{
+			// The symlink regression: an empty body reaching the parser must
+			// not read as a control violation.
+			name:           "an empty file needs review rather than failing",
+			workflows:      []data.WorkflowFile{{Name: "ci.yml", Path: "p/ci.yml", Content: ""}},
+			checkWorkflow:  alwaysPasses,
+			expectedResult: gemara.NeedsReview,
+		},
+		{
+			name:           "a truncated file needs review rather than passing silently",
+			workflows:      []data.WorkflowFile{{Name: "huge.yml", Path: "p/huge.yml", Truncated: true}},
+			checkWorkflow:  alwaysPasses,
+			expectedResult: gemara.NeedsReview,
+		},
+		{
+			// An uninspectable sibling must never suppress a real finding.
+			name: "a real violation outranks an uninspectable sibling",
+			workflows: []data.WorkflowFile{
+				{Name: "broken.yml", Path: "p/broken.yml", Content: "not a workflow"},
+				{Name: "ci.yml", Path: "p/ci.yml", Content: goodWorkflowFile},
+			},
+			checkWorkflow:  alwaysFails,
+			expectedResult: gemara.Failed,
+		},
+		{
+			name: "non-workflow extensions are ignored, not flagged",
+			workflows: []data.WorkflowFile{
+				{Name: "README.md", Path: "p/README.md", Content: "not a workflow"},
+				{Name: "ci.yml", Path: "p/ci.yml", Content: goodWorkflowFile},
+			},
+			checkWorkflow:  alwaysPasses,
+			expectedResult: gemara.Passed,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, message, _ := evaluateWorkflows(testCase.workflows, testCase.checkWorkflow, "all workflows passed")
+			assert.Equal(t, testCase.expectedResult, result, message)
+		})
+	}
 }


### PR DESCRIPTION
Fast follow from https://github.com/ossf/pvtr-github-repo-scanner/pull/373#discussion_r3617037356

checkAllWorkflows mapped any actionlint parse error to Failed, asserting the repository violates the control when the file was in fact never inspected. That is the wrong verdict for a file we could not read: Failed claims an observed violation, when the honest answer is that a human needs to look.

Parse failures now report NeedsReview instead. Truncated files (GitHub declines to return oversized or non-UTF-8 blobs in full) are carried through as marked entries rather than silently dropped, so they reach the same NeedsReview path instead of a workflow-less Passed. A real violation in a file we did parse still returns Failed first, so an unreadable sibling can never mask a finding.

Note for consumers: this changes results for repositories with a malformed or oversized workflow from Failed to NeedsReview. badgeurl.mapResult does not map NeedsReview, so such a criterion is omitted from Best Practices Badge proposals rather than emitted as Unmet.

Builds on the symlink skip in the parent branch; both stem from the same Failed-on-uninspected-file bug.