### PR TITLE
perf: skip fetching subdirectories absent from the root listing

### DIFF
--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -257,6 +257,13 @@ func (r *RestData) getSubdirContents(path string) (RepoContent, error) {
 	if cached, ok := r.contents.SubContent[path]; ok {
 		return cached, nil
 	}
+	// A directory absent from the root listing cannot be fetched, so answer from
+	// that listing instead of spending a guaranteed-404 round trip. This is the
+	// miss the cache above cannot cover: errors are not cached, so without this a
+	// repository with no .github directory pays one 404 per checkFile probe.
+	if !strings.Contains(path, "/") && !r.rootHasDir(path) {
+		return RepoContent{}, fmt.Errorf("directory %q not found in repository root", path)
+	}
 	_, content, _, err := r.ghClient.Repositories.GetContents(context.Background(), r.owner, r.repo, path, nil)
 	if err != nil {
 		return RepoContent{}, err
@@ -272,6 +279,21 @@ func (r *RestData) getSubdirContents(path string) (RepoContent, error) {
 	}
 	r.contents.SubContent[path] = subdir
 	return subdir, nil
+}
+
+// rootHasDir reports whether the cached root listing holds a directory by this
+// name. An unavailable root listing reports true so that a failed root fetch
+// falls through to the API rather than declaring every directory missing.
+func (r *RestData) rootHasDir(name string) bool {
+	if len(r.contents.Content) == 0 {
+		return true
+	}
+	for _, entry := range r.contents.Content {
+		if entry.GetType() == "dir" && entry.GetName() == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *RestData) getReleases() error {

--- a/data/rest-data_test.go
+++ b/data/rest-data_test.go
@@ -198,4 +198,44 @@ func TestGetSubdirContentsCaching(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, *calls, "an empty directory is a real answer worth caching")
 	})
+
+	t.Run("a directory absent from the root listing is never fetched", func(t *testing.T) {
+		// Errors are not cached, so without consulting the root listing a repo
+		// with no .github directory pays a 404 on every checkFile probe.
+		restData, calls := newRestData(t, `[]`)
+		restData.contents.Content = []*github.RepositoryContent{
+			{Name: github.Ptr("README.md"), Path: github.Ptr("README.md"), Type: github.Ptr("file")},
+			{Name: github.Ptr("src"), Path: github.Ptr("src"), Type: github.Ptr("dir")},
+		}
+
+		_, err := restData.getSubdirContents(".github")
+		assert.Error(t, err)
+		_, err = restData.getSubdirContents(".github")
+		assert.Error(t, err)
+		assert.Equal(t, 0, *calls, "a directory the root listing rules out needs no API call")
+	})
+
+	t.Run("an unavailable root listing still falls through to the API", func(t *testing.T) {
+		// A failed root fetch must not be read as "no directories exist".
+		restData, calls := newRestData(t, `[{"name":"workflows","path":".github/workflows","type":"dir"}]`)
+
+		_, err := restData.getSubdirContents(".github")
+		require.NoError(t, err)
+		assert.Equal(t, 1, *calls)
+	})
+
+	t.Run("a directory present in the root listing is fetched", func(t *testing.T) {
+		// The production happy path: the root listing records .github as a
+		// directory, so the guard lets the fetch through and caches it.
+		restData, calls := newRestData(t, `[{"name":"workflows","path":".github/workflows","type":"dir"}]`)
+		restData.contents.Content = []*github.RepositoryContent{
+			{Name: github.Ptr("README.md"), Path: github.Ptr("README.md"), Type: github.Ptr("file")},
+			{Name: github.Ptr(".github"), Path: github.Ptr(".github"), Type: github.Ptr("dir")},
+		}
+
+		result, err := restData.getSubdirContents(".github")
+		require.NoError(t, err)
+		assert.Len(t, result.Content, 1)
+		assert.Equal(t, 1, *calls, "a directory the root listing confirms is fetched once")
+	})
 }


### PR DESCRIPTION
getSubdirContents does not cache errors, so a repository with no .github directory paid a guaranteed 404 on every checkFile probe (support.md, readme.md, security-insights.yml — three per scan, each with an error log).

The root listing already records every top-level entry, so consult it first: a directory absent there cannot be fetched and needs no request. An unavailable root listing falls through to the API rather than declaring every directory missing, so a failed root fetch is not mistaken for an empty repo.