### PR TITLE
perf: parallelize payload retrieval stages

### DIFF
--- a/data/payload.go
+++ b/data/payload.go
@@ -10,6 +10,7 @@ import (
 	"github.com/privateerproj/privateer-sdk/pluginkit"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/errgroup"
 )
 
 type Payload struct {
@@ -52,29 +53,40 @@ func Loader(config *config.Config) (payload any, err error) {
 		&oauth2.Token{AccessToken: config.GetString("token")},
 	)))
 
-	graphql, client, err := getGraphqlRepoData(config, httpClient)
-	if err != nil {
-		return nil, err
-	}
-
 	ghClient := github.NewClient(httpClient)
+	owner := config.GetString("owner")
+	repo := config.GetString("repo")
 
-	repo, repositoryMetadata, err := loadRepositoryMetadata(ghClient, config.GetString("owner"), config.GetString("repo"))
-	if err != nil {
+	var (
+		graphql            *GraphqlRepoData
+		client             *githubv4.Client
+		ghRepo             *github.Repository
+		repositoryMetadata RepositoryMetadata
+		isCodeRepo         bool
+	)
+	rest := newRestData(ghClient, httpClient, config)
+
+	g := new(errgroup.Group)
+	g.Go(func() (err error) {
+		graphql, client, err = getGraphqlRepoData(config, httpClient, owner, repo)
+		return err
+	})
+	g.Go(func() (err error) {
+		ghRepo, repositoryMetadata, err = loadRepositoryMetadata(ghClient, owner, repo)
+		return err
+	})
+	g.Go(func() error {
+		return rest.Setup()
+	})
+	g.Go(func() (err error) {
+		isCodeRepo, err = rest.IsCodeRepo()
+		return err
+	})
+	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 
-	rest, err := getRestData(ghClient, httpClient, config)
-	if err != nil {
-		return nil, err
-	}
-
-	isCodeRepo, err := rest.IsCodeRepo()
-	if err != nil {
-		return nil, err
-	}
-
-	securityPosture, err := buildSecurityPosture(repo, *rest)
+	securityPosture, err := buildSecurityPosture(ghRepo, *rest)
 	if err != nil {
 		return nil, err
 	}
@@ -94,12 +106,12 @@ func Loader(config *config.Config) (payload any, err error) {
 	}), nil
 }
 
-func getGraphqlRepoData(config *config.Config, httpClient *http.Client) (data *GraphqlRepoData, client *githubv4.Client, err error) {
+func getGraphqlRepoData(config *config.Config, httpClient *http.Client, owner, repo string) (data *GraphqlRepoData, client *githubv4.Client, err error) {
 	client = githubv4.NewClient(httpClient)
 
 	variables := map[string]any{
-		"owner": githubv4.String(config.GetString("owner")),
-		"name":  githubv4.String(config.GetString("repo")),
+		"owner": githubv4.String(owner),
+		"name":  githubv4.String(repo),
 	}
 
 	err = withRetry(config.Logger, "GraphQL repo data query", func() error {
@@ -112,17 +124,22 @@ func getGraphqlRepoData(config *config.Config, httpClient *http.Client) (data *G
 	return data, client, err
 }
 
-// getRestData builds the REST accessor on the shared httpClient so its raw
+// newRestData builds the REST accessor on the shared httpClient so its raw
 // endpoint fetches are counted too; left nil, RestData falls back to its own
 // uncounted client and the API-call tally silently undercounts.
-func getRestData(ghClient *github.Client, httpClient *http.Client, config *config.Config) (data *RestData, err error) {
-	r := &RestData{
+//
+// Construction is network-free and resolves owner/repo/token up front so that
+// Setup and IsCodeRepo — which only read those fields — can run concurrently
+// without a write racing their reads.
+func newRestData(ghClient *github.Client, httpClient *http.Client, config *config.Config) *RestData {
+	return &RestData{
 		ghClient:   ghClient,
 		HttpClient: httpClient,
 		Config:     config,
+		owner:      config.GetString("owner"),
+		repo:       config.GetString("repo"),
+		token:      config.GetString("token"),
 	}
-	err = r.Setup()
-	return r, err
 }
 
 // newBinaryChecker creates a binaryChecker configured from the payload's

--- a/data/repository_metadata.go
+++ b/data/repository_metadata.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"reflect"
+	"sync"
 
 	"github.com/google/go-github/v74/github"
 )
@@ -106,23 +107,35 @@ func (r *GitHubRepositoryMetadata) OrganizationBlogURL() *string {
 }
 
 func loadRepositoryMetadata(ghClient *github.Client, owner, repo string) (ghRepo *github.Repository, data RepositoryMetadata, err error) {
+	// The repository fetch is the only hard dependency: it carries the default
+	// branch the ruleset lookup needs, and its failure is fatal to the scan.
 	repository, _, err := ghClient.Repositories.Get(context.Background(), owner, repo)
 	if err != nil {
 		return repository, &GitHubRepositoryMetadata{}, err
 	}
-	organization, _, err := ghClient.Organizations.Get(context.Background(), owner)
-	if err != nil {
-		return repository, &GitHubRepositoryMetadata{
-			ghRepo: repository,
-		}, nil
-	}
-	branchRules, err := getRuleset(ghClient, owner, repo, repository.GetDefaultBranch())
-	if err != nil {
-		return repository, &GitHubRepositoryMetadata{
-			ghRepo: repository,
-			ghOrg:  organization,
-		}, nil
-	}
+
+	// The organization and ruleset lookups are independent of each other and hit
+	// separate endpoints, so fetch them concurrently.
+	// Errors are expected when an org or ruleset isn't in place; safe to ignore.
+	var (
+		organization *github.Organization
+		branchRules  *github.BranchRules
+	)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		org, _, orgErr := ghClient.Organizations.Get(context.Background(), owner)
+		if orgErr == nil {
+			organization = org // hoist
+		}
+	})
+	wg.Go(func() {
+		rules, rulesErr := getRuleset(ghClient, owner, repo, repository.GetDefaultBranch())
+		if rulesErr == nil {
+			branchRules = rules // hoist
+		}
+	})
+	wg.Wait()
+
 	return repository, &GitHubRepositoryMetadata{
 		ghRepo:             repository,
 		ghOrg:              organization,

--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -64,12 +64,8 @@ type WorkflowPermissions struct {
 var APIBase = "https://api.github.com"
 
 func (r *RestData) Setup() error {
-	// owner/repo/token are resolved by newRestData
-	if r.owner == "" && r.Config != nil {
-		r.owner = r.Config.GetString("owner")
-		r.repo = r.Config.GetString("repo")
-		r.token = r.Config.GetString("token")
-	}
+	// owner/repo/token are resolved by newRestData; Setup is only ever
+	// reached through it, so no fallback resolution is needed here.
 
 	r.getRepoContents()
 

--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 
 	hclog "github.com/hashicorp/go-hclog"
 
@@ -63,14 +64,27 @@ type WorkflowPermissions struct {
 var APIBase = "https://api.github.com"
 
 func (r *RestData) Setup() error {
-	r.owner = r.Config.GetString("owner")
-	r.repo = r.Config.GetString("repo")
-	r.token = r.Config.GetString("token")
+	// owner/repo/token are resolved by newRestData
+	if r.owner == "" && r.Config != nil {
+		r.owner = r.Config.GetString("owner")
+		r.repo = r.Config.GetString("repo")
+		r.token = r.Config.GetString("token")
+	}
 
 	r.getRepoContents()
-	r.loadSecurityInsights()
-	_ = r.getWorkflowPermissions()
-	_ = r.getReleases()
+
+	// Errors are expected when one of these are not in place; safe to ignore
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		r.loadSecurityInsights()
+	})
+	wg.Go(func() {
+		_ = r.getWorkflowPermissions()
+	})
+	wg.Go(func() {
+		_ = r.getReleases()
+	})
+	wg.Wait()
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/subosito/gotenv v1.6.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect


### PR DESCRIPTION
What it says on the tin.

Using `waitgroup` instead of `errorgroup` because every one of these is safely nullable and resolved later in the assessments.

Benchmarking the payload retrieval specifically:

| `main` | `perf/parallelize-loader` |
| --- | --- |
| 3.68s | 1.48s |
| 3.22s | 1.62s |
| 2.93s | 1.33s |
| 2.84s | 1.93s |
| 4.00s | 1.64s |

## Unintended Consequences

This also fixes a bug related to branch protection data on user branches, which would always fail previously.
