### PR TITLE
perf: move binary inspection calls & logic to payload

### DIFF
--- a/data/payload.go
+++ b/data/payload.go
@@ -23,9 +23,17 @@ type Payload struct {
 	DependencyManifestsCount int
 	IsCodeRepo               bool
 	SecurityPosture          SecurityPosture
+	Binaries                 BinaryAnalysis
 	client                   *githubv4.Client
 	httpClient               *http.Client
 	cache                    *payloadCache
+}
+
+// BinaryAnalysis holds information about binaries found in the repo
+type BinaryAnalysis struct {
+	Suspected    []string // OSPS-QA-05.01: suspected executable binary artifacts
+	Unreviewable []string // OSPS-QA-05.02: unreviewable binary artifacts
+	Err          error
 }
 
 // payloadCache holds lazily-fetched data shared by every step. Steps receive the
@@ -40,7 +48,6 @@ type Payload struct {
 // signal a guarantee that does not exist. If steps ever run in parallel, this
 // should fail loudly under -race rather than half-work.
 type payloadCache struct {
-	tree      *GraphqlRepoTree
 	workflows []WorkflowFile
 	// set once workflows have been fetched, so an empty result is not refetched
 	workflowsLoaded bool
@@ -54,22 +61,28 @@ func Loader(config *config.Config) (payload any, err error) {
 	)))
 
 	ghClient := github.NewClient(httpClient)
+	gqlClient := githubv4.NewClient(httpClient)
 	owner := config.GetString("owner")
 	repo := config.GetString("repo")
 
 	var (
 		graphql            *GraphqlRepoData
-		client             *githubv4.Client
 		ghRepo             *github.Repository
 		repositoryMetadata RepositoryMetadata
 		isCodeRepo         bool
+		tree               *GraphqlRepoTree
+		treeErr            error
 	)
 	rest := newRestData(ghClient, httpClient, config)
 
 	g := new(errgroup.Group)
 	g.Go(func() (err error) {
-		graphql, client, err = getGraphqlRepoData(config, httpClient, owner, repo)
+		graphql, err = getGraphqlRepoData(config, gqlClient, owner, repo)
 		return err
+	})
+	g.Go(func() error {
+		tree, treeErr = fetchGraphqlRepoTree(config, gqlClient, "HEAD")
+		return nil
 	})
 	g.Go(func() (err error) {
 		ghRepo, repositoryMetadata, err = loadRepositoryMetadata(ghClient, owner, repo)
@@ -86,6 +99,8 @@ func Loader(config *config.Config) (payload any, err error) {
 		return nil, err
 	}
 
+	binaries := analyzeBinaries(tree, treeErr, httpClient, config, owner, repo, graphql.Repository.DefaultBranchRef.Name)
+
 	securityPosture, err := buildSecurityPosture(ghRepo, *rest)
 	if err != nil {
 		return nil, err
@@ -98,17 +113,16 @@ func Loader(config *config.Config) (payload any, err error) {
 		RepositoryMetadata:       repositoryMetadata,
 		DependencyManifestsCount: graphql.Repository.DependencyGraphManifests.TotalCount,
 		IsCodeRepo:               isCodeRepo,
-		client:                   client,
 		httpClient:               httpClient,
 		APICallCounter:           callCounter,
 		SecurityPosture:          securityPosture,
+		Binaries:                 binaries,
+		client:                   gqlClient,
 		cache:                    &payloadCache{},
 	}), nil
 }
 
-func getGraphqlRepoData(config *config.Config, httpClient *http.Client, owner, repo string) (data *GraphqlRepoData, client *githubv4.Client, err error) {
-	client = githubv4.NewClient(httpClient)
-
+func getGraphqlRepoData(config *config.Config, client *githubv4.Client, owner, repo string) (data *GraphqlRepoData, err error) {
 	variables := map[string]any{
 		"owner": githubv4.String(owner),
 		"name":  githubv4.String(repo),
@@ -121,7 +135,7 @@ func getGraphqlRepoData(config *config.Config, httpClient *http.Client, owner, r
 	if err != nil {
 		config.Logger.Error(fmt.Sprintf("Error querying GitHub GraphQL API: %s", err.Error()))
 	}
-	return data, client, err
+	return data, err
 }
 
 // newRestData builds the REST accessor on the shared httpClient so its raw
@@ -142,33 +156,28 @@ func newRestData(ghClient *github.Client, httpClient *http.Client, config *confi
 	}
 }
 
-// newBinaryChecker creates a binaryChecker configured from the payload's
-// repository metadata and HTTP client.
-func (p *Payload) newBinaryChecker() *binaryChecker {
-	return &binaryChecker{
-		httpClient: p.httpClient,
-		logger:     p.Config.Logger,
-		owner:      p.Config.GetString("owner"),
-		repo:       p.Config.GetString("repo"),
-		branch:     p.Repository.DefaultBranchRef.Name,
+// analyzeBinaries walks over the fetched tree, feeds the binaryChecker's
+// raw-content fallback for blobs GitHub could not classify.
+func analyzeBinaries(tree *GraphqlRepoTree, treeErr error, httpClient *http.Client, cfg *config.Config, owner, repo, branch string) BinaryAnalysis {
+	if treeErr != nil {
+		return BinaryAnalysis{Err: treeErr}
 	}
-}
-
-// getTree lazily fetches and caches the repository tree so that multiple
-// checks (e.g. QA-05.01 and QA-05.02) share a single GraphQL API call.
-func (p *Payload) getTree() (*GraphqlRepoTree, error) {
-	if p.GraphqlRepoData == nil || p.Config == nil || p.cache == nil {
-		return nil, fmt.Errorf("payload missing required repository data")
+	bc := &binaryChecker{
+		httpClient: httpClient,
+		logger:     cfg.Logger,
+		owner:      owner,
+		repo:       repo,
+		branch:     branch,
 	}
-	if p.cache.tree != nil {
-		return p.cache.tree, nil
-	}
-	tree, err := fetchGraphqlRepoTree(p.Config, p.client, p.Repository.DefaultBranchRef.Name)
+	suspected, err := checkTreeForBinaries(tree, bc)
 	if err != nil {
-		return nil, err
+		return BinaryAnalysis{Err: err}
 	}
-	p.cache.tree = tree
-	return tree, nil
+	unreviewable, err := checkTreeForUnreviewableBinaries(tree, bc)
+	if err != nil {
+		return BinaryAnalysis{Err: err}
+	}
+	return BinaryAnalysis{Suspected: suspected, Unreviewable: unreviewable}
 }
 
 // GetWorkflowFiles returns the decoded contents of every file in
@@ -188,26 +197,4 @@ func (p *Payload) GetWorkflowFiles() ([]WorkflowFile, error) {
 	p.cache.workflows = files
 	p.cache.workflowsLoaded = true
 	return files, nil
-}
-
-// GetSuspectedBinaries fetches the repository tree and returns file names that
-// appear to be executable binary artifacts per OSPS-QA-05.01.
-func (p *Payload) GetSuspectedBinaries() (suspectedBinaries []string, err error) {
-	tree, err := p.getTree()
-	if err != nil {
-		return nil, err
-	}
-	return checkTreeForBinaries(tree, p.newBinaryChecker())
-}
-
-// GetUnreviewableBinaries fetches the repository tree and returns file names that
-// are unreviewable binary artifacts per OSPS-QA-05.02. This differs from
-// GetSuspectedBinaries by flagging all binaries except acceptable content types
-// like images, audio, video, fonts, and PDFs.
-func (p *Payload) GetUnreviewableBinaries() (unreviewableBinaries []string, err error) {
-	tree, err := p.getTree()
-	if err != nil {
-		return nil, err
-	}
-	return checkTreeForUnreviewableBinaries(tree, p.newBinaryChecker())
 }

--- a/data/payload_test.go
+++ b/data/payload_test.go
@@ -51,15 +51,6 @@ func TestGetWorkflowFilesServesCache(t *testing.T) {
 	})
 }
 
-func TestGetTreeServesCache(t *testing.T) {
-	tree := &GraphqlRepoTree{}
-	payload := payloadWithCache(&payloadCache{tree: tree})
-
-	got, err := payload.getTree()
-	require.NoError(t, err)
-	assert.Same(t, tree, got)
-}
-
 // graphqlServer returns a githubv4 client pointed at a stub that answers every
 // query with the supplied JSON body.
 func graphqlServer(t *testing.T, body string) (*githubv4.Client, *int) {

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -102,9 +102,9 @@ func StatusChecksAreRequiredByBranchProtection(payload data.Payload) (result gem
 func NoBinariesInRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// TODO: This only checks the top 3 levels of the repository tree
 	// for common binary file extensions and it fails on very large repositories.
-	suspectedBinaries, err := payload.GetSuspectedBinaries()
-	if err != nil {
-		payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for binaries: %s", err.Error()))
+	suspectedBinaries := payload.Binaries.Suspected
+	if payload.Binaries.Err != nil {
+		payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for binaries: %s", payload.Binaries.Err.Error()))
 		return gemara.Unknown, "Error while scanning repository for binaries, potentially due to repo size. See logs for details.", confidence
 	}
 
@@ -119,11 +119,9 @@ func NoBinariesInRepo(payload data.Payload) (result gemara.Result, message strin
 // artifacts such as compiled executables, shared libraries, or archive binaries.
 // Acceptable binary content (images, audio, video, fonts, PDFs) is not flagged.
 func NoUnreviewableBinariesInRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	unreviewableBinaries, err := payload.GetUnreviewableBinaries()
-	if err != nil {
-		if payload.Config != nil && payload.Config.Logger != nil {
-			payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for unreviewable binaries: %s", err.Error()))
-		}
+	unreviewableBinaries := payload.Binaries.Unreviewable
+	if payload.Binaries.Err != nil {
+		payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for unreviewable binaries: %s", payload.Binaries.Err.Error()))
 		return gemara.Unknown, "Error while scanning repository for unreviewable binaries, potentially due to repo size. See logs for details.", confidence
 	}
 

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -1,12 +1,15 @@
 package quality
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/ossf/si-tooling/v2/si"
+	"github.com/privateerproj/privateer-sdk/config"
 )
 
 func Test_InsightsListsRepositories(t *testing.T) {
@@ -75,16 +78,84 @@ func Test_InsightsListsRepositories(t *testing.T) {
 	}
 }
 
+func Test_NoBinariesInRepo(t *testing.T) {
+	tests := []struct {
+		name       string
+		binaries   data.BinaryAnalysis
+		wantResult gemara.Result
+	}{
+		{
+			name:       "no suspected binaries passes",
+			binaries:   data.BinaryAnalysis{Suspected: nil},
+			wantResult: gemara.Passed,
+		},
+		{
+			name:       "suspected binaries fail",
+			binaries:   data.BinaryAnalysis{Suspected: []string{"a.out"}},
+			wantResult: gemara.Failed,
+		},
+		{
+			name:       "a gather error is unknown, not a false pass",
+			binaries:   data.BinaryAnalysis{Err: errors.New("tree too large")},
+			wantResult: gemara.Unknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := data.Payload{
+				Config:   &config.Config{Logger: hclog.NewNullLogger()},
+				Binaries: tt.binaries,
+			}
+			result, msg, _ := NoBinariesInRepo(payload)
+			if result != tt.wantResult {
+				t.Errorf("result = %v, want %v", result, tt.wantResult)
+			}
+			if msg == "" {
+				t.Error("expected non-empty message")
+			}
+		})
+	}
+}
+
 func Test_NoUnreviewableBinariesInRepo(t *testing.T) {
-	t.Run("invalid payload returns unknown", func(t *testing.T) {
-		result, msg, _ := NoUnreviewableBinariesInRepo(data.Payload{})
-		if result != gemara.Unknown {
-			t.Errorf("result = %v, want Unknown", result)
-		}
-		if msg == "" {
-			t.Error("expected non-empty message for invalid payload")
-		}
-	})
+	tests := []struct {
+		name       string
+		binaries   data.BinaryAnalysis
+		wantResult gemara.Result
+	}{
+		{
+			name:       "no unreviewable binaries passes",
+			binaries:   data.BinaryAnalysis{Unreviewable: nil},
+			wantResult: gemara.Passed,
+		},
+		{
+			name:       "unreviewable binaries fail",
+			binaries:   data.BinaryAnalysis{Unreviewable: []string{"blob.bin"}},
+			wantResult: gemara.Failed,
+		},
+		{
+			name:       "a gather error is unknown, not a false pass",
+			binaries:   data.BinaryAnalysis{Err: errors.New("tree too large")},
+			wantResult: gemara.Unknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := data.Payload{
+				Config:   &config.Config{Logger: hclog.NewNullLogger()},
+				Binaries: tt.binaries,
+			}
+			result, msg, _ := NoUnreviewableBinariesInRepo(payload)
+			if result != tt.wantResult {
+				t.Errorf("result = %v, want %v", result, tt.wantResult)
+			}
+			if msg == "" {
+				t.Error("expected non-empty message")
+			}
+		})
+	}
 }
 
 // fakeRulesetMetadata stubs only the ruleset accessors; embedding the interface


### PR DESCRIPTION
We previously decided that the call for QA-05 binary checks should happen inside of that assessment, because it forms an opinion of sorts. However, the recent feature to parallelize payload API calls make it so we can shave some more time off each plugin call if we retrieve the binary info in the payload.

## Benchmarking

Before:

```
OSPS-QA-05.01                               quality.NoBinariesInRepo                          1.45s    38.5%
OSPS-QA-05.02                               quality.NoUnreviewableBinariesInRepo              8µs      0.0%
```

After:

```
OSPS-QA-05.01                               quality.NoBinariesInRepo                          83ns     0.0%
OSPS-QA-05.02                               quality.NoUnreviewableBinariesInRepo              458ns    0.0%
```