### PR TITLE
fix: report unobservable branch protection as NeedsReview, not Failed

### DIFF
--- a/data/repository_metadata.go
+++ b/data/repository_metadata.go
@@ -17,6 +17,8 @@ type RepositoryMetadata interface {
 	IsDefaultBranchProtectedFromDeletion() *bool
 	HasBranchRules() bool
 	RequiredStatusCheckContexts() []string
+	RulesetsObserved() bool
+	ViewerCanAdminister() bool
 }
 
 type GitHubRepositoryMetadata struct {
@@ -97,6 +99,24 @@ func (r *GitHubRepositoryMetadata) RequiredStatusCheckContexts() []string {
 		}
 	}
 	return contexts
+}
+
+// RulesetsObserved reports whether the ruleset lookup for the default branch
+// actually completed. The rulesets REST API is publicly readable, so a nil
+// value means the fetch failed rather than that no rulesets exist — this lets
+// callers tell "observed, none configured" from "never observed".
+func (r *GitHubRepositoryMetadata) RulesetsObserved() bool {
+	return r.defaultBranchRules != nil
+}
+
+// ViewerCanAdminister reports whether the scanning token holds admin on the
+// repository. GitHub exposes classic branch protection (the GraphQL
+// BranchProtectionRule and RefUpdateRule objects) only to admins; for any other
+// token they come back as zero values indistinguishable from "no protection".
+// Callers gate on this to tell an observed absence of protection apart from an
+// invisible one.
+func (r *GitHubRepositoryMetadata) ViewerCanAdminister() bool {
+	return r.ghRepo.GetPermissions()["admin"]
 }
 
 func (r *GitHubRepositoryMetadata) OrganizationBlogURL() *string {

--- a/data/repository_metadata_test.go
+++ b/data/repository_metadata_test.go
@@ -99,6 +99,75 @@ func TestRequiredStatusCheckContexts(t *testing.T) {
 	}
 }
 
+func TestRulesetsObserved(t *testing.T) {
+	testCases := []struct {
+		name     string
+		rules    *github.BranchRules
+		expected bool
+	}{
+		{
+			name:     "ruleset fetch failed",
+			rules:    nil,
+			expected: false,
+		},
+		{
+			name:     "rulesets fetched, none configured",
+			rules:    &github.BranchRules{},
+			expected: true,
+		},
+		{
+			name: "rulesets fetched and configured",
+			rules: &github.BranchRules{
+				Deletion: []*github.BranchRuleMetadata{{RulesetID: 1}},
+			},
+			expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			metadata := &GitHubRepositoryMetadata{defaultBranchRules: testCase.rules}
+			assert.Equal(t, testCase.expected, metadata.RulesetsObserved())
+		})
+	}
+}
+
+func TestViewerCanAdminister(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ghRepo   *github.Repository
+		expected bool
+	}{
+		{
+			name:     "no repository loaded",
+			ghRepo:   nil,
+			expected: false,
+		},
+		{
+			name:     "no permissions reported",
+			ghRepo:   &github.Repository{},
+			expected: false,
+		},
+		{
+			name:     "non-admin permissions",
+			ghRepo:   &github.Repository{Permissions: map[string]bool{"pull": true, "push": true, "admin": false}},
+			expected: false,
+		},
+		{
+			name:     "admin permissions",
+			ghRepo:   &github.Repository{Permissions: map[string]bool{"admin": true}},
+			expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			metadata := &GitHubRepositoryMetadata{ghRepo: testCase.ghRepo}
+			assert.Equal(t, testCase.expected, metadata.ViewerCanAdminister())
+		})
+	}
+}
+
 func TestLoadRepositoryMetadata(t *testing.T) {
 	testCases := []struct {
 		name              string

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -41,8 +41,8 @@ func BranchProtectionRestrictsPushes(payload data.Payload) (result gemara.Result
 		confidence = gemara.High
 	case metadata.RulesetsObserved() && metadata.ViewerCanAdminister():
 		result = gemara.Failed
-		message = "Default branch is not protected"
-		confidence = gemara.High
+		message = "Found Ruleset, but not protection of the default branch"
+		confidence = gemara.Medium
 	default:
 		result = gemara.NeedsReview
 		message = unobservableProtectionMessage

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -6,47 +6,69 @@ import (
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
+// unobservableProtectionMessage explains why an unprotected-looking default
+// branch is reported as NeedsReview rather than Failed: classic branch
+// protection is only visible to admins, so a non-admin scan cannot tell an
+// unprotected branch from a protected one it simply cannot see.
+const unobservableProtectionMessage = "Default branch protection is not observable with the current token; an admin token or a Security Insights declaration is required to confirm it."
+
+func isTrue(b *bool) bool {
+	return b != nil && *b
+}
+
 func BranchProtectionRestrictsPushes(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	protectionData := payload.Repository.DefaultBranchRef.BranchProtectionRule
+	metadata := payload.RepositoryMetadata
 
-	if protectionData.RestrictsPushes {
+	switch {
+	// Classic branch protection is admin-only, so a non-zero value is a positive
+	// observation of protection regardless of the token's other permissions.
+	case protectionData.RestrictsPushes:
 		result = gemara.Passed
 		message = "Branch protection rule restricts pushes"
-	} else if protectionData.RequiresApprovingReviews {
+		confidence = gemara.High
+	case protectionData.RequiresApprovingReviews:
 		result = gemara.Passed
 		message = "Branch protection rule requires approving reviews"
-	} else {
-		if payload.RepositoryMetadata.IsDefaultBranchProtected() != nil && *payload.RepositoryMetadata.IsDefaultBranchProtected() {
-			result = gemara.Passed
-			message = "Branch rule restricts pushes"
-		} else if payload.RepositoryMetadata.DefaultBranchRequiresPRReviews() != nil && *payload.RepositoryMetadata.DefaultBranchRequiresPRReviews() {
-			result = gemara.Passed
-			message = "Branch rule requires approving reviews"
-		} else {
-			result = gemara.Failed
-			message = "Default branch is not protected"
-		}
+		confidence = gemara.High
+	case isTrue(metadata.IsDefaultBranchProtected()):
+		result = gemara.Passed
+		message = "Branch rule restricts pushes"
+		confidence = gemara.High
+	case isTrue(metadata.DefaultBranchRequiresPRReviews()):
+		result = gemara.Passed
+		message = "Branch rule requires approving reviews"
+		confidence = gemara.High
+	case metadata.RulesetsObserved() && metadata.ViewerCanAdminister():
+		result = gemara.Failed
+		message = "Default branch is not protected"
+		confidence = gemara.High
+	default:
+		result = gemara.NeedsReview
+		message = unobservableProtectionMessage
+		confidence = gemara.Low
 	}
 	return result, message, confidence
 }
 
 func BranchProtectionPreventsDeletion(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	branchProtectionAllowsDeletion := payload.Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions
-	deletionRule := payload.RepositoryMetadata.IsDefaultBranchProtectedFromDeletion()
-	branchRulesAllowDeletion := deletionRule == nil || !*deletionRule
+	metadata := payload.RepositoryMetadata
 
-	if branchProtectionAllowsDeletion && branchRulesAllowDeletion {
-		result = gemara.Failed
-		message = "Default branch is not protected from deletions"
-	} else {
-		result = gemara.Passed
-		if deletionRule != nil && *deletionRule {
-			message = "Default branch is protected from deletions by rulesets"
-		} else {
-			message = "Default branch is protected from deletions by branch protection rules"
-		}
+	// Rulesets are publicly readable, so a positive deletion rule is trustworthy.
+	if isTrue(metadata.IsDefaultBranchProtectedFromDeletion()) {
+		return gemara.Passed, "Default branch is protected from deletions by rulesets", gemara.High
 	}
-	return result, message, confidence
+
+	// A non-admin token reads it as a zero-value false, which must not be
+	// mistaken for "deletions are blocked" — the original false-pass bug.
+	if !metadata.ViewerCanAdminister() {
+		return gemara.NeedsReview, unobservableProtectionMessage, gemara.Low
+	}
+
+	if payload.Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions {
+		return gemara.Failed, "Default branch is not protected from deletions", gemara.High
+	}
+	return gemara.Passed, "Default branch is protected from deletions by branch protection rules", gemara.High
 }
 
 func WorkflowDefaultReadPermissions(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/access_control/steps_test.go
+++ b/evaluation_plans/osps/access_control/steps_test.go
@@ -17,6 +17,8 @@ type FakeBranchRuleMetadata struct {
 	defaultBranchProtected *bool
 	requiresPRReviews      *bool
 	protectedFromDeletion  *bool
+	rulesetsObserved       bool
+	viewerCanAdminister    bool
 }
 
 func (f *FakeBranchRuleMetadata) IsDefaultBranchProtected() *bool {
@@ -29,6 +31,14 @@ func (f *FakeBranchRuleMetadata) DefaultBranchRequiresPRReviews() *bool {
 
 func (f *FakeBranchRuleMetadata) IsDefaultBranchProtectedFromDeletion() *bool {
 	return f.protectedFromDeletion
+}
+
+func (f *FakeBranchRuleMetadata) RulesetsObserved() bool {
+	return f.rulesetsObserved
+}
+
+func (f *FakeBranchRuleMetadata) ViewerCanAdminister() bool {
+	return f.viewerCanAdminister
 }
 
 // See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository
@@ -154,6 +164,7 @@ func Test_BranchProtectionRestrictsPushes(t *testing.T) {
 				GraphqlRepoData: &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{
 					defaultBranchProtected: &trueVal,
+					rulesetsObserved:       true,
 				},
 			},
 			wantResult:  gemara.Passed,
@@ -166,31 +177,48 @@ func Test_BranchProtectionRestrictsPushes(t *testing.T) {
 				RepositoryMetadata: &FakeBranchRuleMetadata{
 					defaultBranchProtected: &falseVal,
 					requiresPRReviews:      &trueVal,
+					rulesetsObserved:       true,
 				},
 			},
 			wantResult:  gemara.Passed,
 			wantMessage: "Branch rule requires approving reviews",
 		},
 		{
-			name: "no branch protection and no ruleset protection",
+			name: "observed unprotected: rulesets visible and empty, admin token",
 			payload: data.Payload{
 				GraphqlRepoData: &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{
 					defaultBranchProtected: &falseVal,
 					requiresPRReviews:      &falseVal,
+					rulesetsObserved:       true,
+					viewerCanAdminister:    true,
 				},
 			},
 			wantResult:  gemara.Failed,
 			wantMessage: "Default branch is not protected",
 		},
 		{
-			name: "no branch protection and no ruleset data",
+			name: "unobservable: rulesets visible and empty but non-admin token",
+			payload: data.Payload{
+				GraphqlRepoData: &data.GraphqlRepoData{},
+				RepositoryMetadata: &FakeBranchRuleMetadata{
+					defaultBranchProtected: &falseVal,
+					requiresPRReviews:      &falseVal,
+					rulesetsObserved:       true,
+					viewerCanAdminister:    false,
+				},
+			},
+			wantResult:  gemara.NeedsReview,
+			wantMessage: unobservableProtectionMessage,
+		},
+		{
+			name: "unobservable: no ruleset data and non-admin token",
 			payload: data.Payload{
 				GraphqlRepoData:    &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{},
 			},
-			wantResult:  gemara.Failed,
-			wantMessage: "Default branch is not protected",
+			wantResult:  gemara.NeedsReview,
+			wantMessage: unobservableProtectionMessage,
 		},
 	}
 
@@ -218,20 +246,23 @@ func Test_BranchProtectionPreventsDeletion(t *testing.T) {
 		wantMessage string
 	}{
 		{
-			name: "branch protection prevents deletion, no rulesets",
+			name: "admin token, branch protection prevents deletion, no rulesets",
 			payload: data.Payload{
-				GraphqlRepoData:    &data.GraphqlRepoData{},
-				RepositoryMetadata: &FakeBranchRuleMetadata{},
+				GraphqlRepoData: &data.GraphqlRepoData{},
+				RepositoryMetadata: &FakeBranchRuleMetadata{
+					viewerCanAdminister: true,
+				},
 			},
 			wantResult:  gemara.Passed,
 			wantMessage: "Default branch is protected from deletions by branch protection rules",
 		},
 		{
-			name: "branch protection prevents deletion, ruleset also prevents deletion",
+			name: "ruleset prevents deletion (trustworthy without admin)",
 			payload: data.Payload{
 				GraphqlRepoData: &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{
 					protectedFromDeletion: &trueVal,
+					rulesetsObserved:      true,
 				},
 			},
 			wantResult:  gemara.Passed,
@@ -243,35 +274,62 @@ func Test_BranchProtectionPreventsDeletion(t *testing.T) {
 				GraphqlRepoData: &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{
 					protectedFromDeletion: &trueVal,
+					rulesetsObserved:      true,
 				},
 			},
 			wantResult:  gemara.Passed,
 			wantMessage: "Default branch is protected from deletions by rulesets",
 		},
 		{
-			name: "branch protection allows deletion and no ruleset data",
-			payload: data.Payload{
-				GraphqlRepoData:    &data.GraphqlRepoData{},
-				RepositoryMetadata: &FakeBranchRuleMetadata{},
-			},
-			wantResult:  gemara.Failed,
-			wantMessage: "Default branch is not protected from deletions",
-		},
-		{
-			name: "branch protection allows deletion and ruleset allows deletion",
+			name: "admin token, branch protection allows deletion, no ruleset protection",
 			payload: data.Payload{
 				GraphqlRepoData: &data.GraphqlRepoData{},
 				RepositoryMetadata: &FakeBranchRuleMetadata{
-					protectedFromDeletion: &falseVal,
+					viewerCanAdminister: true,
 				},
 			},
 			wantResult:  gemara.Failed,
 			wantMessage: "Default branch is not protected from deletions",
 		},
+		{
+			name: "admin token, branch protection allows deletion and ruleset allows deletion",
+			payload: data.Payload{
+				GraphqlRepoData: &data.GraphqlRepoData{},
+				RepositoryMetadata: &FakeBranchRuleMetadata{
+					protectedFromDeletion: &falseVal,
+					rulesetsObserved:      true,
+					viewerCanAdminister:   true,
+				},
+			},
+			wantResult:  gemara.Failed,
+			wantMessage: "Default branch is not protected from deletions",
+		},
+		{
+			name: "false-pass regression: non-admin token, deletion data invisible, no ruleset protection",
+			payload: data.Payload{
+				GraphqlRepoData:    &data.GraphqlRepoData{},
+				RepositoryMetadata: &FakeBranchRuleMetadata{},
+			},
+			wantResult:  gemara.NeedsReview,
+			wantMessage: unobservableProtectionMessage,
+		},
+		{
+			name: "unobservable: non-admin token, ruleset visible without deletion protection",
+			payload: data.Payload{
+				GraphqlRepoData: &data.GraphqlRepoData{},
+				RepositoryMetadata: &FakeBranchRuleMetadata{
+					protectedFromDeletion: &falseVal,
+					rulesetsObserved:      true,
+				},
+			},
+			wantResult:  gemara.NeedsReview,
+			wantMessage: unobservableProtectionMessage,
+		},
 	}
 
-	// AllowsDeletions defaults to false (branch protection prevents deletion)
-	// Set it to true for cases where branch protection allows deletion
+	// AllowsDeletions defaults to false (a visible rule prevents deletion). Set it
+	// to true for the cases where branch protection allows deletion. Indexes track
+	// the tests slice above.
 	tests[2].payload.Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions = true
 	tests[3].payload.Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions = true
 	tests[4].payload.Repository.DefaultBranchRef.RefUpdateRule.AllowsDeletions = true

--- a/evaluation_plans/osps/access_control/steps_test.go
+++ b/evaluation_plans/osps/access_control/steps_test.go
@@ -195,7 +195,7 @@ func Test_BranchProtectionRestrictsPushes(t *testing.T) {
 				},
 			},
 			wantResult:  gemara.Failed,
-			wantMessage: "Default branch is not protected",
+			wantMessage: "Found Ruleset, but not protection of the default branch",
 		},
 		{
 			name: "unobservable: rulesets visible and empty but non-admin token",


### PR DESCRIPTION
**Fixes ~1,900 wrong results** on OSPS-AC-03 — a false-fail *and* a silent false-pass.

The GraphQL `BranchProtectionRule`/`RefUpdateRule` objects are **admin-only**. A non-admin scan reads them as empty and treats that as "unprotected", so AC-03 confidently reported protection state it never actually saw:
- **AC-03.01** — invisible protection → false **Failed** (~1,752 repos).
- **AC-03.02** — invisible deletion protection → silent false **Passed**.

### What changes
- Add two observability signals: `RulesetsObserved` (public rulesets fetch succeeded) and `ViewerCanAdminister` (token can see classic protection).
- Assert a violation **only when protection was actually observable**; otherwise return **NeedsReview** asking for an admin token or a Security Insights declaration.

Tests cover the observed / unobserved / admin / non-admin matrix.

> **Rebase note:** shares `data/repository_metadata.go` (BR-03) and `access_control/steps.go` (AC-04) — second to merge needs a trivial rebase.
