### PR TITLE
feat: pass GV-03 on any observed contribution guide

### DIFF
--- a/data/contribution-lookup.go
+++ b/data/contribution-lookup.go
@@ -1,0 +1,20 @@
+package data
+
+// FindFile returns the repository path of the first of the given filenames found
+// in the repository root or .github directory, matched case-insensitively. It
+// reuses the REST contents fetched during Setup, so once .github has been probed
+// it costs no additional API call. Returns "" when none of the names is present.
+//
+// It exists so evaluation steps in other packages can run deterministic
+// filesystem fallbacks without reaching into RestData's unexported checkFile.
+func (r *RestData) FindFile(names ...string) string {
+	if r == nil {
+		return ""
+	}
+	for _, name := range names {
+		if path := r.checkFile(name); path != "" {
+			return path
+		}
+	}
+	return ""
+}

--- a/data/contribution-lookup_test.go
+++ b/data/contribution-lookup_test.go
@@ -1,0 +1,70 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindFile(t *testing.T) {
+	names := []string{"CONTRIBUTING.md", "CONTRIBUTING", "CONTRIBUTING.rst", "CONTRIBUTING.txt"}
+
+	tests := []struct {
+		name      string
+		toplevel  []*github.RepositoryContent
+		githubDir []*github.RepositoryContent
+		expected  string
+	}{
+		{
+			name: "CONTRIBUTING.md in root",
+			toplevel: []*github.RepositoryContent{
+				{Type: github.Ptr("file"), Name: github.Ptr("CONTRIBUTING.md"), Path: github.Ptr("CONTRIBUTING.md")},
+			},
+			expected: "CONTRIBUTING.md",
+		},
+		{
+			name: "case-insensitive extensionless CONTRIBUTING in root",
+			toplevel: []*github.RepositoryContent{
+				{Type: github.Ptr("file"), Name: github.Ptr("contributing"), Path: github.Ptr("contributing")},
+			},
+			expected: "contributing",
+		},
+		{
+			name:     "CONTRIBUTING.rst in .github",
+			toplevel: []*github.RepositoryContent{},
+			githubDir: []*github.RepositoryContent{
+				{Type: github.Ptr("file"), Name: github.Ptr("CONTRIBUTING.rst"), Path: github.Ptr(".github/CONTRIBUTING.rst")},
+			},
+			expected: ".github/CONTRIBUTING.rst",
+		},
+		{
+			name: "no contribution guide present",
+			toplevel: []*github.RepositoryContent{
+				{Type: github.Ptr("file"), Name: github.Ptr("README.md"), Path: github.Ptr("README.md")},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rest := &RestData{
+				owner: "test-owner",
+				repo:  "test-repo",
+				contents: RepoContent{
+					Content: tt.toplevel,
+					SubContent: map[string]RepoContent{
+						".github": {Content: tt.githubDir},
+					},
+				},
+			}
+			assert.Equal(t, tt.expected, rest.FindFile(names...))
+		})
+	}
+}
+
+func TestFindFileNilReceiver(t *testing.T) {
+	var rest *RestData
+	assert.Equal(t, "", rest.FindFile("CONTRIBUTING.md"))
+}

--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -274,6 +274,12 @@ func (r *RestData) getSubdirContents(path string) (RepoContent, error) {
 	if !strings.Contains(path, "/") && !r.rootHasDir(path) {
 		return RepoContent{}, fmt.Errorf("directory %q not found in repository root", path)
 	}
+	// Production always wires a client through newRestData; guarding here keeps
+	// contents-backed lookups (e.g. checkFile) safe to call in tests that supply
+	// no client rather than panicking on a nil dereference.
+	if r.ghClient == nil {
+		return RepoContent{}, fmt.Errorf("no GitHub client configured; cannot fetch %q", path)
+	}
 	_, content, _, err := r.ghClient.Repositories.GetContents(context.Background(), r.owner, r.repo, path, nil)
 	if err != nil {
 		return RepoContent{}, err

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -1,9 +1,21 @@
 package governance
 
 import (
+	"strings"
+
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
+
+// ContributionGuideFiles are the conventional CONTRIBUTING filenames that GitHub
+// and the OSPS Baseline recognize as a documented contribution process. Matched
+// case-insensitively against repository contents.
+var ContributionGuideFiles = []string{
+	"CONTRIBUTING.md",
+	"CONTRIBUTING",
+	"CONTRIBUTING.rst",
+	"CONTRIBUTING.txt",
+}
 
 func CoreTeamIsListed(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if len(payload.Insights.Repository.CoreTeam) == 0 {
@@ -30,19 +42,56 @@ func HasRolesAndResponsibilities(payload data.Payload) (result gemara.Result, me
 }
 
 func HasContributionGuide(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	if payload.Insights.Project.Documentation.CodeOfConduct != nil && payload.Insights.Repository.Documentation.ContributingGuide != nil {
-		return gemara.Passed, "Contributing guide specified in Security Insights data (Bonus: code of conduct location also specified)", confidence
+	hasCoCLocation := payload.Insights.Project.Documentation.CodeOfConduct != nil
+
+	if hasCoCLocation && payload.Insights.Repository.Documentation.ContributingGuide != nil {
+		return gemara.Passed, "Contributing guide specified in Security Insights data (Bonus: code of conduct location also specified)", gemara.High
 	}
 
-	if payload.Repository.ContributingGuidelines.Body != "" && payload.Insights.Project.Documentation.CodeOfConduct != nil {
-		return gemara.Passed, "Contributing guide was found via GitHub API (Bonus: code of conduct was specified in Security Insights data)", confidence
+	// Fallback: an observed contribution guide satisfies the control's requirement
+	// for a documented contribution process, so it Passes. The code of conduct
+	// location stays a recommendation and never demotes the result.
+	if evidence := contributionGuideEvidence(payload); evidence != "" {
+		if hasCoCLocation {
+			return gemara.Passed, "Contributing guide found via " + evidence + " (Bonus: code of conduct location specified in Security Insights data)", gemara.Medium
+		}
+		return gemara.Passed, "Contributing guide found via " + evidence + " (Recommendation: add code of conduct location to Security Insights data)", gemara.Medium
 	}
 
-	if payload.Repository.ContributingGuidelines.Body != "" {
-		return gemara.NeedsReview, "Contributing guide was found via GitHub API (Recommendation: Add code of conduct location to Security Insights data)", confidence
-	}
+	return gemara.Failed, "Contribution guide not found in Security Insights data or via GitHub API", gemara.Medium
+}
 
-	return gemara.Failed, "Contribution guide not found in Security Insights data or via GitHub API", confidence
+// contributionGuideEvidence reports where a contribution guide was observed, or
+// "" if none was found. It prefers the GitHub contributing-guidelines API, then
+// falls back to a deterministic search of the repository root tree and contents
+// (root and .github) so the many repositories that document contribution without
+// declaring it in Security Insights are still credited.
+func contributionGuideEvidence(payload data.Payload) string {
+	if payload.GraphqlRepoData != nil {
+		if payload.Repository.ContributingGuidelines.Body != "" {
+			return "GitHub contributing-guidelines API"
+		}
+		for _, entry := range payload.Repository.Object.Tree.Entries {
+			if entry.Type == "blob" && isContributionGuideName(entry.Name) {
+				return "GitHub API (repository file " + entry.Path + ")"
+			}
+		}
+	}
+	if payload.RestData != nil {
+		if path := payload.FindFile(ContributionGuideFiles...); path != "" {
+			return "GitHub API (repository file " + path + ")"
+		}
+	}
+	return ""
+}
+
+func isContributionGuideName(name string) bool {
+	for _, candidate := range ContributionGuideFiles {
+		if strings.EqualFold(name, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func HasContributionReviewPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/governance/steps_test.go
+++ b/evaluation_plans/osps/governance/steps_test.go
@@ -1,0 +1,123 @@
+package governance
+
+import (
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/si-tooling/v2/si"
+	"github.com/stretchr/testify/assert"
+)
+
+func stubURL(v string) *si.URL {
+	u := si.URL(v)
+	return &u
+}
+
+func treeEntry(name, entryType, path string) struct {
+	Name string
+	Type string
+	Path string
+} {
+	return struct {
+		Name string
+		Type string
+		Path string
+	}{Name: name, Type: entryType, Path: path}
+}
+
+func TestHasContributionGuide(t *testing.T) {
+	tests := []struct {
+		name            string
+		build           func() data.Payload
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name: "Security Insights declares contributing guide and code of conduct",
+			build: func() data.Payload {
+				p := data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: &data.GraphqlRepoData{}}, nil, 200, nil)
+				p.Insights.Project.Documentation.CodeOfConduct = stubURL("https://example.com/CODE_OF_CONDUCT.md")
+				p.Insights.Repository.Documentation.ContributingGuide = stubURL("https://example.com/CONTRIBUTING.md")
+				return p
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Contributing guide specified in Security Insights data (Bonus: code of conduct location also specified)",
+		},
+		{
+			name: "GitHub contributing-guidelines API body present, no code of conduct",
+			build: func() data.Payload {
+				repo := &data.GraphqlRepoData{}
+				repo.Repository.ContributingGuidelines.Body = "How to contribute"
+				return data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: repo}, nil, 200, nil)
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Contributing guide found via GitHub contributing-guidelines API (Recommendation: add code of conduct location to Security Insights data)",
+		},
+		{
+			name: "GitHub contributing-guidelines API body present, code of conduct declared",
+			build: func() data.Payload {
+				repo := &data.GraphqlRepoData{}
+				repo.Repository.ContributingGuidelines.Body = "How to contribute"
+				p := data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: repo}, nil, 200, nil)
+				p.Insights.Project.Documentation.CodeOfConduct = stubURL("https://example.com/CODE_OF_CONDUCT.md")
+				return p
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Contributing guide found via GitHub contributing-guidelines API (Bonus: code of conduct location specified in Security Insights data)",
+		},
+		{
+			name: "CONTRIBUTING.md observed in root tree, no Security Insights",
+			build: func() data.Payload {
+				repo := &data.GraphqlRepoData{}
+				repo.Repository.Object.Tree.Entries = append(repo.Repository.Object.Tree.Entries,
+					treeEntry("README.md", "blob", "README.md"),
+					treeEntry("CONTRIBUTING.md", "blob", "CONTRIBUTING.md"),
+				)
+				return data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: repo}, nil, 200, nil)
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Contributing guide found via GitHub API (repository file CONTRIBUTING.md) (Recommendation: add code of conduct location to Security Insights data)",
+		},
+		{
+			name: "CONTRIBUTING.rst observed in root tree, case-insensitive",
+			build: func() data.Payload {
+				repo := &data.GraphqlRepoData{}
+				repo.Repository.Object.Tree.Entries = append(repo.Repository.Object.Tree.Entries,
+					treeEntry("contributing.rst", "blob", "docs/contributing.rst"),
+				)
+				return data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: repo}, nil, 200, nil)
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Contributing guide found via GitHub API (repository file docs/contributing.rst) (Recommendation: add code of conduct location to Security Insights data)",
+		},
+		{
+			name: "directory named contributing is not mistaken for a guide",
+			build: func() data.Payload {
+				repo := &data.GraphqlRepoData{}
+				repo.Repository.Object.Tree.Entries = append(repo.Repository.Object.Tree.Entries,
+					treeEntry("CONTRIBUTING", "tree", "CONTRIBUTING"),
+				)
+				return data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: repo}, nil, 200, nil)
+			},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "Contribution guide not found in Security Insights data or via GitHub API",
+		},
+		{
+			name: "nothing observed anywhere",
+			build: func() data.Payload {
+				return data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: &data.GraphqlRepoData{}}, nil, 200, nil)
+			},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "Contribution guide not found in Security Insights data or via GitHub API",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message, _ := HasContributionGuide(test.build())
+			assert.Equal(t, test.expectedResult, result)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}


### PR DESCRIPTION
**Fixes ~1,740/1,850 wrong results** on OSPS-GV-03.

GV-03.01 **Failed** unless a `CONTRIBUTING` file was declared in Security Insights (or NeedsReview'd on the GitHub API body alone) — mislabeling the many repos that just keep a plain `CONTRIBUTING` file.

### What changes
- `HasContributionGuide` falls back to a deterministic search of the root tree and contents (root + `.github`, via new `RestData.FindFile`) for `CONTRIBUTING`(`.md`/`.rst`/`.txt`), and **Passes on any observed guide**.
- Code-of-conduct location becomes a message recommendation, not a demotion. Every message names its evidence source; SI stays primary.

Adds a nil-client guard so contents lookups are test-safe. New lookup + step tests.

> **Rebase note:** shares `data/rest-data.go` and `governance/steps.go` (GV-01) — second to merge needs a trivial rebase.
