### PR TITLE
fix: evaluate observable links for BR-03 when Security Insights is absent

### DIFF
--- a/data/repository_metadata.go
+++ b/data/repository_metadata.go
@@ -11,6 +11,7 @@ import (
 type RepositoryMetadata interface {
 	IsActive() bool
 	IsPublic() bool
+	Homepage() string
 	OrganizationBlogURL() *string
 	IsDefaultBranchProtected() *bool
 	DefaultBranchRequiresPRReviews() *bool
@@ -117,6 +118,13 @@ func (r *GitHubRepositoryMetadata) RulesetsObserved() bool {
 // invisible one.
 func (r *GitHubRepositoryMetadata) ViewerCanAdminister() bool {
 	return r.ghRepo.GetPermissions()["admin"]
+}
+
+// Homepage returns the repository's configured homepage URL, or "" when unset.
+// It is observable without Security Insights and used as a fallback link to
+// evaluate for HTTPS. GetHomepage is nil-safe on a missing repository.
+func (r *GitHubRepositoryMetadata) Homepage() string {
+	return r.ghRepo.GetHomepage()
 }
 
 func (r *GitHubRepositoryMetadata) OrganizationBlogURL() *string {

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -50,7 +50,6 @@ var (
 			reusable_steps.NotImplemented,
 		},
 		"OSPS-BR-03.01": {
-			reusable_steps.HasSecurityInsightsFile,
 			build_release.EnsureInsightsLinksUseHTTPS,
 		},
 		"OSPS-BR-03.02": {

--- a/evaluation_plans/osps/build_release/links_https_test.go
+++ b/evaluation_plans/osps/build_release/links_https_test.go
@@ -11,21 +11,18 @@ import (
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
 
-// mockRepositoryMetadata is a stand-in for data.RepositoryMetadata; only
-// Homepage is meaningful to these tests, the rest satisfy the interface.
+// mockRepositoryMetadata is a stand-in for data.RepositoryMetadata. Embedding
+// the interface keeps the mock compiling as the interface grows; only the
+// methods the links steps actually read are overridden, and any other method
+// panics (nil interface) if a test unexpectedly reaches for it. The links steps
+// read Homepage (observableLinks) and OrganizationBlogURL (getLinks).
 type mockRepositoryMetadata struct {
+	data.RepositoryMetadata
 	homepage string
 }
 
-func (m mockRepositoryMetadata) IsActive() bool                              { return true }
-func (m mockRepositoryMetadata) IsPublic() bool                              { return true }
-func (m mockRepositoryMetadata) Homepage() string                            { return m.homepage }
-func (m mockRepositoryMetadata) OrganizationBlogURL() *string                { return nil }
-func (m mockRepositoryMetadata) IsDefaultBranchProtected() *bool             { return nil }
-func (m mockRepositoryMetadata) DefaultBranchRequiresPRReviews() *bool       { return nil }
-func (m mockRepositoryMetadata) IsDefaultBranchProtectedFromDeletion() *bool { return nil }
-func (m mockRepositoryMetadata) HasBranchRules() bool                        { return false }
-func (m mockRepositoryMetadata) RequiredStatusCheckContexts() []string       { return nil }
+func (m mockRepositoryMetadata) Homepage() string             { return m.homepage }
+func (m mockRepositoryMetadata) OrganizationBlogURL() *string { return nil }
 
 // insightsPresent builds a minimally-initialized Security Insights whose Header
 // URL marks the file as present, matching the state getLinks enumeration needs.

--- a/evaluation_plans/osps/build_release/links_https_test.go
+++ b/evaluation_plans/osps/build_release/links_https_test.go
@@ -1,0 +1,166 @@
+package build_release
+
+import (
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/google/go-github/v74/github"
+	"github.com/ossf/si-tooling/v2/si"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+)
+
+// mockRepositoryMetadata is a stand-in for data.RepositoryMetadata; only
+// Homepage is meaningful to these tests, the rest satisfy the interface.
+type mockRepositoryMetadata struct {
+	homepage string
+}
+
+func (m mockRepositoryMetadata) IsActive() bool                              { return true }
+func (m mockRepositoryMetadata) IsPublic() bool                              { return true }
+func (m mockRepositoryMetadata) Homepage() string                            { return m.homepage }
+func (m mockRepositoryMetadata) OrganizationBlogURL() *string                { return nil }
+func (m mockRepositoryMetadata) IsDefaultBranchProtected() *bool             { return nil }
+func (m mockRepositoryMetadata) DefaultBranchRequiresPRReviews() *bool       { return nil }
+func (m mockRepositoryMetadata) IsDefaultBranchProtectedFromDeletion() *bool { return nil }
+func (m mockRepositoryMetadata) HasBranchRules() bool                        { return false }
+func (m mockRepositoryMetadata) RequiredStatusCheckContexts() []string       { return nil }
+
+// insightsPresent builds a minimally-initialized Security Insights whose Header
+// URL marks the file as present, matching the state getLinks enumeration needs.
+func insightsPresent(homepage *si.URL) si.SecurityInsights {
+	return si.SecurityInsights{
+		Header:  si.Header{URL: si.URL("https://example.com/security-insights.yml")},
+		Project: &si.Project{HomePage: homepage, Documentation: &si.ProjectDocumentation{}},
+		Repository: &si.Repository{
+			ReleaseDetails: &si.ReleaseDetails{},
+		},
+	}
+}
+
+func releasesWithAssetURLs(urls ...string) []data.ReleaseData {
+	var assets []data.ReleaseAsset
+	for _, u := range urls {
+		assets = append(assets, data.ReleaseAsset{DownloadURL: u})
+	}
+	return []data.ReleaseData{{Assets: assets}}
+}
+
+func TestEnsureInsightsLinksUseHTTPS(t *testing.T) {
+	tests := []struct {
+		name           string
+		payload        data.Payload
+		expectedResult gemara.Result
+	}{
+		{
+			// Unchanged behavior: SI present, every declared link is HTTPS.
+			name: "security insights present, all links https",
+			payload: data.Payload{
+				RestData:           &data.RestData{Insights: insightsPresent(nil)},
+				RepositoryMetadata: mockRepositoryMetadata{},
+			},
+			expectedResult: gemara.Passed,
+		},
+		{
+			// Unchanged behavior: SI present with an insecure declared link fails.
+			name: "security insights present, insecure homepage link",
+			payload: data.Payload{
+				RestData:           &data.RestData{Insights: insightsPresent(github.Ptr(si.URL("http://insecure.example.com")))},
+				RepositoryMetadata: mockRepositoryMetadata{},
+			},
+			expectedResult: gemara.Failed,
+		},
+		{
+			// Fallback: no SI, observable homepage and release assets are HTTPS.
+			name: "security insights absent, observable links https",
+			payload: data.Payload{
+				RestData:           &data.RestData{Releases: releasesWithAssetURLs("https://github.com/o/r/releases/download/v1/bin")},
+				RepositoryMetadata: mockRepositoryMetadata{homepage: "https://project.example.com"},
+			},
+			expectedResult: gemara.Passed,
+		},
+		{
+			// Fallback: no SI, an insecure homepage is a real, observed violation.
+			name: "security insights absent, insecure homepage",
+			payload: data.Payload{
+				RestData:           &data.RestData{},
+				RepositoryMetadata: mockRepositoryMetadata{homepage: "http://project.example.com"},
+			},
+			expectedResult: gemara.Failed,
+		},
+		{
+			// Fallback: no SI and nothing observable. GitHub serves the repo over
+			// HTTPS, so an empty observable set is a pass, not a human punt.
+			name: "security insights absent, no observable links",
+			payload: data.Payload{
+				RestData:           &data.RestData{},
+				RepositoryMetadata: mockRepositoryMetadata{},
+			},
+			expectedResult: gemara.Passed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, message, _ := EnsureInsightsLinksUseHTTPS(tt.payload)
+			assert.Equal(t, tt.expectedResult, result, message)
+		})
+	}
+}
+
+func TestDistributionPointsUseHTTPS(t *testing.T) {
+	withDistributionPoints := func(uris ...string) si.SecurityInsights {
+		var points []si.Link
+		for _, u := range uris {
+			points = append(points, si.Link{Uri: u})
+		}
+		return si.SecurityInsights{
+			Repository: &si.Repository{ReleaseDetails: &si.ReleaseDetails{DistributionPoints: points}},
+		}
+	}
+	noDistributionPoints := si.SecurityInsights{
+		Repository: &si.Repository{ReleaseDetails: &si.ReleaseDetails{}},
+	}
+
+	tests := []struct {
+		name           string
+		payload        data.Payload
+		expectedResult gemara.Result
+	}{
+		{
+			// Unchanged: SI declares distribution points, all HTTPS.
+			name:           "security insights distribution points https",
+			payload:        data.Payload{RestData: &data.RestData{Insights: withDistributionPoints("https://dl.example.com/v1")}},
+			expectedResult: gemara.Passed,
+		},
+		{
+			// Unchanged: SI declares an insecure distribution point.
+			name:           "security insights distribution point insecure",
+			payload:        data.Payload{RestData: &data.RestData{Insights: withDistributionPoints("http://dl.example.com/v1")}},
+			expectedResult: gemara.Failed,
+		},
+		{
+			// Fallback: no SI distribution points, release assets are HTTPS.
+			name: "release assets are the observable distribution points",
+			payload: data.Payload{RestData: &data.RestData{
+				Insights: noDistributionPoints,
+				Releases: releasesWithAssetURLs("https://github.com/o/r/releases/download/v1/bin"),
+			}},
+			expectedResult: gemara.Passed,
+		},
+		{
+			// Genuinely nothing to evaluate: no SI entries, no release assets.
+			name:           "no distribution points and no release assets",
+			payload:        data.Payload{RestData: &data.RestData{Insights: noDistributionPoints}},
+			expectedResult: gemara.NotApplicable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, message, _ := DistributionPointsUseHTTPS(tt.payload)
+			assert.Equal(t, tt.expectedResult, result, message)
+		})
+	}
+}

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -362,9 +362,9 @@ func EnsureInsightsLinksUseHTTPS(payload data.Payload) (result gemara.Result, me
 			}
 		}
 		if len(badURIs) > 0 {
-			return gemara.Failed, fmt.Sprintf("The following links do not use HTTPS: %v", strings.Join(badURIs, ", ")), confidence
+			return gemara.Failed, fmt.Sprintf("The following links do not use HTTPS: %v", strings.Join(badURIs, ", ")), gemara.High
 		}
-		return gemara.Passed, "All links use HTTPS", confidence
+		return gemara.Passed, "All links use HTTPS", gemara.High
 	}
 
 	var badURIs []string
@@ -374,9 +374,9 @@ func EnsureInsightsLinksUseHTTPS(payload data.Payload) (result gemara.Result, me
 		}
 	}
 	if len(badURIs) > 0 {
-		return gemara.Failed, "The following observable project links do not use HTTPS: " + strings.Join(badURIs, ", "), confidence
+		return gemara.Failed, "The following observable project links do not use HTTPS: " + strings.Join(badURIs, ", "), gemara.High
 	}
-	return gemara.Passed, "All observable project links use HTTPS (Security Insights not present; checked homepage and release assets)", confidence
+	return gemara.Passed, "All observable project links use HTTPS (Security Insights not present; checked homepage and release assets)", gemara.Medium
 }
 
 func EnsureLatestReleaseHasChangelog(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
@@ -409,9 +409,9 @@ func DistributionPointsUseHTTPS(payload data.Payload) (result gemara.Result, mes
 			}
 		}
 		if len(badURIs) > 0 {
-			return gemara.Failed, fmt.Sprintf("The following distribution points do not use HTTPS: %v", strings.Join(badURIs, ", ")), confidence
+			return gemara.Failed, fmt.Sprintf("The following distribution points do not use HTTPS: %v", strings.Join(badURIs, ", ")), gemara.High
 		}
-		return gemara.Passed, "All distribution points use HTTPS", confidence
+		return gemara.Passed, "All distribution points use HTTPS", gemara.High
 	}
 
 	// Security Insights declares no distribution points. Release assets are the
@@ -436,9 +436,9 @@ func DistributionPointsUseHTTPS(payload data.Payload) (result gemara.Result, mes
 		}
 	}
 	if len(badURIs) > 0 {
-		return gemara.Failed, "The following release asset distribution points do not use HTTPS: " + strings.Join(badURIs, ", "), confidence
+		return gemara.Failed, "The following release asset distribution points do not use HTTPS: " + strings.Join(badURIs, ", "), gemara.High
 	}
-	return gemara.Passed, "All release asset distribution points use HTTPS (checked release assets; Security Insights not present)", confidence
+	return gemara.Passed, "All release asset distribution points use HTTPS (checked release assets; Security Insights not present)", gemara.Medium
 }
 
 func SecretScanningInUse(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -332,18 +332,51 @@ func insecureURI(uri string) bool {
 	return true
 }
 
+// observableLinks returns the project links that can be checked without a
+// Security Insights file: the repository homepage and release asset download
+// URLs. GitHub serves both over HTTPS, so an empty set is not a violation.
+func observableLinks(payload data.Payload) []string {
+	var links []string
+	if homepage := payload.RepositoryMetadata.Homepage(); homepage != "" {
+		links = append(links, homepage)
+	}
+	for _, release := range payload.Releases {
+		for _, asset := range release.Assets {
+			if asset.DownloadURL != "" {
+				links = append(links, asset.DownloadURL)
+			}
+		}
+	}
+	return links
+}
+
 func EnsureInsightsLinksUseHTTPS(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	links := getLinks(payload)
+	// With a Security Insights file, enumerate every declared link. Without one
+	// (the common case), fall back to the directly observable link set rather
+	// than punting to a human for links we can actually see.
+	if payload.Insights.Header.URL != "" {
+		var badURIs []string
+		for _, link := range getLinks(payload) {
+			if insecureURI(link) {
+				badURIs = append(badURIs, link)
+			}
+		}
+		if len(badURIs) > 0 {
+			return gemara.Failed, fmt.Sprintf("The following links do not use HTTPS: %v", strings.Join(badURIs, ", ")), confidence
+		}
+		return gemara.Passed, "All links use HTTPS", confidence
+	}
+
 	var badURIs []string
-	for _, link := range links {
+	for _, link := range observableLinks(payload) {
 		if insecureURI(link) {
 			badURIs = append(badURIs, link)
 		}
 	}
 	if len(badURIs) > 0 {
-		return gemara.Failed, fmt.Sprintf("The following links do not use HTTPS: %v", strings.Join(badURIs, ", ")), confidence
+		return gemara.Failed, "The following observable project links do not use HTTPS: " + strings.Join(badURIs, ", "), confidence
 	}
-	return gemara.Passed, "All links use HTTPS", confidence
+	return gemara.Passed, "All observable project links use HTTPS (Security Insights not present; checked homepage and release assets)", confidence
 }
 
 func EnsureLatestReleaseHasChangelog(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
@@ -368,20 +401,44 @@ func InsightsHasSlsaAttestation(payload data.Payload) (result gemara.Result, mes
 func DistributionPointsUseHTTPS(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	distributionPoints := payload.Insights.Repository.ReleaseDetails.DistributionPoints
 
-	if len(distributionPoints) == 0 {
+	if len(distributionPoints) > 0 {
+		var badURIs []string
+		for _, point := range distributionPoints {
+			if insecureURI(point.Uri) {
+				badURIs = append(badURIs, point.Uri)
+			}
+		}
+		if len(badURIs) > 0 {
+			return gemara.Failed, fmt.Sprintf("The following distribution points do not use HTTPS: %v", strings.Join(badURIs, ", ")), confidence
+		}
+		return gemara.Passed, "All distribution points use HTTPS", confidence
+	}
+
+	// Security Insights declares no distribution points. Release assets are the
+	// observable distribution points, so evaluate those before concluding the
+	// control does not apply.
+	var assetURLs []string
+	for _, release := range payload.Releases {
+		for _, asset := range release.Assets {
+			if asset.DownloadURL != "" {
+				assetURLs = append(assetURLs, asset.DownloadURL)
+			}
+		}
+	}
+	if len(assetURLs) == 0 {
 		return gemara.NotApplicable, "No official distribution points found in Security Insights data", confidence
 	}
 
 	var badURIs []string
-	for _, point := range distributionPoints {
-		if insecureURI(point.Uri) {
-			badURIs = append(badURIs, point.Uri)
+	for _, url := range assetURLs {
+		if insecureURI(url) {
+			badURIs = append(badURIs, url)
 		}
 	}
 	if len(badURIs) > 0 {
-		return gemara.Failed, fmt.Sprintf("The following distribution points do not use HTTPS: %v", strings.Join(badURIs, ", ")), confidence
+		return gemara.Failed, "The following release asset distribution points do not use HTTPS: " + strings.Join(badURIs, ", "), confidence
 	}
-	return gemara.Passed, "All distribution points use HTTPS", confidence
+	return gemara.Passed, "All release asset distribution points use HTTPS (checked release assets; Security Insights not present)", confidence
 }
 
 func SecretScanningInUse(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {


### PR DESCRIPTION
Fixes OSPS-BR-03.

The link check was gated behind `HasSecurityInsightsFile`, so **1,701 of 1,882** repos went to `NeedsReview` for links that are directly observable.

### What changes
- `EnsureInsightsLinksUseHTTPS` handles SI-or-fallback itself: with SI, enumerate declared links; without it, check the observable set (repo homepage + release asset URLs) — Pass when all HTTPS (or none exist, since GitHub is HTTPS-only), Fail on any insecure link.
- `DistributionPointsUseHTTPS` uses release assets as observable distribution points; stays `NotApplicable` only when nothing is observable.
- Drop the `HasSecurityInsightsFile` guard from BR-03.01. Add a `Homepage` accessor.
- Test hygiene: the metadata mock now **embeds** the interface and overrides only what the links steps read — so it no longer breaks when another branch grows the interface (makes this PR order-independent of AC-03).

> **Rebase note:** shares `data/repository_metadata.go` (AC-03), `evaluation-plans.go`, `build_release/steps.go` (BR-04) — second to merge needs a trivial rebase.
