### PR TITLE
feat: recognize dependabot/renovate configs as dependency-management evidence for DO-06

### DIFF
--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -159,6 +159,32 @@ func (r *RestData) checkFile(filename string) (filepath string) {
 	return filepath
 }
 
+// dependencyToolingConfigFiles are the config files read by automated
+// dependency-update tools (Dependabot, Renovate). Their presence is direct
+// evidence a repository manages its dependencies, observable even when
+// security-insights.yml is absent.
+var dependencyToolingConfigFiles = []string{
+	"dependabot.yml",
+	"dependabot.yaml",
+	"renovate.json",
+	"renovate.json5",
+	".renovaterc",
+	".renovaterc.json",
+}
+
+// DependencyToolingConfig returns the path to the first automated
+// dependency-update tool config found in the repository root or .github
+// directory, or "" when none is present. checkFile probes .github
+// case-insensitively, which is where Dependabot configs live.
+func (r *RestData) DependencyToolingConfig() string {
+	for _, filename := range dependencyToolingConfigFiles {
+		if path := r.checkFile(filename); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
 // returns true when a file with case insensitive name matching support.md is found in the root or forge directories or when the readme.md contains a heading named "Support"
 func (r *RestData) HasSupportMarkdown() bool {
 	if r.checkFile("support.md") != "" {

--- a/data/rest_data_mock.go
+++ b/data/rest_data_mock.go
@@ -12,7 +12,18 @@ type ClientMock struct {
 }
 
 func (c *ClientMock) Do(req *http.Request) (*http.Response, error) {
-    return c.Response, c.Err
+	return c.Response, c.Err
+}
+
+// NewRestDataWithContents returns a RestData seeded with canned repository
+// contents so file-presence checks can be exercised without a GitHub client.
+// Pre-populating SubContent (e.g. for ".github") lets checkFile answer from the
+// cache instead of making an API call. Security Insights is initialized to its
+// empty-but-non-nil shape, matching the state Setup leaves it in.
+func NewRestDataWithContents(contents RepoContent) *RestData {
+	r := &RestData{contents: contents}
+	r.ensureInsightsInitialized()
+	return r
 }
 
 func NewPayloadWithHTTPMock(base Payload, body []byte, statusCode int, httpErr error) Payload {

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -103,7 +103,6 @@ var (
 		"OSPS-DO-06.01": {
 			reusable_steps.IsCodeRepo,
 			reusable_steps.HasMadeReleases,
-			reusable_steps.HasSecurityInsightsFile,
 			docs.HasDependencyManagementPolicy,
 		},
 		"OSPS-GV-01.01": {

--- a/evaluation_plans/osps/docs/dependency_policy_test.go
+++ b/evaluation_plans/osps/docs/dependency_policy_test.go
@@ -1,0 +1,84 @@
+package docs
+
+import (
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/google/go-github/v74/github"
+	"github.com/ossf/si-tooling/v2/si"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+)
+
+func file(name, path string) *github.RepositoryContent {
+	return &github.RepositoryContent{
+		Type: github.Ptr("file"),
+		Name: github.Ptr(name),
+		Path: github.Ptr(path),
+	}
+}
+
+func TestHasDependencyManagementPolicy(t *testing.T) {
+	// siWithPolicy declares the policy directly in security-insights.yml.
+	siWithPolicy := &data.RestData{
+		Insights: si.SecurityInsights{
+			Repository: &si.Repository{
+				Documentation: &si.RepositoryDocumentation{
+					DependencyManagementPolicy: github.Ptr(si.URL("https://example.com/dependency-management")),
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		payload        data.Payload
+		expectedResult gemara.Result
+	}{
+		{
+			// Unchanged behavior: a Security Insights declaration passes.
+			name:           "security insights declares the policy",
+			payload:        data.Payload{RestData: siWithPolicy},
+			expectedResult: gemara.Passed,
+		},
+		{
+			// Fallback: Dependabot config lives in .github, found via checkFile.
+			name: "dependabot config in .github is recognized",
+			payload: data.Payload{RestData: data.NewRestDataWithContents(data.RepoContent{
+				SubContent: map[string]data.RepoContent{
+					".github": {Content: []*github.RepositoryContent{
+						file("dependabot.yml", ".github/dependabot.yml"),
+					}},
+				},
+			})},
+			expectedResult: gemara.Passed,
+		},
+		{
+			// Fallback: Renovate config in the repository root.
+			name: "renovate config in repository root is recognized",
+			payload: data.Payload{RestData: data.NewRestDataWithContents(data.RepoContent{
+				Content: []*github.RepositoryContent{
+					file("renovate.json", "renovate.json"),
+				},
+				SubContent: map[string]data.RepoContent{".github": {}},
+			})},
+			expectedResult: gemara.Passed,
+		},
+		{
+			// No declaration and no tooling config: a real, observed absence.
+			name: "no policy and no tooling config fails",
+			payload: data.Payload{RestData: data.NewRestDataWithContents(data.RepoContent{
+				SubContent: map[string]data.RepoContent{".github": {}},
+			})},
+			expectedResult: gemara.Failed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, message, _ := HasDependencyManagementPolicy(tt.payload)
+			assert.Equal(t, tt.expectedResult, result, message)
+		})
+	}
+}

--- a/evaluation_plans/osps/docs/steps.go
+++ b/evaluation_plans/osps/docs/steps.go
@@ -39,11 +39,18 @@ func HasSignatureVerificationGuide(payload data.Payload) (result gemara.Result, 
 }
 
 func HasDependencyManagementPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	if payload.Insights.Repository.Documentation.DependencyManagementPolicy == nil {
-		return gemara.Failed, "Dependency management policy was NOT specified in Security Insights data", confidence
+	if payload.Insights.Repository.Documentation.DependencyManagementPolicy != nil {
+		return gemara.Passed, "Dependency management policy was specified in Security Insights data", gemara.High
 	}
 
-	return gemara.Passed, "Dependency management policy was specified in Security Insights data", confidence
+	// Most repositories lack security-insights.yml. An automated dependency-update
+	// tool config (Dependabot, Renovate) is directly observable evidence that the
+	// repository manages its dependencies, so honor it as a fallback.
+	if configPath := payload.DependencyToolingConfig(); configPath != "" {
+		return gemara.Passed, "Automated dependency-update tooling configuration found in GitHub repository contents: " + configPath, gemara.Medium
+	}
+
+	return gemara.Failed, "Dependency management policy was NOT specified in Security Insights data", gemara.Medium
 }
 
 func HasIdentityVerificationGuide(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {


### PR DESCRIPTION
Fixes OSPS-DO-06 — which today passes **3 of 1,882** repos.

`HasDependencyManagementPolicy` read only `security-insights.yml` (missing on ~93% of repos), and the chain's `HasSecurityInsightsFile` guard capped everything else at `NeedsReview` — so repos that demonstrably manage dependencies still Failed.

### What changes
- Add `RestData.DependencyToolingConfig` — detects Dependabot/Renovate configs (case-insensitive, root + `.github`).
- `HasDependencyManagementPolicy` Passes on that evidence when SI is silent.
- Drop the `HasSecurityInsightsFile` guard from DO-06.01 so the fallback can actually Pass; `IsCodeRepo` and `HasMadeReleases` stay.

Adds a test-only contents seeder. Tests cover Dependabot, Renovate, root vs `.github`, and SI-present.

> **Rebase note:** shares `data/rest-data.go`, `rest_data_mock.go`, `evaluation-plans.go`, `docs/steps.go` with other PRs — second to merge needs a trivial rebase.
