### PR TITLE
fix: scan the full repository tree for binaries with explicit truncation handling

### DIFF
--- a/data/binary_scan_test.go
+++ b/data/binary_scan_test.go
@@ -1,0 +1,146 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests drive the QA-05 accessors through a pre-populated cache so no API
+// call is made. They cover the two behaviors the REST recursive tree adds:
+// full-depth detection and propagation of the truncation flag.
+
+func TestClassifyIsBinary(t *testing.T) {
+	tests := []struct {
+		path string
+		want *bool // nil means "cannot determine"
+	}{
+		{"app.exe", boolPtr(true)},
+		{"lib.so", boolPtr(true)},
+		{"pkg.jar", boolPtr(true)},
+		{"release.tar.gz", boolPtr(true)}, // .gz wins; archives are binary artifacts
+		{"logo.png", boolPtr(true)},       // acceptable media is still binary content
+		{"manual.pdf", boolPtr(true)},
+		{"main.go", boolPtr(false)},
+		{"README.md", boolPtr(false)},
+		{"sbom.spdx.json", boolPtr(false)}, // .json is text; not a binary artifact
+		{"OWNERS", nil},                    // extensionless: cannot determine
+		{"mystery.xyz", nil},               // unknown extension: cannot determine
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := classifyIsBinary(tt.path)
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tt.want, *got)
+		})
+	}
+}
+
+func TestGetSuspectedBinaries(t *testing.T) {
+	tests := []struct {
+		name          string
+		tree          *RepoTree
+		wantPaths     []string
+		wantTruncated bool
+	}{
+		{
+			name: "clean full tree passes with no truncation",
+			tree: &RepoTree{Entries: []RepoTreeEntry{
+				blobPath("README.md", modeNonExecutable),
+				blobPath("cmd/main.go", modeNonExecutable),
+			}},
+			wantPaths:     nil,
+			wantTruncated: false,
+		},
+		{
+			name: "executable binary deeper than three levels is detected",
+			tree: &RepoTree{Entries: []RepoTreeEntry{
+				dirPath("a"),
+				blobPath("a/b/c/d/tool.exe", modeExecutable),
+			}},
+			wantPaths:     []string{"a/b/c/d/tool.exe"},
+			wantTruncated: false,
+		},
+		{
+			name: "clean scan over a truncated tree reports truncation",
+			tree: &RepoTree{
+				Truncated: true,
+				Entries:   []RepoTreeEntry{blobPath("README.md", modeNonExecutable)},
+			},
+			wantPaths:     nil,
+			wantTruncated: true,
+		},
+		{
+			name: "a finding on a truncated tree still surfaces the finding",
+			tree: &RepoTree{
+				Truncated: true,
+				Entries:   []RepoTreeEntry{blobPath("bin/app.exe", modeExecutable)},
+			},
+			wantPaths:     []string{"bin/app.exe"},
+			wantTruncated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := payloadWithCache(&payloadCache{tree: tt.tree})
+			paths, truncated, err := payload.GetSuspectedBinaries()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPaths, paths)
+			assert.Equal(t, tt.wantTruncated, truncated)
+		})
+	}
+}
+
+func TestGetUnreviewableBinaries(t *testing.T) {
+	tests := []struct {
+		name          string
+		tree          *RepoTree
+		wantPaths     []string
+		wantTruncated bool
+	}{
+		{
+			name: "acceptable binaries and text are not flagged",
+			tree: &RepoTree{Entries: []RepoTreeEntry{
+				blobPath("assets/logo.png", modeNonExecutable),
+				blobPath("docs/manual.pdf", modeNonExecutable),
+				blobPath("README.md", modeNonExecutable),
+			}},
+			wantPaths:     nil,
+			wantTruncated: false,
+		},
+		{
+			name: "unreviewable binary deeper than three levels is detected",
+			tree: &RepoTree{Entries: []RepoTreeEntry{
+				blobPath("vendor/a/b/c/lib.so", modeNonExecutable),
+			}},
+			wantPaths:     []string{"vendor/a/b/c/lib.so"},
+			wantTruncated: false,
+		},
+		{
+			name: "clean scan over a truncated tree reports truncation",
+			tree: &RepoTree{
+				Truncated: true,
+				Entries:   []RepoTreeEntry{blobPath("main.go", modeNonExecutable)},
+			},
+			wantPaths:     nil,
+			wantTruncated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := payloadWithCache(&payloadCache{tree: tt.tree})
+			paths, truncated, err := payload.GetUnreviewableBinaries()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPaths, paths)
+			assert.Equal(t, tt.wantTruncated, truncated)
+		})
+	}
+}

--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -6,62 +6,30 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gabriel-vasile/mimetype"
+	"github.com/google/go-github/v74/github"
 	"github.com/hashicorp/go-hclog"
-	"github.com/privateerproj/privateer-sdk/config"
-	"github.com/shurcooL/githubv4"
 )
 
-type GraphqlRepoTree struct {
-	Repository struct {
-		Object struct {
-			Tree struct {
-				Entries []struct {
-					Name   string
-					Type   string
-					Path   string
-					Mode   int
-					Object *struct {
-						Blob struct {
-							IsBinary    *bool
-							IsTruncated bool
-						} `graphql:"... on Blob"`
-						Tree struct {
-							Entries []struct {
-								Name   string
-								Type   string
-								Path   string
-								Mode   int
-								Object *struct {
-									Blob struct {
-										IsBinary    *bool
-										IsTruncated bool
-									} `graphql:"... on Blob"`
-									Tree struct {
-										Entries []struct {
-											Name   string
-											Type   string
-											Path   string
-											Mode   int
-											Object *struct {
-												Blob struct {
-													IsBinary    *bool
-													IsTruncated bool
-												} `graphql:"... on Blob"`
-											} `graphql:"object"`
-										}
-									} `graphql:"... on Tree"`
-								} `graphql:"object"`
-							}
-						} `graphql:"... on Tree"`
-					} `graphql:"object"`
-				}
-			} `graphql:"... on Tree"`
-		} `graphql:"object(expression: $branch)"`
-	} `graphql:"repository(owner: $owner, name: $name)"`
+// RepoTree is the full repository file tree fetched in a single REST call. Unlike
+// the old depth-limited GraphQL tree, it covers every level. Truncated is set by
+// GitHub when the repository has too many entries to return in one response, in
+// which case Entries is a partial listing and a clean scan is not conclusive.
+type RepoTree struct {
+	Entries   []RepoTreeEntry
+	Truncated bool
+}
+
+// RepoTreeEntry is a single node in the repository tree. Mode is the parsed octal
+// file mode (e.g. 0o100755 for an executable); Type is "blob" or "tree".
+type RepoTreeEntry struct {
+	Path string
+	Mode int
+	Type string
 }
 
 type binaryChecker struct {
@@ -257,80 +225,112 @@ func (bc *binaryChecker) checkUnreviewable(isBinaryPtr *bool, isTruncated bool, 
 // blobCheckFn inspects a single blob entry and returns whether it should be flagged.
 type blobCheckFn func(isBinary *bool, isTruncated bool, path string, mode int) (bool, error)
 
-// walkTree walks the GraphQL repository tree (up to 3 levels deep) and returns
-// the names of blob entries for which fn returns true.
-// TODO: The current GraphQL query only fetches 3 levels of nesting.
-// Additional API calls will be required for recursion into deeper subtrees.
-func walkTree(tree *GraphqlRepoTree, fn blobCheckFn) (flagged []string, err error) {
+// binaryArtifactExtensions are file extensions of compiled executables, object
+// files, libraries, and archives — content that is a binary artifact rather than
+// reviewable source. Acceptable binary formats (images, audio, video, fonts,
+// PDFs) are intentionally excluded here and handled by acceptableBinaryExtension.
+var binaryArtifactExtensions = []string{
+	// Executables and installers
+	".exe", ".out", ".app", ".msi", ".apk", ".aab", ".dmg", ".pkg", ".deb", ".rpm",
+	// Object files, libraries, and other compiled artifacts
+	".dll", ".so", ".dylib", ".a", ".lib", ".o", ".obj", ".class", ".jar", ".war",
+	".ear", ".wasm", ".bin", ".node", ".ko", ".elf", ".nupkg", ".whl", ".egg",
+	".pyc", ".pyo", ".jmod",
+	// Archives (opaque, unreviewable containers)
+	".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z", ".rar", ".iso",
+}
+
+func binaryArtifactExtension(path string) bool {
+	ext := fileExtension(path)
+	if ext == "" {
+		return false
+	}
+	return slices.Contains(binaryArtifactExtensions, ext)
+}
+
+// classifyIsBinary infers a blob's binary status from its extension, standing in
+// for GitHub's GraphQL IsBinary field, which the REST tree endpoint does not
+// provide. It returns a definitive true for known binary/media extensions and
+// false for known text extensions; an unknown extension yields nil, which the
+// checkers treat as "cannot determine" and leave unflagged. Detection is
+// extension-based so the tree scan needs no per-file content fetch.
+func classifyIsBinary(path string) *bool {
+	binary := true
+	notBinary := false
+	if binaryArtifactExtension(path) || acceptableBinaryExtension(path) {
+		return &binary
+	}
+	if commonAcceptableFileExtension(path) {
+		return &notBinary
+	}
+	return nil
+}
+
+// scanTree applies fn to every blob in the tree and returns the paths of blobs
+// for which fn returns true. It reads the flat REST tree, so files at any depth
+// are covered. isTruncated is always false here: the REST tree carries no blob
+// content to inspect, and detection relies on the extension classifier rather
+// than per-file fetches.
+func scanTree(tree *RepoTree, fn blobCheckFn) (flagged []string, err error) {
 	if tree == nil {
 		return nil, nil
 	}
-	for _, entry := range tree.Repository.Object.Tree.Entries {
-		if entry.Type == "blob" && entry.Object != nil {
-			ok, err := fn(entry.Object.Blob.IsBinary, entry.Object.Blob.IsTruncated, entry.Path, entry.Mode)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				flagged = append(flagged, entry.Name)
-			}
+	for _, entry := range tree.Entries {
+		if entry.Type != "blob" {
+			continue
 		}
-		if entry.Type == "tree" && entry.Object != nil {
-			for _, subEntry := range entry.Object.Tree.Entries {
-				if subEntry.Type == "blob" && subEntry.Object != nil {
-					ok, err := fn(subEntry.Object.Blob.IsBinary, subEntry.Object.Blob.IsTruncated, subEntry.Path, subEntry.Mode)
-					if err != nil {
-						return nil, err
-					}
-					if ok {
-						flagged = append(flagged, subEntry.Name)
-					}
-				}
-				if subEntry.Type == "tree" && subEntry.Object != nil {
-					for _, subSubEntry := range subEntry.Object.Tree.Entries {
-						if subSubEntry.Type == "blob" && subSubEntry.Object != nil {
-							ok, err := fn(subSubEntry.Object.Blob.IsBinary, subSubEntry.Object.Blob.IsTruncated, subSubEntry.Path, subSubEntry.Mode)
-							if err != nil {
-								return nil, err
-							}
-							if ok {
-								flagged = append(flagged, subSubEntry.Name)
-							}
-						}
-						// TODO: The current GraphQL call stops after 3 levels of depth.
-						// Additional API calls will be required for recursion if another tree is found.
-					}
-				}
-			}
+		ok, err := fn(classifyIsBinary(entry.Path), false, entry.Path, entry.Mode)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			flagged = append(flagged, entry.Path)
 		}
 	}
 	return flagged, nil
 }
 
-// checkTreeForUnreviewableBinaries returns file names that are unreviewable binary
-// artifacts (OSPS-QA-05.02), excluding acceptable formats like images, audio, and fonts.
-func checkTreeForUnreviewableBinaries(tree *GraphqlRepoTree, bc *binaryChecker) ([]string, error) {
-	return walkTree(tree, func(isBinary *bool, isTruncated bool, path string, _ int) (bool, error) {
+// checkTreeForUnreviewableBinaries returns paths of unreviewable binary artifacts
+// (OSPS-QA-05.02), excluding acceptable formats like images, audio, and fonts.
+func checkTreeForUnreviewableBinaries(tree *RepoTree, bc *binaryChecker) ([]string, error) {
+	return scanTree(tree, func(isBinary *bool, isTruncated bool, path string, _ int) (bool, error) {
 		return bc.checkUnreviewable(isBinary, isTruncated, path)
 	})
 }
 
-func checkTreeForBinaries(tree *GraphqlRepoTree, bc *binaryChecker) ([]string, error) {
-	return walkTree(tree, bc.check)
+// checkTreeForBinaries returns paths of suspected executable binary artifacts
+// (OSPS-QA-05.01).
+func checkTreeForBinaries(tree *RepoTree, bc *binaryChecker) ([]string, error) {
+	return scanTree(tree, bc.check)
 }
 
-func fetchGraphqlRepoTree(config *config.Config, client *githubv4.Client, branch string) (tree *GraphqlRepoTree, err error) {
-	path := ""
-
-	fullPath := fmt.Sprintf("%s:%s", branch, path)
-
-	variables := map[string]any{
-		"owner":  githubv4.String(config.GetString("owner")),
-		"name":   githubv4.String(config.GetString("repo")),
-		"branch": githubv4.String(fullPath),
+// fetchRestRepoTree retrieves the entire repository tree in a single REST call
+// (git/trees/{ref}?recursive=1). This replaces the depth-limited GraphQL tree
+// query: it covers every level and reports GitHub's truncation flag when the
+// repository is too large to return in full, rather than failing outright.
+func fetchRestRepoTree(ghClient *github.Client, owner, repo, ref string) (*RepoTree, error) {
+	ghTree, _, err := ghClient.Git.GetTree(context.Background(), owner, repo, ref, true)
+	if err != nil {
+		return nil, err
 	}
 
-	err = client.Query(context.Background(), &tree, variables)
-
-	return tree, err
+	tree := &RepoTree{Truncated: ghTree.GetTruncated()}
+	for _, entry := range ghTree.Entries {
+		if entry == nil {
+			continue
+		}
+		mode := 0
+		if m := entry.GetMode(); m != "" {
+			// Git tree modes are octal strings such as "100755".
+			if parsed, perr := strconv.ParseInt(m, 8, 32); perr == nil {
+				mode = int(parsed)
+			}
+		}
+		tree.Entries = append(tree.Entries, RepoTreeEntry{
+			Path: entry.GetPath(),
+			Mode: mode,
+			Type: entry.GetType(),
+		})
+	}
+	return tree, nil
 }

--- a/data/graphql-binary-check_test.go
+++ b/data/graphql-binary-check_test.go
@@ -24,7 +24,7 @@ func TestCheckTreeForBinaries(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		tree     *GraphqlRepoTree
+		tree     *RepoTree
 		expected []string
 	}{
 		{
@@ -34,63 +34,61 @@ func TestCheckTreeForBinaries(t *testing.T) {
 		},
 		{
 			name:     "empty tree returns no binaries",
-			tree:     &GraphqlRepoTree{},
+			tree:     &RepoTree{},
 			expected: nil,
 		},
 		{
 			name: "text files are not flagged as binary",
-			tree: buildTree([]testEntry{
-				{name: "README.md", isBinary: boolPtr(false)},
-				{name: "LICENSE", isBinary: boolPtr(false)},
-				{name: "OWNERS", isBinary: boolPtr(false)},
-				{name: "Tiltfile", isBinary: boolPtr(false)},
-			}),
+			tree: buildRepoTree(
+				blobPath("README.md", modeNonExecutable),
+				blobPath("main.go", modeNonExecutable),
+				blobPath("LICENSE", modeNonExecutable),
+			),
 			expected: nil,
 		},
 		{
-			name: "executable binary files are correctly detected",
-			tree: buildTree([]testEntry{
-				{name: "app.jar", isBinary: boolPtr(true), mode: modeExecutable},
-				{name: "README.md", isBinary: boolPtr(false)},
-			}),
+			name: "executable binary files are detected",
+			tree: buildRepoTree(
+				blobPath("app.jar", modeExecutable),
+				blobPath("README.md", modeNonExecutable),
+			),
 			expected: []string{"app.jar"},
 		},
 		{
 			name: "multiple executable binary files detected",
-			tree: buildTree([]testEntry{
-				{name: "app.exe", isBinary: boolPtr(true), mode: modeExecutable},
-				{name: "lib.dll", isBinary: boolPtr(true), mode: modeExecutable},
-				{name: "main.go", isBinary: boolPtr(false)},
-			}),
+			tree: buildRepoTree(
+				blobPath("app.exe", modeExecutable),
+				blobPath("lib.dll", modeExecutable),
+				blobPath("main.go", modeNonExecutable),
+			),
 			expected: []string{"app.exe", "lib.dll"},
 		},
 		{
-			name: "nested executable binary files detected",
-			tree: buildTreeWithNested(
-				[]testEntry{{name: "README.md", isBinary: boolPtr(false)}},
-				[]testEntry{{name: "wrapper.jar", isBinary: boolPtr(true), mode: modeExecutable}},
-			),
-			expected: []string{"wrapper.jar"},
-		},
-		{
+			// 05.01 only flags binaries that also carry an execute bit.
 			name: "non-executable binary files not flagged",
-			tree: buildTree([]testEntry{
-				{name: "logo.png", isBinary: boolPtr(true), mode: modeNonExecutable},
-				{name: "diagram.pdf", isBinary: boolPtr(true), mode: modeNonExecutable},
-				{name: "README.md", isBinary: boolPtr(false)},
-			}),
+			tree: buildRepoTree(
+				blobPath("app.exe", modeNonExecutable),
+				blobPath("logo.png", modeNonExecutable),
+				blobPath("diagram.pdf", modeNonExecutable),
+			),
 			expected: nil,
 		},
 		{
-			name: "extensionless text files not flagged",
-			tree: buildTree([]testEntry{
-				{name: "OWNERS", isBinary: boolPtr(false)},
-				{name: "OWNERS_ALIASES", isBinary: boolPtr(false)},
-				{name: "SECURITY_CONTACTS", isBinary: boolPtr(false)},
-				{name: "Tiltfile", isBinary: boolPtr(false)},
-				{name: "dockerignore", isBinary: boolPtr(false)},
-				{name: "TECHNICAL_ADVISORY_MEMBERS", isBinary: boolPtr(false)},
-			}),
+			// The whole point of the REST recursive tree: depth beyond 3 is covered.
+			name: "deeply nested executable binary detected",
+			tree: buildRepoTree(
+				blobPath("README.md", modeNonExecutable),
+				dirPath("cmd"),
+				blobPath("cmd/tool/dist/build/app.exe", modeExecutable),
+			),
+			expected: []string{"cmd/tool/dist/build/app.exe"},
+		},
+		{
+			name: "extensionless files not flagged",
+			tree: buildRepoTree(
+				blobPath("OWNERS", modeNonExecutable),
+				blobPath("Dockerfile", modeNonExecutable),
+			),
 			expected: nil,
 		},
 	}
@@ -98,7 +96,6 @@ func TestCheckTreeForBinaries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := checkTreeForBinaries(tt.tree, bc)
-			// TODO: Add expected error test cases
 			if err != nil {
 				t.Errorf("checkTreeForBinaries() error = %v", err)
 				return
@@ -118,7 +115,6 @@ func TestCheckTreeForBinaries(t *testing.T) {
 		})
 	}
 }
-
 func TestBinaryCheckerIsBinary(t *testing.T) {
 	bc := &binaryChecker{logger: hclog.NewNullLogger()}
 
@@ -486,246 +482,16 @@ func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.transport.RoundTrip(req)
 }
 
-type testEntry struct {
-	name     string
-	isBinary *bool
-	mode     int
+func blobPath(path string, mode int) RepoTreeEntry {
+	return RepoTreeEntry{Path: path, Mode: mode, Type: "blob"}
 }
 
-func buildTree(entries []testEntry) *GraphqlRepoTree {
-	tree := &GraphqlRepoTree{}
-
-	for _, e := range entries {
-		entry := struct {
-			Name   string
-			Type   string
-			Path   string
-			Mode   int
-			Object *struct {
-				Blob struct {
-					IsBinary    *bool
-					IsTruncated bool
-				} `graphql:"... on Blob"`
-				Tree struct {
-					Entries []struct {
-						Name   string
-						Type   string
-						Path   string
-						Mode   int
-						Object *struct {
-							Blob struct {
-								IsBinary    *bool
-								IsTruncated bool
-							} `graphql:"... on Blob"`
-							Tree struct {
-								Entries []struct {
-									Name   string
-									Type   string
-									Path   string
-									Mode   int
-									Object *struct {
-										Blob struct {
-											IsBinary    *bool
-											IsTruncated bool
-										} `graphql:"... on Blob"`
-									} `graphql:"object"`
-								}
-							} `graphql:"... on Tree"`
-						} `graphql:"object"`
-					}
-				} `graphql:"... on Tree"`
-			} `graphql:"object"`
-		}{
-			Name: e.name,
-			Type: "blob",
-			Path: e.name,
-			Mode: e.mode,
-		}
-		entry.Object = &struct {
-			Blob struct {
-				IsBinary    *bool
-				IsTruncated bool
-			} `graphql:"... on Blob"`
-			Tree struct {
-				Entries []struct {
-					Name   string
-					Type   string
-					Path   string
-					Mode   int
-					Object *struct {
-						Blob struct {
-							IsBinary    *bool
-							IsTruncated bool
-						} `graphql:"... on Blob"`
-						Tree struct {
-							Entries []struct {
-								Name   string
-								Type   string
-								Path   string
-								Mode   int
-								Object *struct {
-									Blob struct {
-										IsBinary    *bool
-										IsTruncated bool
-									} `graphql:"... on Blob"`
-								} `graphql:"object"`
-							}
-						} `graphql:"... on Tree"`
-					} `graphql:"object"`
-				}
-			} `graphql:"... on Tree"`
-		}{}
-		entry.Object.Blob.IsBinary = e.isBinary
-
-		tree.Repository.Object.Tree.Entries = append(tree.Repository.Object.Tree.Entries, entry)
-	}
-
-	return tree
+func dirPath(path string) RepoTreeEntry {
+	return RepoTreeEntry{Path: path, Type: "tree"}
 }
 
-func buildTreeWithNested(rootEntries []testEntry, subEntries []testEntry) *GraphqlRepoTree {
-	tree := buildTree(rootEntries)
-
-	dirEntry := struct {
-		Name   string
-		Type   string
-		Path   string
-		Mode   int
-		Object *struct {
-			Blob struct {
-				IsBinary    *bool
-				IsTruncated bool
-			} `graphql:"... on Blob"`
-			Tree struct {
-				Entries []struct {
-					Name   string
-					Type   string
-					Path   string
-					Mode   int
-					Object *struct {
-						Blob struct {
-							IsBinary    *bool
-							IsTruncated bool
-						} `graphql:"... on Blob"`
-						Tree struct {
-							Entries []struct {
-								Name   string
-								Type   string
-								Path   string
-								Mode   int
-								Object *struct {
-									Blob struct {
-										IsBinary    *bool
-										IsTruncated bool
-									} `graphql:"... on Blob"`
-								} `graphql:"object"`
-							}
-						} `graphql:"... on Tree"`
-					} `graphql:"object"`
-				}
-			} `graphql:"... on Tree"`
-		} `graphql:"object"`
-	}{
-		Name: "subdir",
-		Type: "tree",
-		Path: "subdir",
-	}
-
-	dirEntry.Object = &struct {
-		Blob struct {
-			IsBinary    *bool
-			IsTruncated bool
-		} `graphql:"... on Blob"`
-		Tree struct {
-			Entries []struct {
-				Name   string
-				Type   string
-				Path   string
-				Mode   int
-				Object *struct {
-					Blob struct {
-						IsBinary    *bool
-						IsTruncated bool
-					} `graphql:"... on Blob"`
-					Tree struct {
-						Entries []struct {
-							Name   string
-							Type   string
-							Path   string
-							Mode   int
-							Object *struct {
-								Blob struct {
-									IsBinary    *bool
-									IsTruncated bool
-								} `graphql:"... on Blob"`
-							} `graphql:"object"`
-						}
-					} `graphql:"... on Tree"`
-				} `graphql:"object"`
-			}
-		} `graphql:"... on Tree"`
-	}{}
-
-	for _, e := range subEntries {
-		subEntry := struct {
-			Name   string
-			Type   string
-			Path   string
-			Mode   int
-			Object *struct {
-				Blob struct {
-					IsBinary    *bool
-					IsTruncated bool
-				} `graphql:"... on Blob"`
-				Tree struct {
-					Entries []struct {
-						Name   string
-						Type   string
-						Path   string
-						Mode   int
-						Object *struct {
-							Blob struct {
-								IsBinary    *bool
-								IsTruncated bool
-							} `graphql:"... on Blob"`
-						} `graphql:"object"`
-					}
-				} `graphql:"... on Tree"`
-			} `graphql:"object"`
-		}{
-			Name: e.name,
-			Type: "blob",
-			Path: "subdir/" + e.name,
-			Mode: e.mode,
-		}
-		subEntry.Object = &struct {
-			Blob struct {
-				IsBinary    *bool
-				IsTruncated bool
-			} `graphql:"... on Blob"`
-			Tree struct {
-				Entries []struct {
-					Name   string
-					Type   string
-					Path   string
-					Mode   int
-					Object *struct {
-						Blob struct {
-							IsBinary    *bool
-							IsTruncated bool
-						} `graphql:"... on Blob"`
-					} `graphql:"object"`
-				}
-			} `graphql:"... on Tree"`
-		}{}
-		subEntry.Object.Blob.IsBinary = e.isBinary
-
-		dirEntry.Object.Tree.Entries = append(dirEntry.Object.Tree.Entries, subEntry)
-	}
-
-	tree.Repository.Object.Tree.Entries = append(tree.Repository.Object.Tree.Entries, dirEntry)
-
-	return tree
+func buildRepoTree(entries ...RepoTreeEntry) *RepoTree {
+	return &RepoTree{Entries: entries}
 }
 
 func TestAcceptableBinaryExtension(t *testing.T) {
@@ -930,7 +696,7 @@ func TestCheckTreeForUnreviewableBinaries(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		tree     *GraphqlRepoTree
+		tree     *RepoTree
 		expected []string
 	}{
 		{
@@ -939,67 +705,56 @@ func TestCheckTreeForUnreviewableBinaries(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name:     "empty tree returns no binaries",
-			tree:     &GraphqlRepoTree{},
-			expected: nil,
-		},
-		{
 			name: "text files not flagged",
-			tree: buildTree([]testEntry{
-				{name: "README.md", isBinary: boolPtr(false)},
-				{name: "main.go", isBinary: boolPtr(false)},
-			}),
+			tree: buildRepoTree(
+				blobPath("README.md", modeNonExecutable),
+				blobPath("main.go", modeNonExecutable),
+			),
 			expected: nil,
 		},
 		{
 			name: "acceptable binary files not flagged",
-			tree: buildTree([]testEntry{
-				{name: "logo.png", isBinary: boolPtr(true), mode: modeNonExecutable},
-				{name: "icon.ico", isBinary: boolPtr(true), mode: modeNonExecutable},
-				{name: "doc.pdf", isBinary: boolPtr(true), mode: modeNonExecutable},
-			}),
+			tree: buildRepoTree(
+				blobPath("logo.png", modeNonExecutable),
+				blobPath("icon.ico", modeNonExecutable),
+				blobPath("doc.pdf", modeNonExecutable),
+				blobPath("font.woff2", modeNonExecutable),
+			),
 			expected: nil,
 		},
 		{
+			// Unreviewable artifacts are flagged regardless of the execute bit.
 			name: "unreviewable binary files flagged",
-			tree: buildTree([]testEntry{
-				{name: "app.jar", isBinary: boolPtr(true), mode: modeNonExecutable},
-				{name: "lib.dll", isBinary: boolPtr(true), mode: modeNonExecutable},
-				{name: "README.md", isBinary: boolPtr(false)},
-			}),
-			expected: []string{"app.jar", "lib.dll"},
+			tree: buildRepoTree(
+				blobPath("app.jar", modeNonExecutable),
+				blobPath("lib.dll", modeNonExecutable),
+				blobPath("bundle.zip", modeNonExecutable),
+				blobPath("README.md", modeNonExecutable),
+			),
+			expected: []string{"app.jar", "lib.dll", "bundle.zip"},
 		},
 		{
 			name: "mix of acceptable and unreviewable binaries",
-			tree: buildTree([]testEntry{
-				{name: "logo.png", isBinary: boolPtr(true), mode: modeNonExecutable},
-				{name: "app.exe", isBinary: boolPtr(true), mode: modeExecutable},
-				{name: "font.woff2", isBinary: boolPtr(true), mode: modeNonExecutable},
-			}),
+			tree: buildRepoTree(
+				blobPath("logo.png", modeNonExecutable),
+				blobPath("app.exe", modeExecutable),
+				blobPath("font.woff2", modeNonExecutable),
+			),
 			expected: []string{"app.exe"},
 		},
 		{
-			name: "nested unreviewable binary detected",
-			tree: buildTreeWithNested(
-				[]testEntry{{name: "README.md", isBinary: boolPtr(false)}},
-				[]testEntry{{name: "wrapper.jar", isBinary: boolPtr(true), mode: modeNonExecutable}},
+			// Deep artifacts the old 3-level scan could not reach.
+			name: "deeply nested unreviewable binary detected",
+			tree: buildRepoTree(
+				blobPath("README.md", modeNonExecutable),
+				blobPath("vendor/a/b/c/d/hidden.so", modeNonExecutable),
 			),
-			expected: []string{"wrapper.jar"},
-		},
-		{
-			name: "level 3 nested unreviewable binary detected",
-			tree: buildTreeWithLevel3(
-				[]testEntry{{name: "README.md", isBinary: boolPtr(false)}},
-				[]testEntry{},
-				[]testEntry{{name: "hidden.dll", isBinary: boolPtr(true), mode: modeNonExecutable}},
-			),
-			expected: []string{"hidden.dll"},
+			expected: []string{"vendor/a/b/c/d/hidden.so"},
 		},
 		{
 			name: "acceptable binary in nested subtree not flagged",
-			tree: buildTreeWithNested(
-				[]testEntry{},
-				[]testEntry{{name: "photo.jpg", isBinary: boolPtr(true), mode: modeNonExecutable}},
+			tree: buildRepoTree(
+				blobPath("assets/img/deep/photo.jpg", modeNonExecutable),
 			),
 			expected: nil,
 		},
@@ -1027,101 +782,6 @@ func TestCheckTreeForUnreviewableBinaries(t *testing.T) {
 		})
 	}
 }
-
-func buildTreeWithLevel3(rootEntries []testEntry, level2Entries []testEntry, level3Entries []testEntry) *GraphqlRepoTree {
-	tree := buildTreeWithNested(rootEntries, level2Entries)
-
-	// Find the "subdir" tree entry added by buildTreeWithNested
-	for i := range tree.Repository.Object.Tree.Entries {
-		if tree.Repository.Object.Tree.Entries[i].Type == "tree" {
-			// Add a sub-subtree inside it
-			subDirEntry := struct {
-				Name   string
-				Type   string
-				Path   string
-				Mode   int
-				Object *struct {
-					Blob struct {
-						IsBinary    *bool
-						IsTruncated bool
-					} `graphql:"... on Blob"`
-					Tree struct {
-						Entries []struct {
-							Name   string
-							Type   string
-							Path   string
-							Mode   int
-							Object *struct {
-								Blob struct {
-									IsBinary    *bool
-									IsTruncated bool
-								} `graphql:"... on Blob"`
-							} `graphql:"object"`
-						}
-					} `graphql:"... on Tree"`
-				} `graphql:"object"`
-			}{
-				Name: "deep",
-				Type: "tree",
-				Path: "subdir/deep",
-			}
-			subDirEntry.Object = &struct {
-				Blob struct {
-					IsBinary    *bool
-					IsTruncated bool
-				} `graphql:"... on Blob"`
-				Tree struct {
-					Entries []struct {
-						Name   string
-						Type   string
-						Path   string
-						Mode   int
-						Object *struct {
-							Blob struct {
-								IsBinary    *bool
-								IsTruncated bool
-							} `graphql:"... on Blob"`
-						} `graphql:"object"`
-					}
-				} `graphql:"... on Tree"`
-			}{}
-
-			for _, e := range level3Entries {
-				l3Entry := struct {
-					Name   string
-					Type   string
-					Path   string
-					Mode   int
-					Object *struct {
-						Blob struct {
-							IsBinary    *bool
-							IsTruncated bool
-						} `graphql:"... on Blob"`
-					} `graphql:"object"`
-				}{
-					Name: e.name,
-					Type: "blob",
-					Path: "subdir/deep/" + e.name,
-					Mode: e.mode,
-				}
-				l3Entry.Object = &struct {
-					Blob struct {
-						IsBinary    *bool
-						IsTruncated bool
-					} `graphql:"... on Blob"`
-				}{}
-				l3Entry.Object.Blob.IsBinary = e.isBinary
-				subDirEntry.Object.Tree.Entries = append(subDirEntry.Object.Tree.Entries, l3Entry)
-			}
-
-			tree.Repository.Object.Tree.Entries[i].Object.Tree.Entries = append(
-				tree.Repository.Object.Tree.Entries[i].Object.Tree.Entries, subDirEntry)
-			break
-		}
-	}
-	return tree
-}
-
 func TestCheckUnreviewablePartialFetchError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/data/payload.go
+++ b/data/payload.go
@@ -23,17 +23,9 @@ type Payload struct {
 	DependencyManifestsCount int
 	IsCodeRepo               bool
 	SecurityPosture          SecurityPosture
-	Binaries                 BinaryAnalysis
 	client                   *githubv4.Client
 	httpClient               *http.Client
 	cache                    *payloadCache
-}
-
-// BinaryAnalysis holds information about binaries found in the repo
-type BinaryAnalysis struct {
-	Suspected    []string // OSPS-QA-05.01: suspected executable binary artifacts
-	Unreviewable []string // OSPS-QA-05.02: unreviewable binary artifacts
-	Err          error
 }
 
 // payloadCache holds lazily-fetched data shared by every step. Steps receive the
@@ -48,6 +40,7 @@ type BinaryAnalysis struct {
 // signal a guarantee that does not exist. If steps ever run in parallel, this
 // should fail loudly under -race rather than half-work.
 type payloadCache struct {
+	tree      *RepoTree
 	workflows []WorkflowFile
 	// set once workflows have been fetched, so an empty result is not refetched
 	workflowsLoaded bool
@@ -61,28 +54,22 @@ func Loader(config *config.Config) (payload any, err error) {
 	)))
 
 	ghClient := github.NewClient(httpClient)
-	gqlClient := githubv4.NewClient(httpClient)
 	owner := config.GetString("owner")
 	repo := config.GetString("repo")
 
 	var (
 		graphql            *GraphqlRepoData
+		client             *githubv4.Client
 		ghRepo             *github.Repository
 		repositoryMetadata RepositoryMetadata
 		isCodeRepo         bool
-		tree               *GraphqlRepoTree
-		treeErr            error
 	)
 	rest := newRestData(ghClient, httpClient, config)
 
 	g := new(errgroup.Group)
 	g.Go(func() (err error) {
-		graphql, err = getGraphqlRepoData(config, gqlClient, owner, repo)
+		graphql, client, err = getGraphqlRepoData(config, httpClient, owner, repo)
 		return err
-	})
-	g.Go(func() error {
-		tree, treeErr = fetchGraphqlRepoTree(config, gqlClient, "HEAD")
-		return nil
 	})
 	g.Go(func() (err error) {
 		ghRepo, repositoryMetadata, err = loadRepositoryMetadata(ghClient, owner, repo)
@@ -99,8 +86,6 @@ func Loader(config *config.Config) (payload any, err error) {
 		return nil, err
 	}
 
-	binaries := analyzeBinaries(tree, treeErr, httpClient, config, owner, repo, graphql.Repository.DefaultBranchRef.Name)
-
 	securityPosture, err := buildSecurityPosture(ghRepo, *rest)
 	if err != nil {
 		return nil, err
@@ -113,16 +98,17 @@ func Loader(config *config.Config) (payload any, err error) {
 		RepositoryMetadata:       repositoryMetadata,
 		DependencyManifestsCount: graphql.Repository.DependencyGraphManifests.TotalCount,
 		IsCodeRepo:               isCodeRepo,
+		client:                   client,
 		httpClient:               httpClient,
 		APICallCounter:           callCounter,
 		SecurityPosture:          securityPosture,
-		Binaries:                 binaries,
-		client:                   gqlClient,
 		cache:                    &payloadCache{},
 	}), nil
 }
 
-func getGraphqlRepoData(config *config.Config, client *githubv4.Client, owner, repo string) (data *GraphqlRepoData, err error) {
+func getGraphqlRepoData(config *config.Config, httpClient *http.Client, owner, repo string) (data *GraphqlRepoData, client *githubv4.Client, err error) {
+	client = githubv4.NewClient(httpClient)
+
 	variables := map[string]any{
 		"owner": githubv4.String(owner),
 		"name":  githubv4.String(repo),
@@ -135,7 +121,7 @@ func getGraphqlRepoData(config *config.Config, client *githubv4.Client, owner, r
 	if err != nil {
 		config.Logger.Error(fmt.Sprintf("Error querying GitHub GraphQL API: %s", err.Error()))
 	}
-	return data, err
+	return data, client, err
 }
 
 // newRestData builds the REST accessor on the shared httpClient so its raw
@@ -156,28 +142,33 @@ func newRestData(ghClient *github.Client, httpClient *http.Client, config *confi
 	}
 }
 
-// analyzeBinaries walks over the fetched tree, feeds the binaryChecker's
-// raw-content fallback for blobs GitHub could not classify.
-func analyzeBinaries(tree *GraphqlRepoTree, treeErr error, httpClient *http.Client, cfg *config.Config, owner, repo, branch string) BinaryAnalysis {
-	if treeErr != nil {
-		return BinaryAnalysis{Err: treeErr}
+// newBinaryChecker creates a binaryChecker configured from the payload's
+// repository metadata and HTTP client.
+func (p *Payload) newBinaryChecker() *binaryChecker {
+	return &binaryChecker{
+		httpClient: p.httpClient,
+		logger:     p.Config.Logger,
+		owner:      p.Config.GetString("owner"),
+		repo:       p.Config.GetString("repo"),
+		branch:     p.Repository.DefaultBranchRef.Name,
 	}
-	bc := &binaryChecker{
-		httpClient: httpClient,
-		logger:     cfg.Logger,
-		owner:      owner,
-		repo:       repo,
-		branch:     branch,
+}
+
+// getTree lazily fetches and caches the full repository tree so that multiple
+// checks (e.g. QA-05.01 and QA-05.02) share a single REST API call.
+func (p *Payload) getTree() (*RepoTree, error) {
+	if p.cache != nil && p.cache.tree != nil {
+		return p.cache.tree, nil
 	}
-	suspected, err := checkTreeForBinaries(tree, bc)
+	if p.GraphqlRepoData == nil || p.RestData == nil || p.ghClient == nil || p.Config == nil || p.cache == nil {
+		return nil, fmt.Errorf("payload missing required repository data")
+	}
+	tree, err := fetchRestRepoTree(p.ghClient, p.Config.GetString("owner"), p.Config.GetString("repo"), p.Repository.DefaultBranchRef.Name)
 	if err != nil {
-		return BinaryAnalysis{Err: err}
+		return nil, err
 	}
-	unreviewable, err := checkTreeForUnreviewableBinaries(tree, bc)
-	if err != nil {
-		return BinaryAnalysis{Err: err}
-	}
-	return BinaryAnalysis{Suspected: suspected, Unreviewable: unreviewable}
+	p.cache.tree = tree
+	return tree, nil
 }
 
 // GetWorkflowFiles returns the decoded contents of every file in
@@ -197,4 +188,31 @@ func (p *Payload) GetWorkflowFiles() ([]WorkflowFile, error) {
 	p.cache.workflows = files
 	p.cache.workflowsLoaded = true
 	return files, nil
+}
+
+// GetSuspectedBinaries fetches the repository tree and returns paths that appear
+// to be executable binary artifacts per OSPS-QA-05.01. The truncated return
+// reports whether the tree was too large for GitHub to return in full, so a
+// clean scan covers only part of the repository.
+func (p *Payload) GetSuspectedBinaries() (suspectedBinaries []string, truncated bool, err error) {
+	tree, err := p.getTree()
+	if err != nil {
+		return nil, false, err
+	}
+	flagged, err := checkTreeForBinaries(tree, p.newBinaryChecker())
+	return flagged, tree.Truncated, err
+}
+
+// GetUnreviewableBinaries fetches the repository tree and returns paths that are
+// unreviewable binary artifacts per OSPS-QA-05.02. This differs from
+// GetSuspectedBinaries by flagging all binaries except acceptable content types
+// like images, audio, video, fonts, and PDFs. The truncated return has the same
+// meaning as in GetSuspectedBinaries.
+func (p *Payload) GetUnreviewableBinaries() (unreviewableBinaries []string, truncated bool, err error) {
+	tree, err := p.getTree()
+	if err != nil {
+		return nil, false, err
+	}
+	flagged, err := checkTreeForUnreviewableBinaries(tree, p.newBinaryChecker())
+	return flagged, tree.Truncated, err
 }

--- a/data/payload_test.go
+++ b/data/payload_test.go
@@ -51,6 +51,15 @@ func TestGetWorkflowFilesServesCache(t *testing.T) {
 	})
 }
 
+func TestGetTreeServesCache(t *testing.T) {
+	tree := &RepoTree{}
+	payload := payloadWithCache(&payloadCache{tree: tree})
+
+	got, err := payload.getTree()
+	require.NoError(t, err)
+	assert.Same(t, tree, got)
+}
+
 // graphqlServer returns a githubv4 client pointed at a stub that answers every
 // query with the supplied JSON body.
 func graphqlServer(t *testing.T, body string) (*githubv4.Client, *int) {

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -100,18 +100,22 @@ func StatusChecksAreRequiredByBranchProtection(payload data.Payload) (result gem
 }
 
 func NoBinariesInRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	// TODO: This only checks the top 3 levels of the repository tree
-	// for common binary file extensions and it fails on very large repositories.
-	suspectedBinaries := payload.Binaries.Suspected
-	if payload.Binaries.Err != nil {
-		payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for binaries: %s", payload.Binaries.Err.Error()))
+	suspectedBinaries, truncated, err := payload.GetSuspectedBinaries()
+	if err != nil {
+		payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for binaries: %s", err.Error()))
 		return gemara.Unknown, "Error while scanning repository for binaries, potentially due to repo size. See logs for details.", confidence
 	}
 
-	if len(suspectedBinaries) == 0 {
-		return gemara.Passed, "No common binary file extensions were found in the repository", confidence
+	// A positive finding stands regardless of coverage: a binary we saw is a binary.
+	if len(suspectedBinaries) > 0 {
+		return gemara.Failed, fmt.Sprintf("Suspected binaries found in the repository: %s", strings.Join(suspectedBinaries, ", ")), gemara.High
 	}
-	return gemara.Failed, fmt.Sprintf("Suspected binaries found in the repository: %s", strings.Join(suspectedBinaries, ", ")), confidence
+	// A clean scan over a truncated tree is not a confident pass: we only saw part
+	// of the repository.
+	if truncated {
+		return gemara.NeedsReview, "No binaries found in the scanned portion of the repository, but the file tree was too large to scan in full; manual review required.", gemara.Low
+	}
+	return gemara.Passed, "No common binary file extensions were found in the repository", gemara.High
 }
 
 // NoUnreviewableBinariesInRepo is the assessment step for OSPS-QA-05.02.
@@ -119,16 +123,23 @@ func NoBinariesInRepo(payload data.Payload) (result gemara.Result, message strin
 // artifacts such as compiled executables, shared libraries, or archive binaries.
 // Acceptable binary content (images, audio, video, fonts, PDFs) is not flagged.
 func NoUnreviewableBinariesInRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	unreviewableBinaries := payload.Binaries.Unreviewable
-	if payload.Binaries.Err != nil {
-		payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for unreviewable binaries: %s", payload.Binaries.Err.Error()))
+	unreviewableBinaries, truncated, err := payload.GetUnreviewableBinaries()
+	if err != nil {
+		if payload.Config != nil && payload.Config.Logger != nil {
+			payload.Config.Logger.Trace(fmt.Sprintf("unexpected response while checking for unreviewable binaries: %s", err.Error()))
+		}
 		return gemara.Unknown, "Error while scanning repository for unreviewable binaries, potentially due to repo size. See logs for details.", confidence
 	}
 
-	if len(unreviewableBinaries) == 0 {
-		return gemara.Passed, "No unreviewable binary artifacts were found in the repository", confidence
+	// A positive finding stands regardless of coverage.
+	if len(unreviewableBinaries) > 0 {
+		return gemara.Failed, fmt.Sprintf("Unreviewable binary artifacts found in the repository: %s", strings.Join(unreviewableBinaries, ", ")), gemara.High
 	}
-	return gemara.Failed, fmt.Sprintf("Unreviewable binary artifacts found in the repository: %s", strings.Join(unreviewableBinaries, ", ")), confidence
+	// A clean scan over a truncated tree only covered part of the repository.
+	if truncated {
+		return gemara.NeedsReview, "No unreviewable binary artifacts found in the scanned portion of the repository, but the file tree was too large to scan in full; manual review required.", gemara.Low
+	}
+	return gemara.Passed, "No unreviewable binary artifacts were found in the repository", gemara.High
 }
 
 func RequiresNonAuthorApproval(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -1,15 +1,12 @@
 package quality
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
-	hclog "github.com/hashicorp/go-hclog"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/ossf/si-tooling/v2/si"
-	"github.com/privateerproj/privateer-sdk/config"
 )
 
 func Test_InsightsListsRepositories(t *testing.T) {
@@ -73,86 +70,6 @@ func Test_InsightsListsRepositories(t *testing.T) {
 			}
 			if gotMsg != tt.wantMsg {
 				t.Errorf("message = %q, want %q", gotMsg, tt.wantMsg)
-			}
-		})
-	}
-}
-
-func Test_NoBinariesInRepo(t *testing.T) {
-	tests := []struct {
-		name       string
-		binaries   data.BinaryAnalysis
-		wantResult gemara.Result
-	}{
-		{
-			name:       "no suspected binaries passes",
-			binaries:   data.BinaryAnalysis{Suspected: nil},
-			wantResult: gemara.Passed,
-		},
-		{
-			name:       "suspected binaries fail",
-			binaries:   data.BinaryAnalysis{Suspected: []string{"a.out"}},
-			wantResult: gemara.Failed,
-		},
-		{
-			name:       "a gather error is unknown, not a false pass",
-			binaries:   data.BinaryAnalysis{Err: errors.New("tree too large")},
-			wantResult: gemara.Unknown,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			payload := data.Payload{
-				Config:   &config.Config{Logger: hclog.NewNullLogger()},
-				Binaries: tt.binaries,
-			}
-			result, msg, _ := NoBinariesInRepo(payload)
-			if result != tt.wantResult {
-				t.Errorf("result = %v, want %v", result, tt.wantResult)
-			}
-			if msg == "" {
-				t.Error("expected non-empty message")
-			}
-		})
-	}
-}
-
-func Test_NoUnreviewableBinariesInRepo(t *testing.T) {
-	tests := []struct {
-		name       string
-		binaries   data.BinaryAnalysis
-		wantResult gemara.Result
-	}{
-		{
-			name:       "no unreviewable binaries passes",
-			binaries:   data.BinaryAnalysis{Unreviewable: nil},
-			wantResult: gemara.Passed,
-		},
-		{
-			name:       "unreviewable binaries fail",
-			binaries:   data.BinaryAnalysis{Unreviewable: []string{"blob.bin"}},
-			wantResult: gemara.Failed,
-		},
-		{
-			name:       "a gather error is unknown, not a false pass",
-			binaries:   data.BinaryAnalysis{Err: errors.New("tree too large")},
-			wantResult: gemara.Unknown,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			payload := data.Payload{
-				Config:   &config.Config{Logger: hclog.NewNullLogger()},
-				Binaries: tt.binaries,
-			}
-			result, msg, _ := NoUnreviewableBinariesInRepo(payload)
-			if result != tt.wantResult {
-				t.Errorf("result = %v, want %v", result, tt.wantResult)
-			}
-			if msg == "" {
-				t.Error("expected non-empty message")
 			}
 		})
 	}


### PR DESCRIPTION
**Fixes a real missed binary + unknown false-passes** on OSPS-QA-05, resolves 129 `Unknown`s, and cuts scan time **~4–18s → ~1–2s**.

The scan used a GraphQL tree hardcoded to **3 levels deep**: it errored out (→ `Unknown`) on huge repos and could **falsely pass** a repo whose only binaries live at depth 4+. A full-depth scan found a real committed binary the old one missed.

### What changes
- Replace the depth-3 GraphQL tree with a single `REST git/trees?recursive=1` — full depth plus an explicit `truncated` flag.
- REST carries no `IsBinary`/content, so binary status is inferred by extension (existing text/acceptable classifiers + a new binary-artifact list) feeding the unchanged `binaryChecker` — **still one call, no per-file fetches**.
- Honest coverage: a finding → **Fail** (even if truncated); clean over a **truncated** tree → **NeedsReview**; clean over a full tree → **Pass**; failed fetch → **Unknown**.

Net API calls unchanged (one GraphQL → one REST), shared across QA-05.01/.02 via the payload cache.

> **Rebase note:** shares `quality/steps.go` (QA-02) — second to merge needs a trivial rebase.
