### PR TITLE
feat: recognize unclassified license files in LE checks

### DIFF
--- a/evaluation_plans/osps/legal/steps.go
+++ b/evaluation_plans/osps/legal/steps.go
@@ -50,21 +50,70 @@ func splitSpdxExpression(expression string) (spdx_ids []string) {
 	return
 }
 
-func FoundLicense(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	if payload.Repository.LicenseInfo.Url == "" {
-		return gemara.Failed, "License was not found in a well known location via the GitHub API", confidence
+// noAssertion is what GitHub's license detector reports when a license file is
+// present but cannot be classified. It means "unidentified", not "disapproved".
+const noAssertion = "NOASSERTION"
+
+// licenseFilePrefix matches per-license files such as LICENSE-MIT / LICENSE-APACHE.
+const licenseFilePrefix = "license-"
+
+// rootLicenseFiles are conventional license filenames GitHub's detector
+// sometimes fails to classify (nonstandard text, multi-license repos, or an
+// unexpected location). Compared case-insensitively.
+var rootLicenseFiles = []string{
+	"LICENSE",
+	"LICENCE",
+	"COPYING",
+	"COPYING.LESSER",
+	"LICENSE.md",
+	"LICENSE.txt",
+}
+
+// findRootLicenseFile returns the name of a license file present in the
+// repository root tree, or "" if none is found. The repository root is itself a
+// well-known location, so a conventionally-named file there is independent
+// evidence a license exists even when GitHub's detector returns nothing.
+func findRootLicenseFile(payload data.Payload) string {
+	if payload.GraphqlRepoData == nil {
+		return ""
 	}
-	return gemara.Passed, "License was found in a well known location via the GitHub API", confidence
+	for _, entry := range payload.Repository.Object.Tree.Entries {
+		if entry.Type != "blob" {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(entry.Name), licenseFilePrefix) {
+			return entry.Name
+		}
+		for _, name := range rootLicenseFiles {
+			if strings.EqualFold(entry.Name, name) {
+				return entry.Name
+			}
+		}
+	}
+	return ""
+}
+
+func FoundLicense(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if payload.Repository.LicenseInfo.Url != "" {
+		return gemara.Passed, "License was found in a well known location via the GitHub API", gemara.High
+	}
+	if file := findRootLicenseFile(payload); file != "" {
+		return gemara.Passed, fmt.Sprintf("License file %q found in the repository root, a well known location; GitHub could not identify the license type", file), gemara.Medium
+	}
+	return gemara.Failed, "License was not found in a well known location via the GitHub API", gemara.Medium
 }
 
 func ReleasesLicensed(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if len(payload.Releases) == 0 {
 		return gemara.NotApplicable, "No releases found", confidence
 	}
-	if payload.Repository.LicenseInfo.Url == "" {
-		return gemara.Failed, "License was not found in a well known location via the GitHub API", confidence
+	if payload.Repository.LicenseInfo.Url != "" {
+		return gemara.Passed, "GitHub releases include the license(s) in the released source code.", gemara.High
 	}
-	return gemara.Passed, "GitHub releases include the license(s) in the released source code.", confidence
+	if file := findRootLicenseFile(payload); file != "" {
+		return gemara.Passed, fmt.Sprintf("License file %q found in the repository root; GitHub could not identify the license type", file), gemara.Medium
+	}
+	return gemara.Failed, "License was not found in a well known location via the GitHub API", gemara.Medium
 }
 
 func GoodLicense(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
@@ -76,19 +125,19 @@ func GoodLicense(payload data.Payload) (result gemara.Result, message string, co
 
 	apiInfo := payload.Repository.LicenseInfo.SpdxId
 	siInfo := payload.Insights.Repository.License.Expression
-	if apiInfo == "" && siInfo == "" {
-		return gemara.Failed, "License SPDX identifier was not found in Security Insights data or via GitHub API", confidence
-	}
 
-	spdx_ids_a := splitSpdxExpression(apiInfo)
-	spdx_ids_b := splitSpdxExpression(siInfo)
-	spdx_ids := append(spdx_ids_a, spdx_ids_b...)
+	spdx_ids := append(splitSpdxExpression(apiInfo), splitSpdxExpression(siInfo)...)
 	badLicenses := []string{}
 	deprecatedApproved := []string{}
+	usableIDs := []string{}
 	for _, spdx_id := range spdx_ids {
-		if spdx_id == "" {
+		// An empty string comes from splitting an empty expression, and
+		// NOASSERTION is GitHub's marker for a license it could not identify.
+		// Neither is an SPDX identifier we can evaluate for approval.
+		if spdx_id == "" || spdx_id == noAssertion {
 			continue
 		}
+		usableIDs = append(usableIDs, spdx_id)
 		var validId bool
 		for _, license := range licenses.Licenses {
 			if license.LicenseID == spdx_id {
@@ -104,7 +153,18 @@ func GoodLicense(payload data.Payload) (result gemara.Result, message string, co
 			badLicenses = append(badLicenses, spdx_id)
 		}
 	}
-	approvedLicenses := strings.Join(spdx_ids, ", ")
+
+	if len(usableIDs) == 0 {
+		// No SPDX identifier is available from GitHub or Security Insights. A
+		// license file in the root means one exists but its identity is unknown,
+		// so a human must judge OSI/FSF approval rather than us passing or failing.
+		if file := findRootLicenseFile(payload); file != "" {
+			return gemara.NeedsReview, fmt.Sprintf("License file %q is present but its SPDX identity could not be determined; manual review is required to confirm OSI or FSF approval", file), gemara.High
+		}
+		return gemara.Failed, "License SPDX identifier was not found in Security Insights data or via GitHub API", gemara.Medium
+	}
+
+	approvedLicenses := strings.Join(usableIDs, ", ")
 	if payload.Config.Logger != nil {
 		payload.Config.Logger.Trace(fmt.Sprintf("Requested licenses: %s", approvedLicenses))
 		payload.Config.Logger.Trace(fmt.Sprintf("Non-approved licenses: %s", badLicenses))
@@ -112,10 +172,10 @@ func GoodLicense(payload data.Payload) (result gemara.Result, message string, co
 	}
 
 	if len(badLicenses) > 0 {
-		return gemara.Failed, fmt.Sprintf("These licenses are not OSI or FSF approved: %s", strings.Join(badLicenses, ", ")), confidence
+		return gemara.Failed, fmt.Sprintf("These licenses are not OSI or FSF approved: %s", strings.Join(badLicenses, ", ")), gemara.High
 	}
 	if len(deprecatedApproved) > 0 {
-		return gemara.Passed, fmt.Sprintf("All licenses found are OSI or FSF approved. Note: the following SPDX IDs are deprecated and should be migrated to their -only/-or-later form: %s", strings.Join(deprecatedApproved, ", ")), confidence
+		return gemara.Passed, fmt.Sprintf("All licenses found are OSI or FSF approved. Note: the following SPDX IDs are deprecated and should be migrated to their -only/-or-later form: %s", strings.Join(deprecatedApproved, ", ")), gemara.High
 	}
-	return gemara.Passed, "All license found are OSI or FSF approved", confidence
+	return gemara.Passed, "All license found are OSI or FSF approved", gemara.High
 }

--- a/evaluation_plans/osps/legal/steps_test.go
+++ b/evaluation_plans/osps/legal/steps_test.go
@@ -24,6 +24,86 @@ func stubGraphqlRepo(licenseUrl string) *data.GraphqlRepoData {
 	return repo
 }
 
+type treeEntry struct {
+	name string
+	typ  string
+}
+
+// stubGraphqlRepoWithTree builds repo data with a license URL and the given root
+// tree entries, mirroring the anonymous entry struct in the GraphQL query.
+func stubGraphqlRepoWithTree(licenseUrl string, entries ...treeEntry) *data.GraphqlRepoData {
+	repo := stubGraphqlRepo(licenseUrl)
+	for _, e := range entries {
+		typ := e.typ
+		if typ == "" {
+			typ = "blob"
+		}
+		repo.Repository.Object.Tree.Entries = append(
+			repo.Repository.Object.Tree.Entries,
+			struct {
+				Name string
+				Type string
+				Path string
+			}{Name: e.name, Type: typ},
+		)
+	}
+	return repo
+}
+
+func TestFoundLicense(t *testing.T) {
+	tests := []struct {
+		name            string
+		payload         data.Payload
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name:            "GitHub identifies the license",
+			payload:         data.Payload{GraphqlRepoData: stubGraphqlRepo("https://api.github.com/licenses/mit")},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "License was found in a well known location via the GitHub API",
+		},
+		{
+			name:            "unclassified LICENSE file in root",
+			payload:         data.Payload{GraphqlRepoData: stubGraphqlRepoWithTree("", treeEntry{name: "LICENSE"})},
+			expectedResult:  gemara.Passed,
+			expectedMessage: `License file "LICENSE" found in the repository root, a well known location; GitHub could not identify the license type`,
+		},
+		{
+			name:            "per-license LICENSE-MIT file in root",
+			payload:         data.Payload{GraphqlRepoData: stubGraphqlRepoWithTree("", treeEntry{name: "LICENSE-MIT"})},
+			expectedResult:  gemara.Passed,
+			expectedMessage: `License file "LICENSE-MIT" found in the repository root, a well known location; GitHub could not identify the license type`,
+		},
+		{
+			name:            "COPYING file in root, case-insensitive",
+			payload:         data.Payload{GraphqlRepoData: stubGraphqlRepoWithTree("", treeEntry{name: "copying"})},
+			expectedResult:  gemara.Passed,
+			expectedMessage: `License file "copying" found in the repository root, a well known location; GitHub could not identify the license type`,
+		},
+		{
+			name:            "a directory named LICENSE is not a license file",
+			payload:         data.Payload{GraphqlRepoData: stubGraphqlRepoWithTree("", treeEntry{name: "LICENSE", typ: "tree"})},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "License was not found in a well known location via the GitHub API",
+		},
+		{
+			name:            "no license anywhere",
+			payload:         data.Payload{GraphqlRepoData: stubGraphqlRepoWithTree("", treeEntry{name: "README.md"})},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "License was not found in a well known location via the GitHub API",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message, _ := FoundLicense(test.payload)
+			assert.Equal(t, test.expectedResult, result)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}
+
 func TestReleasesLicensed(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -70,6 +150,21 @@ func TestReleasesLicensed(t *testing.T) {
 			},
 			expectedResult:  gemara.Passed,
 			expectedMessage: "GitHub releases include the license(s) in the released source code.",
+		},
+		{
+			name: "Release with unclassified root license file",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					Releases: []data.ReleaseData{
+						{
+							Name: "v1.0.0",
+						},
+					},
+				},
+				GraphqlRepoData: stubGraphqlRepoWithTree("", treeEntry{name: "LICENSE"}),
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: `License file "LICENSE" found in the repository root; GitHub could not identify the license type`,
 		},
 	}
 
@@ -312,6 +407,47 @@ func TestGoodLicense(t *testing.T) {
 			apiError:        nil,
 			expectedResult:  gemara.Failed,
 			expectedMessage: "These licenses are not OSI or FSF approved: BadLicense",
+		},
+		{
+			name: "NOASSERTION with a license file present needs review",
+			payload: data.Payload{
+				GraphqlRepoData: func() *data.GraphqlRepoData {
+					repo := stubGraphqlRepoWithTree("", treeEntry{name: "LICENSE"})
+					repo.Repository.LicenseInfo.SpdxId = "NOASSERTION"
+					return repo
+				}(),
+				Config: &config.Config{},
+			},
+			apiResponse:     []byte(`{"licenses":[{"licenseId":"MIT","isOsiApproved":true,"isFsfLibre":false}]}`),
+			apiError:        nil,
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: `License file "LICENSE" is present but its SPDX identity could not be determined; manual review is required to confirm OSI or FSF approval`,
+		},
+		{
+			name: "NOASSERTION with no license file fails",
+			payload: data.Payload{
+				GraphqlRepoData: func() *data.GraphqlRepoData {
+					repo := stubGraphqlRepo("")
+					repo.Repository.LicenseInfo.SpdxId = "NOASSERTION"
+					return repo
+				}(),
+				Config: &config.Config{},
+			},
+			apiResponse:     []byte(`{"licenses":[{"licenseId":"MIT","isOsiApproved":true,"isFsfLibre":false}]}`),
+			apiError:        nil,
+			expectedResult:  gemara.Failed,
+			expectedMessage: "License SPDX identifier was not found in Security Insights data or via GitHub API",
+		},
+		{
+			name: "No SPDX id but a license file present needs review",
+			payload: data.Payload{
+				GraphqlRepoData: stubGraphqlRepoWithTree("", treeEntry{name: "COPYING"}),
+				Config:          &config.Config{},
+			},
+			apiResponse:     []byte(`{"licenses":[{"licenseId":"MIT","isOsiApproved":true,"isFsfLibre":false}]}`),
+			apiError:        nil,
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: `License file "COPYING" is present but its SPDX identity could not be determined; manual review is required to confirm OSI or FSF approval`,
 		},
 		{
 			name: "Deprecated and non-approved license fails",


### PR DESCRIPTION
**Fixes ~500–900 of 1882 false negatives** on OSPS-LE-02/LE-03, and stops branding `NOASSERTION` as "not approved".

GitHub's license detector returns nothing or `NOASSERTION` for real-but-nonstandard licenses, multi-license repos, and licenses in odd locations.

### What changes
- **LE-03.01/.02** — when GitHub reports no license URL, fall back to the root tree and **Pass** on a conventional license file (`LICENSE`/`LICENCE`/`COPYING`/`COPYING.LESSER`/`LICENSE.md`/`.txt`/`LICENSE-*`, case-insensitive, blobs only).
- **LE-02.01/.02** — treat `NOASSERTION`/empty as an *absent* identifier, not a disapproved license: no usable SPDX id but a root license file → **NeedsReview** for a human; neither → **Fail**. SPDX approval logic unchanged.

Tests cover empty / `NOASSERTION` / valid-SPDX and the file-fallback path.

> **Fully self-contained** — touches only `legal/steps.go` + its test. No rebase needed against the rest of the batch.
