### PR TITLE
fix: evaluate workflow permissions from workflow files when the API is not accessible

### DIFF
--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -24,20 +24,25 @@ type HttpClient interface {
 }
 
 type RestData struct {
-	owner                string
-	repo                 string
-	token                string
-	Config               *config.Config
-	WorkflowsEnabled     bool
-	WorkflowPermissions  WorkflowPermissions
-	Insights             si.SecurityInsights
-	InsightsError        bool
-	PrivateVulnReporting PrivateVulnReporting
-	SecurityPolicy       SecurityPolicy
-	Releases             []ReleaseData
-	contents             RepoContent
-	ghClient             *github.Client `json:"-" yaml:"-"`
-	HttpClient           HttpClient     `json:"-" yaml:"-"`
+	owner               string
+	repo                string
+	token               string
+	Config              *config.Config
+	WorkflowsEnabled    bool
+	WorkflowPermissions WorkflowPermissions
+	// WorkflowPermissionsObserved is true only when both admin-only Actions
+	// endpoints were fetched and parsed successfully. When false, WorkflowsEnabled
+	// and WorkflowPermissions are unset defaults rather than observed values, and
+	// callers must not read "Actions disabled" or "write default" into them.
+	WorkflowPermissionsObserved bool
+	Insights                    si.SecurityInsights
+	InsightsError               bool
+	PrivateVulnReporting        PrivateVulnReporting
+	SecurityPolicy              SecurityPolicy
+	Releases                    []ReleaseData
+	contents                    RepoContent
+	ghClient                    *github.Client `json:"-" yaml:"-"`
+	HttpClient                  HttpClient     `json:"-" yaml:"-"`
 }
 
 type RepoContent struct {
@@ -378,7 +383,8 @@ func (r *RestData) getWorkflowPermissions() error {
 	if err := json.Unmarshal(responseData, &r.WorkflowPermissions); err != nil {
 		return fmt.Errorf("failed to parse permissions: %v", err)
 	}
-	return err
+	r.WorkflowPermissionsObserved = true
+	return nil
 }
 
 // IsCodeRepo returns true if the repository contains any programming languages.

--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -1,7 +1,11 @@
 package access_control
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/gemaraproj/go-gemara"
+	"github.com/rhysd/actionlint"
 
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
@@ -72,23 +76,143 @@ func BranchProtectionPreventsDeletion(payload data.Payload) (result gemara.Resul
 }
 
 func WorkflowDefaultReadPermissions(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	permissions := payload.WorkflowPermissions
-	if !payload.WorkflowsEnabled {
-		return gemara.NeedsReview, "GitHub Actions is disabled for this repository; manual review required.", confidence
+	// The Actions permissions endpoints are admin-only. When we actually observed
+	// them, evaluate the reported default. When we did not, fall back to what the
+	// workflow files themselves declare rather than misreading unset defaults as
+	// "Actions disabled".
+	if payload.WorkflowPermissionsObserved {
+		permissions := payload.WorkflowPermissions
+		if !payload.WorkflowsEnabled {
+			return gemara.NeedsReview, "GitHub Actions is disabled for this repository; manual review required.", gemara.Low
+		}
+
+		if permissions.DefaultPermissions == "read" && !permissions.CanApprovePullRequest {
+			result = gemara.Passed
+			message = "Workflow permissions default to read only."
+			confidence = gemara.High
+		} else if permissions.DefaultPermissions == "read" && permissions.CanApprovePullRequest {
+			result = gemara.Failed
+			message = "Workflow permissions default to read only for contents and packages, but PR approval is permitted."
+			confidence = gemara.High
+		} else if permissions.DefaultPermissions == "write" && !permissions.CanApprovePullRequest {
+			result = gemara.Failed
+			message = "Workflow permissions default to read/write, but PR approval is forbidden."
+			confidence = gemara.High
+		} else {
+			result = gemara.Failed
+			message = "Workflow permissions default to read/write and PR approval is permitted."
+			confidence = gemara.High
+		}
+		return
 	}
 
-	if permissions.DefaultPermissions == "read" && !permissions.CanApprovePullRequest {
-		result = gemara.Passed
-		message = "Workflow permissions default to read only."
-	} else if permissions.DefaultPermissions == "read" && permissions.CanApprovePullRequest {
-		result = gemara.Failed
-		message = "Workflow permissions default to read only for contents and packages, but PR approval is permitted."
-	} else if permissions.DefaultPermissions == "write" && !permissions.CanApprovePullRequest {
-		result = gemara.Failed
-		message = "Workflow permissions default to read/write, but PR approval is forbidden."
-	} else {
-		result = gemara.Failed
-		message = "Workflow permissions default to read/write and PR approval is permitted."
+	files, err := payload.GetWorkflowFiles()
+	if err != nil {
+		return gemara.NeedsReview, "Admin access to workflow permissions is unavailable and workflow files could not be retrieved; manual review required.", gemara.Low
 	}
-	return
+	return evaluateWorkflowPermissionsFromFiles(files)
+}
+
+// evaluateWorkflowPermissionsFromFiles infers AC-04 compliance from the workflow
+// files when the admin-only permissions API is inaccessible. A workflow that
+// declares explicit permissions overrides the org/repo default, so the default
+// becomes immaterial; a workflow that grants write-all is an observed violation;
+// a workflow with no explicit permissions still relies on the unobservable
+// default and needs a human with admin access to confirm.
+func evaluateWorkflowPermissionsFromFiles(files []data.WorkflowFile) (gemara.Result, string, gemara.ConfidenceLevel) {
+	var confidence gemara.ConfidenceLevel
+
+	var workflowCount int
+	var writeAllFile string
+	var unscoped []string
+
+	for _, file := range files {
+		if !strings.HasSuffix(file.Name, ".yml") && !strings.HasSuffix(file.Name, ".yaml") {
+			continue
+		}
+		workflowCount++
+
+		// A file we cannot read or parse cannot be confirmed to scope its
+		// permissions, so it counts toward the unobservable default.
+		if file.Truncated {
+			unscoped = append(unscoped, file.Path)
+			continue
+		}
+		workflow, parseErr := actionlint.Parse([]byte(file.Content))
+		if parseErr != nil || workflow == nil {
+			unscoped = append(unscoped, file.Path)
+			continue
+		}
+
+		if workflowUsesWriteAll(workflow) {
+			if writeAllFile == "" {
+				writeAllFile = file.Path
+			}
+			continue
+		}
+		if !workflowExplicitlyScoped(workflow) {
+			unscoped = append(unscoped, file.Path)
+		}
+	}
+
+	if workflowCount == 0 {
+		return gemara.NotApplicable, "No GitHub Actions workflows found", confidence
+	}
+	if writeAllFile != "" {
+		return gemara.Failed, fmt.Sprintf("Workflow %s grants write-all token permissions, exceeding minimal defaults", writeAllFile), gemara.High
+	}
+	if len(unscoped) == 0 {
+		return gemara.Passed, "Default token permissions are overridden by explicit permissions blocks in all workflow files", gemara.Medium
+	}
+	return gemara.NeedsReview, fmt.Sprintf(
+		"%d of %d workflow files lack an explicit permissions block, so the org/repo default applies (admin access required to confirm it): %s",
+		len(unscoped), workflowCount, summarizeFileList(unscoped)), gemara.Low
+}
+
+// permissionsAreWriteAll reports whether a permissions block is the write-all
+// shorthand (permissions: write-all), which grants every scope write access.
+func permissionsAreWriteAll(p *actionlint.Permissions) bool {
+	return p != nil && p.All != nil && strings.ToLower(p.All.Value) == "write-all"
+}
+
+// workflowUsesWriteAll reports whether the workflow grants write-all either at
+// the workflow level or in any of its jobs.
+func workflowUsesWriteAll(workflow *actionlint.Workflow) bool {
+	if permissionsAreWriteAll(workflow.Permissions) {
+		return true
+	}
+	for _, job := range workflow.Jobs {
+		if job != nil && permissionsAreWriteAll(job.Permissions) {
+			return true
+		}
+	}
+	return false
+}
+
+// workflowExplicitlyScoped reports whether the workflow overrides the default
+// token permissions: either a workflow-level permissions block (which applies to
+// every job) or an explicit permissions block on every job.
+func workflowExplicitlyScoped(workflow *actionlint.Workflow) bool {
+	if workflow.Permissions != nil {
+		return true
+	}
+	if len(workflow.Jobs) == 0 {
+		return false
+	}
+	for _, job := range workflow.Jobs {
+		if job == nil || job.Permissions == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// summarizeFileList joins file paths for a single-line message, capping the
+// list so a repository with many workflows cannot produce an unbounded string.
+func summarizeFileList(files []string) string {
+	const max = 5
+	if len(files) <= max {
+		return strings.Join(files, ", ")
+	}
+	return fmt.Sprintf("%s, and %d more", strings.Join(files[:max], ", "), len(files)-max)
 }

--- a/evaluation_plans/osps/access_control/steps_test.go
+++ b/evaluation_plans/osps/access_control/steps_test.go
@@ -53,7 +53,8 @@ func Test_WorkflowDefaultReadPermissions(t *testing.T) {
 			name: "Workflows enabled, read permissions and no PR permissions",
 			payload: data.Payload{
 				RestData: &data.RestData{
-					WorkflowsEnabled: true,
+					WorkflowPermissionsObserved: true,
+					WorkflowsEnabled:            true,
 					WorkflowPermissions: data.WorkflowPermissions{
 						DefaultPermissions:    "read", // read access for the contents and packages permissions
 						CanApprovePullRequest: false,  // cannot create or approve PRs
@@ -67,7 +68,8 @@ func Test_WorkflowDefaultReadPermissions(t *testing.T) {
 			name: "Workflows enabled, read permissions, but allows PR approvals",
 			payload: data.Payload{
 				RestData: &data.RestData{
-					WorkflowsEnabled: true,
+					WorkflowPermissionsObserved: true,
+					WorkflowsEnabled:            true,
 					WorkflowPermissions: data.WorkflowPermissions{
 						DefaultPermissions:    "read", // read access for the contents and packages permissions
 						CanApprovePullRequest: true,   // can create & approve PRs
@@ -81,7 +83,8 @@ func Test_WorkflowDefaultReadPermissions(t *testing.T) {
 			name: "Workflows enabled, write permissions and no PR permissions",
 			payload: data.Payload{
 				RestData: &data.RestData{
-					WorkflowsEnabled: true,
+					WorkflowPermissionsObserved: true,
+					WorkflowsEnabled:            true,
 					WorkflowPermissions: data.WorkflowPermissions{
 						DefaultPermissions:    "write", // read & write access for all permission scopes
 						CanApprovePullRequest: false,   // cannot create or approve PRs (in theory at least)
@@ -95,7 +98,8 @@ func Test_WorkflowDefaultReadPermissions(t *testing.T) {
 			name: "Workflows enabled, write permissions and PR permissions",
 			payload: data.Payload{
 				RestData: &data.RestData{
-					WorkflowsEnabled: true,
+					WorkflowPermissionsObserved: true,
+					WorkflowsEnabled:            true,
 					WorkflowPermissions: data.WorkflowPermissions{
 						DefaultPermissions:    "write",
 						CanApprovePullRequest: true,
@@ -109,7 +113,8 @@ func Test_WorkflowDefaultReadPermissions(t *testing.T) {
 			name: "Workflows disabled",
 			payload: data.Payload{
 				RestData: &data.RestData{
-					WorkflowsEnabled: false,
+					WorkflowPermissionsObserved: true,
+					WorkflowsEnabled:            false,
 					WorkflowPermissions: data.WorkflowPermissions{
 						DefaultPermissions:    "write",
 						CanApprovePullRequest: true,

--- a/evaluation_plans/osps/access_control/workflow_permissions_test.go
+++ b/evaluation_plans/osps/access_control/workflow_permissions_test.go
@@ -1,0 +1,255 @@
+package access_control
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+)
+
+// Workflow YAML fixtures for the file-based fallback. Each declares (or omits)
+// permissions in a distinct way so the parser exercises every branch.
+
+const workflowTopLevelReadAll = `name: ci
+on: [push]
+permissions: read-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`
+
+const workflowTopLevelScopedMapping = `name: ci
+on: [push]
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`
+
+const workflowJobLevelScoped = `name: ci
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo hi`
+
+const workflowNoPermissions = `name: ci
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`
+
+const workflowTopLevelWriteAll = `name: ci
+on: [push]
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`
+
+const workflowJobLevelWriteAll = `name: ci
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - run: echo hi`
+
+// One job scoped, the other not: the workflow still relies on the default.
+const workflowPartiallyScoped = `name: ci
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo hi
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo deploy`
+
+func yml(name, content string) data.WorkflowFile {
+	return data.WorkflowFile{Name: name, Path: ".github/workflows/" + name, Content: content}
+}
+
+func TestWorkflowDefaultReadPermissionsObserved(t *testing.T) {
+	testCases := []struct {
+		name            string
+		payload         data.Payload
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name: "observed read-only default passes",
+			payload: data.Payload{RestData: &data.RestData{
+				WorkflowPermissionsObserved: true,
+				WorkflowsEnabled:            true,
+				WorkflowPermissions:         data.WorkflowPermissions{DefaultPermissions: "read", CanApprovePullRequest: false},
+			}},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Workflow permissions default to read only.",
+		},
+		{
+			name: "observed write default fails",
+			payload: data.Payload{RestData: &data.RestData{
+				WorkflowPermissionsObserved: true,
+				WorkflowsEnabled:            true,
+				WorkflowPermissions:         data.WorkflowPermissions{DefaultPermissions: "write", CanApprovePullRequest: false},
+			}},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "Workflow permissions default to read/write, but PR approval is forbidden.",
+		},
+		{
+			name: "observed but Actions disabled needs review",
+			payload: data.Payload{RestData: &data.RestData{
+				WorkflowPermissionsObserved: true,
+				WorkflowsEnabled:            false,
+			}},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "GitHub Actions is disabled for this repository; manual review required.",
+		},
+		{
+			name: "unobserved and workflow files unavailable needs review",
+			// No GraphqlRepoData/Config/cache, so GetWorkflowFiles errors.
+			payload:         data.Payload{RestData: &data.RestData{WorkflowPermissionsObserved: false}},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "Admin access to workflow permissions is unavailable and workflow files could not be retrieved; manual review required.",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, message, _ := WorkflowDefaultReadPermissions(testCase.payload)
+			assert.Equal(t, testCase.expectedResult, result, testCase.name)
+			assert.Equal(t, testCase.expectedMessage, message, testCase.name)
+		})
+	}
+}
+
+func TestEvaluateWorkflowPermissionsFromFiles(t *testing.T) {
+	testCases := []struct {
+		name            string
+		files           []data.WorkflowFile
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name:            "no workflow files is not applicable",
+			files:           nil,
+			expectedResult:  gemara.NotApplicable,
+			expectedMessage: "No GitHub Actions workflows found",
+		},
+		{
+			name: "non-yaml files are ignored, none applicable",
+			files: []data.WorkflowFile{
+				{Name: "README.md", Path: ".github/workflows/README.md", Content: "not a workflow"},
+			},
+			expectedResult:  gemara.NotApplicable,
+			expectedMessage: "No GitHub Actions workflows found",
+		},
+		{
+			name: "all workflows explicitly scoped passes",
+			files: []data.WorkflowFile{
+				yml("ci.yml", workflowTopLevelReadAll),
+				yml("scoped.yaml", workflowTopLevelScopedMapping),
+				yml("jobs.yml", workflowJobLevelScoped),
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Default token permissions are overridden by explicit permissions blocks in all workflow files",
+		},
+		{
+			name: "workflow-level write-all fails naming the file",
+			files: []data.WorkflowFile{
+				yml("scoped.yml", workflowTopLevelReadAll),
+				yml("danger.yml", workflowTopLevelWriteAll),
+			},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "Workflow .github/workflows/danger.yml grants write-all token permissions, exceeding minimal defaults",
+		},
+		{
+			name: "job-level write-all fails",
+			files: []data.WorkflowFile{
+				yml("danger.yml", workflowJobLevelWriteAll),
+			},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "Workflow .github/workflows/danger.yml grants write-all token permissions, exceeding minimal defaults",
+		},
+		{
+			name: "write-all outranks an unscoped sibling",
+			files: []data.WorkflowFile{
+				yml("plain.yml", workflowNoPermissions),
+				yml("danger.yml", workflowTopLevelWriteAll),
+			},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "Workflow .github/workflows/danger.yml grants write-all token permissions, exceeding minimal defaults",
+		},
+		{
+			name: "unscoped workflow needs review",
+			files: []data.WorkflowFile{
+				yml("scoped.yml", workflowTopLevelReadAll),
+				yml("plain.yml", workflowNoPermissions),
+			},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "1 of 2 workflow files lack an explicit permissions block, so the org/repo default applies (admin access required to confirm it): .github/workflows/plain.yml",
+		},
+		{
+			name: "partially scoped workflow (not every job) needs review",
+			files: []data.WorkflowFile{
+				yml("partial.yml", workflowPartiallyScoped),
+			},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "1 of 1 workflow files lack an explicit permissions block, so the org/repo default applies (admin access required to confirm it): .github/workflows/partial.yml",
+		},
+		{
+			name: "truncated and unparseable files count as unscoped",
+			files: []data.WorkflowFile{
+				{Name: "huge.yml", Path: ".github/workflows/huge.yml", Truncated: true},
+				{Name: "broken.yml", Path: ".github/workflows/broken.yml", Content: "this is not a workflow"},
+			},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "2 of 2 workflow files lack an explicit permissions block, so the org/repo default applies (admin access required to confirm it): .github/workflows/huge.yml, .github/workflows/broken.yml",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, message, _ := evaluateWorkflowPermissionsFromFiles(testCase.files)
+			assert.Equal(t, testCase.expectedResult, result, testCase.name)
+			assert.Equal(t, testCase.expectedMessage, message, testCase.name)
+		})
+	}
+}
+
+// TestEvaluateWorkflowPermissionsCapsFileList verifies the NeedsReview file list
+// is bounded when many workflows lack explicit permissions.
+func TestEvaluateWorkflowPermissionsCapsFileList(t *testing.T) {
+	var files []data.WorkflowFile
+	for i := 0; i < 7; i++ {
+		name := fmt.Sprintf("wf%d.yml", i)
+		files = append(files, yml(name, workflowNoPermissions))
+	}
+
+	result, message, _ := evaluateWorkflowPermissionsFromFiles(files)
+
+	assert.Equal(t, gemara.NeedsReview, result)
+	assert.Contains(t, message, "7 of 7 workflow files lack an explicit permissions block")
+	assert.Contains(t, message, "and 2 more")
+	// Only the first 5 paths should be listed verbatim, the rest summarized.
+	assert.Equal(t, 5, strings.Count(message, ".github/workflows/wf"))
+}


### PR DESCRIPTION
**Turns a blanket `NeedsReview` (100% of 1,882 repos) into real NA / Pass / Fail** on OSPS-AC-04.

The Actions permissions endpoints are **admin-only**. On a non-admin scan both calls fail, `WorkflowsEnabled` stays false, and the step reported "GitHub Actions is disabled" — conflating an inaccessible API with a genuinely disabled one, and ignoring the workflow files themselves.

### What changes
- `getWorkflowPermissions` records `WorkflowPermissionsObserved` (set only when both endpoints parse).
- Observed (admin) logic is unchanged. When **not** observed, fall back to the workflow files:
  - no workflows → **NotApplicable**
  - all explicitly scoped, none write-all → **Pass**
  - any write-all → **Fail**, naming the file
  - otherwise → **NeedsReview**, listing (capped) files still relying on the unobservable default

Tests add the fallback matrix and mark the admin-path cases as observed (populated perms no longer imply observation).

> **Rebase note:** shares `data/rest-data.go` and `access_control/steps.go` (AC-03) — second to merge needs a trivial rebase.
