### PR TITLE
ci: gate release on the 'release' label

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@5193129233b450e9174d4d92fcc467919a989882 # v1.2.2
     with:
       publish: true
+      release-only-with-label: true
       release-config-name: release-drafter.yml
       goreleaser-config-path: .goreleaser.yaml
       go-version-file: go.mod


### PR DESCRIPTION
## What/Why
Set `release-only-with-label: true` so the reusable release workflow only cuts a release when the `release` label is on the merged PR, instead of on any trigger label (breaking/feature/vuln).

## Proof it works
Confirmed `release-only-with-label` is a valid boolean input on `ospo-reusable-workflows` release.yaml at the pinned `v1.2.2` (SHA `5193129`). When true, the reusable workflow's `check_release` job gates `should-release` on the presence of the `release` label. YAML parses cleanly; no application code is affected.

## Risk + AI role
Low - a single CI input on a pinned reusable workflow, no app code touched. Input validated against the upstream workflow definition before adding.

## Review focus
Confirm `release` is the intended sole gate and that dropping the implicit breaking/feature/vuln triggers matches the desired release cadence.