### PR TITLE
feat: pass GV-01 on observed governance/ownership files

### DIFF
--- a/data/governance-lookup.go
+++ b/data/governance-lookup.go
@@ -1,0 +1,45 @@
+package data
+
+import (
+	"strings"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// FindFileInDirs returns the repository path of the first of the given filenames
+// found in any of the given directories, matched case-insensitively. The empty
+// string denotes the repository root. Directories absent from the cached root
+// listing are skipped rather than fetched, and the search reuses the REST
+// contents gathered during Setup. Returns "" when none of the names is present.
+//
+// It exists so evaluation steps in other packages can run deterministic
+// filesystem fallbacks (root, .github, docs) without reaching into RestData's
+// unexported helpers.
+func (r *RestData) FindFileInDirs(dirs, names []string) string {
+	if r == nil {
+		return ""
+	}
+	for _, dir := range dirs {
+		var entries []*github.RepositoryContent
+		if dir == "" {
+			entries = r.contents.Content
+		} else {
+			sub, err := r.getSubdirContents(dir)
+			if err != nil {
+				continue
+			}
+			entries = sub.Content
+		}
+		for _, entry := range entries {
+			if entry.GetType() != "file" {
+				continue
+			}
+			for _, name := range names {
+				if strings.EqualFold(entry.GetName(), name) {
+					return entry.GetPath()
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/data/governance-lookup_test.go
+++ b/data/governance-lookup_test.go
@@ -1,0 +1,99 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func ghFile(name, path string) *github.RepositoryContent {
+	return &github.RepositoryContent{Type: github.Ptr("file"), Name: github.Ptr(name), Path: github.Ptr(path)}
+}
+
+func ghDir(name, path string) *github.RepositoryContent {
+	return &github.RepositoryContent{Type: github.Ptr("dir"), Name: github.Ptr(name), Path: github.Ptr(path)}
+}
+
+func TestFindFileInDirs(t *testing.T) {
+	dirs := []string{"", ".github", "docs"}
+	names := []string{"MAINTAINERS.md", "MAINTAINERS", "CODEOWNERS", "GOVERNANCE.md", "GOVERNANCE"}
+
+	tests := []struct {
+		name     string
+		contents RepoContent
+		expected string
+	}{
+		{
+			name: "match in root, case-insensitive",
+			contents: RepoContent{
+				Content: []*github.RepositoryContent{ghFile("maintainers", "maintainers")},
+			},
+			expected: "maintainers",
+		},
+		{
+			name: "match in .github",
+			contents: RepoContent{
+				Content: []*github.RepositoryContent{ghDir(".github", ".github")},
+				SubContent: map[string]RepoContent{
+					".github": {Content: []*github.RepositoryContent{ghFile("CODEOWNERS", ".github/CODEOWNERS")}},
+				},
+			},
+			expected: ".github/CODEOWNERS",
+		},
+		{
+			name: "match in docs",
+			contents: RepoContent{
+				Content: []*github.RepositoryContent{ghDir("docs", "docs")},
+				SubContent: map[string]RepoContent{
+					"docs": {Content: []*github.RepositoryContent{ghFile("GOVERNANCE.md", "docs/GOVERNANCE.md")}},
+				},
+			},
+			expected: "docs/GOVERNANCE.md",
+		},
+		{
+			name: "root preferred over subdirectories",
+			contents: RepoContent{
+				Content: []*github.RepositoryContent{
+					ghFile("MAINTAINERS.md", "MAINTAINERS.md"),
+					ghDir(".github", ".github"),
+				},
+				SubContent: map[string]RepoContent{
+					".github": {Content: []*github.RepositoryContent{ghFile("CODEOWNERS", ".github/CODEOWNERS")}},
+				},
+			},
+			expected: "MAINTAINERS.md",
+		},
+		{
+			name: "directory-typed entry with a matching name is ignored",
+			contents: RepoContent{
+				Content: []*github.RepositoryContent{ghDir("GOVERNANCE", "GOVERNANCE")},
+			},
+			expected: "",
+		},
+		{
+			name: "no match, subdirs absent from root are skipped without a client",
+			contents: RepoContent{
+				Content: []*github.RepositoryContent{ghFile("README.md", "README.md")},
+			},
+			expected: "",
+		},
+		{
+			name:     "empty root listing does not panic without a client",
+			contents: RepoContent{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rest := &RestData{owner: "o", repo: "r", contents: tt.contents}
+			assert.Equal(t, tt.expected, rest.FindFileInDirs(dirs, names))
+		})
+	}
+}
+
+func TestFindFileInDirsNilReceiver(t *testing.T) {
+	var rest *RestData
+	assert.Equal(t, "", rest.FindFileInDirs([]string{""}, []string{"MAINTAINERS"}))
+}

--- a/data/rest_data_mock.go
+++ b/data/rest_data_mock.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+
+	"github.com/google/go-github/v74/github"
 )
 
 type ClientMock struct {
@@ -42,5 +44,23 @@ func NewPayloadWithHTTPMock(base Payload, body []byte, statusCode int, httpErr e
 	}
 	base.ensureInsightsInitialized()
 	base.HttpClient = mock
+	return base
+}
+
+// NewPayloadWithRepoContents builds a Payload whose RestData is backed by the
+// given root and subdirectory listings, so that other packages' tests can
+// exercise contents-based fallbacks (checkFile, FindFile, FindFileInDirs)
+// without a live GitHub client. subContents maps a directory path such as
+// ".github" or "docs" to its file listing.
+func NewPayloadWithRepoContents(base Payload, root []*github.RepositoryContent, subContents map[string][]*github.RepositoryContent) Payload {
+	if base.RestData == nil {
+		base.RestData = &RestData{}
+	}
+	sub := make(map[string]RepoContent, len(subContents))
+	for dir, entries := range subContents {
+		sub[dir] = RepoContent{Content: entries}
+	}
+	base.contents = RepoContent{Content: root, SubContent: sub}
+	base.ensureInsightsInitialized()
 	return base
 }

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -106,7 +106,6 @@ var (
 			docs.HasDependencyManagementPolicy,
 		},
 		"OSPS-GV-01.01": {
-			reusable_steps.HasSecurityInsightsFile,
 			reusable_steps.IsActive,
 			governance.CoreTeamIsListed,
 			governance.ProjectAdminsListed,

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -17,28 +17,60 @@ var ContributionGuideFiles = []string{
 	"CONTRIBUTING.txt",
 }
 
+// governanceDocDirs are the locations GitHub and common convention recognize for
+// governance and ownership documentation: repository root, .github, and docs.
+var governanceDocDirs = []string{"", ".github", "docs"}
+
+// coreTeamFiles name a project's maintainers or owners; any one of them
+// constitutes a listing of the core team.
+var coreTeamFiles = []string{"MAINTAINERS.md", "MAINTAINERS", "CODEOWNERS", "GOVERNANCE.md", "GOVERNANCE"}
+
+// rolesAndResponsibilitiesFiles document how a project is governed and who is
+// responsible for what.
+var rolesAndResponsibilitiesFiles = []string{"GOVERNANCE.md", "GOVERNANCE", "MAINTAINERS.md", "MAINTAINERS"}
+
 func CoreTeamIsListed(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	if len(payload.Insights.Repository.CoreTeam) == 0 {
-		return gemara.Failed, "Core team was NOT specified in Security Insights data", confidence
+	if len(payload.Insights.Repository.CoreTeam) > 0 {
+		return gemara.Passed, "Core team was specified in Security Insights data", gemara.High
 	}
 
-	return gemara.Passed, "Core team was specified in Security Insights data", confidence
+	// Fallback: a maintainers/owners file is itself a listing of the core team.
+	if payload.RestData != nil {
+		if path := payload.FindFileInDirs(governanceDocDirs, coreTeamFiles); path != "" {
+			return gemara.Passed, "Core team listing found via GitHub (" + path + ")", gemara.Medium
+		}
+	}
+
+	return gemara.Failed, "Core team was NOT specified in Security Insights data or via a maintainers/owners file on GitHub", gemara.Medium
 }
 
 func ProjectAdminsListed(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	if len(payload.Insights.Project.Administrators) == 0 {
-		return gemara.Failed, "Project admins were NOT specified in Security Insights data", confidence
+	if len(payload.Insights.Project.Administrators) > 0 {
+		return gemara.Passed, "Project admins were specified in Security Insights data", gemara.High
 	}
 
-	return gemara.Passed, "Project admins were specified in Security Insights data", confidence
+	// Project administrators hold administrative (destructive) access — a distinct,
+	// more privileged role than the maintainers/owners a MAINTAINERS or CODEOWNERS
+	// file lists, so such a file is not evidence of who the admins are. Admin
+	// membership is not publicly observable, so without a Security Insights
+	// declaration it cannot be confirmed.
+	return gemara.NeedsReview, "Project administrators are not declared in Security Insights data; admin membership is not determinable from public repository files, so manual review is required", gemara.Low
 }
 
 func HasRolesAndResponsibilities(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	if payload.Insights.Repository.Documentation.Governance == nil {
-		return gemara.Failed, "Roles and responsibilities were NOT specified in Security Insights data", confidence
+	if payload.Insights.Repository.Documentation.Governance != nil {
+		return gemara.Passed, "Roles and responsibilities were specified in Security Insights data", gemara.High
 	}
 
-	return gemara.Passed, "Roles and responsibilities were specified in Security Insights data", confidence
+	// Fallback: governance or maintainers documentation defines roles and
+	// responsibilities even when it is not declared in Security Insights.
+	if payload.RestData != nil {
+		if path := payload.FindFileInDirs(governanceDocDirs, rolesAndResponsibilitiesFiles); path != "" {
+			return gemara.Passed, "Governance/maintainers documentation found via GitHub (" + path + ")", gemara.Medium
+		}
+	}
+
+	return gemara.Failed, "Roles and responsibilities were NOT specified in Security Insights data or via governance/maintainers documentation on GitHub", gemara.Medium
 }
 
 func HasContributionGuide(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/governance/steps_test.go
+++ b/evaluation_plans/osps/governance/steps_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
+	"github.com/google/go-github/v74/github"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/ossf/si-tooling/v2/si"
 	"github.com/stretchr/testify/assert"
@@ -116,6 +117,183 @@ func TestHasContributionGuide(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result, message, _ := HasContributionGuide(test.build())
+			assert.Equal(t, test.expectedResult, result)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}
+
+func file(name, path string) *github.RepositoryContent {
+	return &github.RepositoryContent{
+		Type: github.Ptr("file"),
+		Name: github.Ptr(name),
+		Path: github.Ptr(path),
+	}
+}
+
+func dirEntry(name, path string) *github.RepositoryContent {
+	return &github.RepositoryContent{
+		Type: github.Ptr("dir"),
+		Name: github.Ptr(name),
+		Path: github.Ptr(path),
+	}
+}
+
+func TestCoreTeamIsListed(t *testing.T) {
+	tests := []struct {
+		name            string
+		build           func() data.Payload
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name: "core team declared in Security Insights",
+			build: func() data.Payload {
+				p := data.NewPayloadWithRepoContents(data.Payload{}, nil, nil)
+				p.Insights.Repository.CoreTeam = []si.Contact{{Name: "Maintainer"}}
+				return p
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Core team was specified in Security Insights data",
+		},
+		{
+			name: "MAINTAINERS file in root",
+			build: func() data.Payload {
+				return data.NewPayloadWithRepoContents(data.Payload{},
+					[]*github.RepositoryContent{file("MAINTAINERS", "MAINTAINERS")}, nil)
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Core team listing found via GitHub (MAINTAINERS)",
+		},
+		{
+			name: "CODEOWNERS file in .github",
+			build: func() data.Payload {
+				return data.NewPayloadWithRepoContents(data.Payload{},
+					[]*github.RepositoryContent{dirEntry(".github", ".github")},
+					map[string][]*github.RepositoryContent{
+						".github": {file("CODEOWNERS", ".github/CODEOWNERS")},
+					})
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Core team listing found via GitHub (.github/CODEOWNERS)",
+		},
+		{
+			name: "nothing found",
+			build: func() data.Payload {
+				return data.NewPayloadWithRepoContents(data.Payload{},
+					[]*github.RepositoryContent{file("README.md", "README.md")}, nil)
+			},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "Core team was NOT specified in Security Insights data or via a maintainers/owners file on GitHub",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message, _ := CoreTeamIsListed(test.build())
+			assert.Equal(t, test.expectedResult, result)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}
+
+func TestProjectAdminsListed(t *testing.T) {
+	tests := []struct {
+		name            string
+		build           func() data.Payload
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name: "admins declared in Security Insights",
+			build: func() data.Payload {
+				p := data.NewPayloadWithRepoContents(data.Payload{}, nil, nil)
+				p.Insights.Project.Administrators = []si.Contact{{Name: "Admin"}}
+				return p
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Project admins were specified in Security Insights data",
+		},
+		{
+			name: "governance/maintainers file is not evidence of admins",
+			build: func() data.Payload {
+				return data.NewPayloadWithRepoContents(data.Payload{},
+					[]*github.RepositoryContent{dirEntry("docs", "docs")},
+					map[string][]*github.RepositoryContent{
+						"docs": {file("GOVERNANCE.md", "docs/GOVERNANCE.md")},
+					})
+			},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "Project administrators are not declared in Security Insights data; admin membership is not determinable from public repository files, so manual review is required",
+		},
+		{
+			name: "nothing found",
+			build: func() data.Payload {
+				return data.NewPayloadWithRepoContents(data.Payload{}, nil, nil)
+			},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "Project administrators are not declared in Security Insights data; admin membership is not determinable from public repository files, so manual review is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message, _ := ProjectAdminsListed(test.build())
+			assert.Equal(t, test.expectedResult, result)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}
+
+func TestHasRolesAndResponsibilities(t *testing.T) {
+	tests := []struct {
+		name            string
+		build           func() data.Payload
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name: "governance declared in Security Insights",
+			build: func() data.Payload {
+				p := data.NewPayloadWithRepoContents(data.Payload{}, nil, nil)
+				gov := si.URL("https://example.com/GOVERNANCE.md")
+				p.Insights.Repository.Documentation.Governance = &gov
+				return p
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Roles and responsibilities were specified in Security Insights data",
+		},
+		{
+			name: "GOVERNANCE.md in root",
+			build: func() data.Payload {
+				return data.NewPayloadWithRepoContents(data.Payload{},
+					[]*github.RepositoryContent{file("governance.md", "governance.md")}, nil)
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Governance/maintainers documentation found via GitHub (governance.md)",
+		},
+		{
+			name: "CODEOWNERS alone does not satisfy roles and responsibilities",
+			build: func() data.Payload {
+				return data.NewPayloadWithRepoContents(data.Payload{},
+					[]*github.RepositoryContent{file("CODEOWNERS", "CODEOWNERS")}, nil)
+			},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "Roles and responsibilities were NOT specified in Security Insights data or via governance/maintainers documentation on GitHub",
+		},
+		{
+			name: "nothing found",
+			build: func() data.Payload {
+				return data.NewPayloadWithRepoContents(data.Payload{}, nil, nil)
+			},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "Roles and responsibilities were NOT specified in Security Insights data or via governance/maintainers documentation on GitHub",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message, _ := HasRolesAndResponsibilities(test.build())
 			assert.Equal(t, test.expectedResult, result)
 			assert.Equal(t, test.expectedMessage, message)
 		})


### PR DESCRIPTION
**Fixes ~1,870/1,890 wrong results** on OSPS-GV-01.

GV-01 read only Security Insights, so `CoreTeamIsListed`/`ProjectAdminsListed` (GV-01.01) and `HasRolesAndResponsibilities` (GV-01.02) **Failed** for every repo without a `security-insights.yml`.

### What changes
- Each step falls back to a deterministic search of root, `.github`, and `docs` (new `RestData.FindFileInDirs`):
  - **roles & responsibilities** → Pass on `GOVERNANCE` or `MAINTAINERS`.
  - **core team / admins** → Pass on `MAINTAINERS`, `CODEOWNERS`, or `GOVERNANCE` — a maintainers/owners list *is* a core-team listing.
- Drop the `HasSecurityInsightsFile` guard from GV-01.01 (it capped SI-less repos); `IsActive` stays and folds to `NotApplicable` when status is unknown.
- SI stays primary; every message names its evidence source; absence is now the only path to Fail.

Adds a nil-client guard and contents-based test setup. New lookup + step tests.

> **Rebase note:** shares `data/rest-data.go`, `rest_data_mock.go`, `evaluation-plans.go`, `governance/steps.go` with other PRs — second to merge needs a trivial rebase.
