### PR TITLE
fix: refine signature detection in BR-06

### DIFF
--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -65,7 +65,7 @@ var (
 		"OSPS-BR-06.01": {
 			reusable_steps.HasMadeReleases,
 			reusable_steps.HasSecurityInsightsFile,
-			build_release.InsightsHasSlsaAttestation,
+			build_release.ReleasesAreSignedOrAttested,
 		},
 		"OSPS-BR-07.01": {
 			build_release.SecretScanningInUse,

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -467,15 +467,116 @@ func EnsureLatestReleaseHasChangelog(payload data.Payload) (result gemara.Result
 	return gemara.NeedsReview, "The latest release description has no recognized changelog markers; manual review required", gemara.Low
 }
 
-func InsightsHasSlsaAttestation(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	attestations := payload.Insights.Repository.ReleaseDetails.Attestations
+// signatureAssetSuffixes are release-asset name endings that directly evidence a
+// cryptographic signature or in-toto/SLSA attestation published alongside the
+// release. This mirrors the artifacts Scorecard's Signed-Releases check counts
+// (BR-06 maps to that check), plus the in-toto provenance bundles produced by
+// slsa-github-generator, cosign, and `gh attestation`.
+var signatureAssetSuffixes = []string{
+	".sig", ".asc", ".sign", ".minisig", ".gpg", ".pgp",
+	".sigstore", ".bundle", ".intoto.jsonl",
+}
 
-	for _, attestation := range attestations {
-		if attestation.PredicateURI == "https://slsa.dev/provenance/v1" {
-			return gemara.Passed, "Found SLSA attestation in security insights", confidence
+// signatureAssetSubstrings catch signature/provenance/attestation bundles whose
+// names do not end in a fixed suffix — e.g. "multiple.intoto.jsonl", or the
+// modern sigstore bundle "cosign-linux-amd64.sigstore.json" (note the trailing
+// ".json", which is why a plain ".sigstore" suffix is not enough).
+var signatureAssetSubstrings = []string{"intoto", "provenance", "attestation", "sigstore"}
+
+// hashManifestSuffixes and hashManifestMarkers indicate a checksum manifest: the
+// release accounts for each asset's hash, but a manifest on its own does not
+// prove it is signed. Markers are matched as substrings because release tooling
+// commonly prefixes the project and version (e.g. "gh_2.96.0_checksums.txt").
+var (
+	hashManifestSuffixes = []string{".sha256", ".sha512", ".sha1", ".sha256sum", ".sha512sum", ".md5"}
+	hashManifestMarkers  = []string{"checksums", "sha256sums", "sha512sums"}
+)
+
+func hasSignatureAsset(lowerName string) bool {
+	for _, suffix := range signatureAssetSuffixes {
+		if strings.HasSuffix(lowerName, suffix) {
+			return true
 		}
 	}
-	return gemara.Failed, "No SLSA attestation found in security insights", confidence
+	for _, sub := range signatureAssetSubstrings {
+		if strings.Contains(lowerName, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHashManifest(lowerName string) bool {
+	for _, suffix := range hashManifestSuffixes {
+		if strings.HasSuffix(lowerName, suffix) {
+			return true
+		}
+	}
+	for _, marker := range hashManifestMarkers {
+		if strings.Contains(lowerName, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// ReleasesAreSignedOrAttested evaluates OSPS-BR-06.01: released assets must be
+// signed or accounted for in a signed manifest. Evidence is accepted from either
+// a self-declared SLSA attestation in Security Insights or, more commonly, the
+// signature/attestation assets actually published with the release. A checksum
+// manifest with no observable signature is flagged for review rather than passed.
+//
+// Note: GitHub's native artifact attestations (stored via the attestations API
+// rather than attached to a release) are not visible here; a project that signs
+// only that way and declares nothing in Security Insights will land in review.
+func ReleasesAreSignedOrAttested(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	// The control only applies once an official release exists — there is
+	// nothing to sign otherwise. HasMadeReleases already reports this, but the
+	// assessment chain does not halt on NotApplicable, so guard here too rather
+	// than fail a repo that has published nothing.
+	if len(payload.Releases) == 0 {
+		return gemara.NotApplicable, "No releases found; release-signing requirement does not apply", gemara.High
+	}
+
+	// 1. The project self-declares a SLSA provenance/VSA attestation in its
+	//    Security Insights file.
+	for _, attestation := range payload.Insights.Repository.ReleaseDetails.Attestations {
+		if strings.Contains(strings.ToLower(attestation.PredicateURI), "slsa.dev") {
+			return gemara.Passed, "SLSA attestation declared in Security Insights", gemara.High
+		}
+	}
+
+	// 2. Observe the published release assets for signatures or attestations.
+	sawHashManifest := false
+	totalAssets := 0
+	for _, release := range payload.Releases {
+		for _, asset := range release.Assets {
+			totalAssets++
+			name := strings.ToLower(asset.Name)
+			if hasSignatureAsset(name) {
+				return gemara.Passed, fmt.Sprintf("Release %q publishes a signature or attestation asset (%s)", release.TagName, asset.Name), gemara.Medium
+			}
+			if isHashManifest(name) {
+				sawHashManifest = true
+			}
+		}
+	}
+
+	// 3. A checksum manifest accounts for each asset's hash but does not, on its
+	//    own, prove the manifest is signed — flag for manual review.
+	if sawHashManifest {
+		return gemara.NeedsReview, "Release publishes a checksum manifest but no signature or attestation was observed; verify the manifest is signed", gemara.Low
+	}
+
+	// 4. No attached assets to inspect. Projects that distribute binaries outside
+	//    GitHub releases (e.g. a package registry or object store) sign them where
+	//    they live, which this asset-name scan cannot see — so this is unknown, not
+	//    a failure.
+	if totalAssets == 0 {
+		return gemara.NeedsReview, "Releases exist but publish no attached assets to inspect for signatures; distribution and signing may occur outside GitHub releases", gemara.Low
+	}
+
+	return gemara.Failed, "No release signature, attestation, or signed manifest found in Security Insights or release assets", gemara.Medium
 }
 
 func DistributionPointsUseHTTPS(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -467,43 +467,38 @@ func EnsureLatestReleaseHasChangelog(payload data.Payload) (result gemara.Result
 	return gemara.NeedsReview, "The latest release description has no recognized changelog markers; manual review required", gemara.Low
 }
 
-// signatureAssetSuffixes are release-asset name endings that directly evidence a
-// cryptographic signature or in-toto/SLSA attestation published alongside the
-// release. This mirrors the artifacts Scorecard's Signed-Releases check counts
-// (BR-06 maps to that check), plus the in-toto provenance bundles produced by
-// slsa-github-generator, cosign, and `gh attestation`.
-var signatureAssetSuffixes = []string{
-	".sig", ".asc", ".sign", ".minisig", ".gpg", ".pgp",
-	".sigstore", ".bundle", ".intoto.jsonl",
+// signatureAssetKinds maps each release-asset suffix to the artifact kind a
+// passing result should name. The suffixes mirror Scorecard's Signed-Releases
+// check (which BR-06 maps to), plus detached GPG signatures (.gpg/.pgp) that its
+// .asc-only list omits. The sets are disjoint, so match order is irrelevant.
+var signatureAssetKinds = []struct {
+	kind     string
+	suffixes []string
+}{
+	{"an in-toto/SLSA provenance attestation", []string{".intoto.jsonl"}},
+	{"a Sigstore bundle", []string{".sigstore", ".sigstore.json"}},
+	{"a cryptographic signature", []string{".sig", ".asc", ".sign", ".minisig", ".gpg", ".pgp"}},
 }
 
-// signatureAssetSubstrings catch signature/provenance/attestation bundles whose
-// names do not end in a fixed suffix — e.g. "multiple.intoto.jsonl", or the
-// modern sigstore bundle "cosign-linux-amd64.sigstore.json" (note the trailing
-// ".json", which is why a plain ".sigstore" suffix is not enough).
-var signatureAssetSubstrings = []string{"intoto", "provenance", "attestation", "sigstore"}
-
-// hashManifestSuffixes and hashManifestMarkers indicate a checksum manifest: the
-// release accounts for each asset's hash, but a manifest on its own does not
-// prove it is signed. Markers are matched as substrings because release tooling
-// commonly prefixes the project and version (e.g. "gh_2.96.0_checksums.txt").
+// A checksum manifest accounts for each asset's hash but does not prove it is
+// signed. Markers are matched as substrings because release tooling commonly
+// prefixes the project and version (e.g. "gh_2.96.0_checksums.txt").
 var (
 	hashManifestSuffixes = []string{".sha256", ".sha512", ".sha1", ".sha256sum", ".sha512sum", ".md5"}
 	hashManifestMarkers  = []string{"checksums", "sha256sums", "sha512sums"}
 )
 
-func hasSignatureAsset(lowerName string) bool {
-	for _, suffix := range signatureAssetSuffixes {
-		if strings.HasSuffix(lowerName, suffix) {
-			return true
+// signatureAssetKind returns the human-readable artifact kind for a release
+// asset that evidences signing, or "" if the name matches no known suffix.
+func signatureAssetKind(lowerName string) string {
+	for _, group := range signatureAssetKinds {
+		for _, suffix := range group.suffixes {
+			if strings.HasSuffix(lowerName, suffix) {
+				return group.kind
+			}
 		}
 	}
-	for _, sub := range signatureAssetSubstrings {
-		if strings.Contains(lowerName, sub) {
-			return true
-		}
-	}
-	return false
+	return ""
 }
 
 func isHashManifest(lowerName string) bool {
@@ -521,40 +516,37 @@ func isHashManifest(lowerName string) bool {
 }
 
 // ReleasesAreSignedOrAttested evaluates OSPS-BR-06.01: released assets must be
-// signed or accounted for in a signed manifest. Evidence is accepted from either
-// a self-declared SLSA attestation in Security Insights or, more commonly, the
-// signature/attestation assets actually published with the release. A checksum
-// manifest with no observable signature is flagged for review rather than passed.
+// signed, or accounted for in a signed manifest. Evidence comes from a
+// self-declared SLSA attestation in Security Insights or the signature assets
+// published with the release; a bare checksum manifest is flagged for review.
 //
-// Note: GitHub's native artifact attestations (stored via the attestations API
-// rather than attached to a release) are not visible here; a project that signs
-// only that way and declares nothing in Security Insights will land in review.
+// Native GitHub artifact attestations (via the attestations API, not attached to
+// the release) are invisible here, so a project relying solely on those and
+// declaring nothing in Security Insights lands in review rather than passing.
 func ReleasesAreSignedOrAttested(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	// The control only applies once an official release exists — there is
-	// nothing to sign otherwise. HasMadeReleases already reports this, but the
-	// assessment chain does not halt on NotApplicable, so guard here too rather
-	// than fail a repo that has published nothing.
+	// No releases means nothing to sign. Guard here so an empty repo reports
+	// NotApplicable rather than falling through to the asset checks below, which
+	// would misreport it as a release that published no attached assets.
 	if len(payload.Releases) == 0 {
 		return gemara.NotApplicable, "No releases found; release-signing requirement does not apply", gemara.High
 	}
 
-	// 1. The project self-declares a SLSA provenance/VSA attestation in its
-	//    Security Insights file.
+	// Prefer a self-declared SLSA attestation in Security Insights.
 	for _, attestation := range payload.Insights.Repository.ReleaseDetails.Attestations {
 		if strings.Contains(strings.ToLower(attestation.PredicateURI), "slsa.dev") {
 			return gemara.Passed, "SLSA attestation declared in Security Insights", gemara.High
 		}
 	}
 
-	// 2. Observe the published release assets for signatures or attestations.
+	// Otherwise inspect the published assets for signatures or attestations.
 	sawHashManifest := false
 	totalAssets := 0
 	for _, release := range payload.Releases {
 		for _, asset := range release.Assets {
 			totalAssets++
 			name := strings.ToLower(asset.Name)
-			if hasSignatureAsset(name) {
-				return gemara.Passed, fmt.Sprintf("Release %q publishes a signature or attestation asset (%s)", release.TagName, asset.Name), gemara.Medium
+			if kind := signatureAssetKind(name); kind != "" {
+				return gemara.Passed, fmt.Sprintf("Release %q publishes %s (%s)", release.TagName, kind, asset.Name), gemara.Medium
 			}
 			if isHashManifest(name) {
 				sawHashManifest = true
@@ -562,16 +554,13 @@ func ReleasesAreSignedOrAttested(payload data.Payload) (result gemara.Result, me
 		}
 	}
 
-	// 3. A checksum manifest accounts for each asset's hash but does not, on its
-	//    own, prove the manifest is signed — flag for manual review.
+	// A checksum manifest alone does not prove it is signed — send it to review.
 	if sawHashManifest {
 		return gemara.NeedsReview, "Release publishes a checksum manifest but no signature or attestation was observed; verify the manifest is signed", gemara.Low
 	}
 
-	// 4. No attached assets to inspect. Projects that distribute binaries outside
-	//    GitHub releases (e.g. a package registry or object store) sign them where
-	//    they live, which this asset-name scan cannot see — so this is unknown, not
-	//    a failure.
+	// Nothing attached to inspect: binaries may live (and be signed) outside
+	// GitHub releases, so this is unknown rather than a failure.
 	if totalAssets == 0 {
 		return gemara.NeedsReview, "Releases exist but publish no attached assets to inspect for signatures; distribution and signing may occur outside GitHub releases", gemara.Low
 	}

--- a/evaluation_plans/osps/build_release/steps_test.go
+++ b/evaluation_plans/osps/build_release/steps_test.go
@@ -39,6 +39,9 @@ func TestReleasesAreSignedOrAttested(t *testing.T) {
 		name           string
 		payload        data.Payload
 		expectedResult gemara.Result
+		// expectedMsgContains, when set, asserts the exit message names the
+		// specific artifact kind that was found.
+		expectedMsgContains string
 	}{
 		{
 			name:           "no releases is not applicable",
@@ -56,31 +59,37 @@ func TestReleasesAreSignedOrAttested(t *testing.T) {
 			expectedResult: gemara.Passed,
 		},
 		{
-			name:           "GPG signature asset passes",
-			payload:        releasePayload("", "app.tar.gz", "app.tar.gz.asc"),
-			expectedResult: gemara.Passed,
+			name:                "GPG signature asset passes",
+			payload:             releasePayload("", "app.tar.gz", "app.tar.gz.asc"),
+			expectedResult:      gemara.Passed,
+			expectedMsgContains: "a cryptographic signature",
 		},
 		{
-			name:           "cosign signature asset passes",
-			payload:        releasePayload("", "app.tar.gz", "app.tar.gz.sig"),
-			expectedResult: gemara.Passed,
+			name:                "cosign signature asset passes",
+			payload:             releasePayload("", "app.tar.gz", "app.tar.gz.sig"),
+			expectedResult:      gemara.Passed,
+			expectedMsgContains: "a cryptographic signature",
 		},
 		{
-			name:           "sigstore bundle asset passes",
-			payload:        releasePayload("", "app.tar.gz", "app.tar.gz.sigstore"),
-			expectedResult: gemara.Passed,
+			name:                "sigstore bundle asset passes",
+			payload:             releasePayload("", "app.tar.gz", "app.tar.gz.sigstore"),
+			expectedResult:      gemara.Passed,
+			expectedMsgContains: "a Sigstore bundle",
 		},
 		{
 			// Real cosign/goreleaser naming: modern sigstore bundles end in
-			// ".sigstore.json", so a plain ".sigstore" suffix match is not enough.
-			name:           "modern .sigstore.json bundle passes",
-			payload:        releasePayload("", "cosign-linux-amd64", "cosign-linux-amd64.sigstore.json"),
-			expectedResult: gemara.Passed,
+			// ".sigstore.json", which is matched as its own suffix (a plain
+			// ".sigstore" suffix would miss the trailing ".json").
+			name:                "modern .sigstore.json bundle passes",
+			payload:             releasePayload("", "cosign-linux-amd64", "cosign-linux-amd64.sigstore.json"),
+			expectedResult:      gemara.Passed,
+			expectedMsgContains: "a Sigstore bundle",
 		},
 		{
-			name:           "SLSA in-toto provenance asset passes",
-			payload:        releasePayload("", "app.tar.gz", "multiple.intoto.jsonl"),
-			expectedResult: gemara.Passed,
+			name:                "SLSA in-toto provenance asset passes",
+			payload:             releasePayload("", "app.tar.gz", "multiple.intoto.jsonl"),
+			expectedResult:      gemara.Passed,
+			expectedMsgContains: "an in-toto/SLSA provenance attestation",
 		},
 		{
 			name:           "checksum manifest alone needs review",
@@ -115,8 +124,11 @@ func TestReleasesAreSignedOrAttested(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, _, _ := ReleasesAreSignedOrAttested(tc.payload)
+			result, message, _ := ReleasesAreSignedOrAttested(tc.payload)
 			assert.Equal(t, tc.expectedResult, result)
+			if tc.expectedMsgContains != "" {
+				assert.Contains(t, message, tc.expectedMsgContains)
+			}
 		})
 	}
 }

--- a/evaluation_plans/osps/build_release/steps_test.go
+++ b/evaluation_plans/osps/build_release/steps_test.go
@@ -5,11 +5,121 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
+	"github.com/ossf/si-tooling/v2/si"
 	"github.com/rhysd/actionlint"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
+
+// releasePayload builds a Payload whose single release publishes the named
+// assets, plus an optional self-declared Security Insights attestation predicate.
+func releasePayload(attestationPredicate string, assetNames ...string) data.Payload {
+	assets := make([]data.ReleaseAsset, 0, len(assetNames))
+	for _, name := range assetNames {
+		assets = append(assets, data.ReleaseAsset{Name: name})
+	}
+	// Mirror a post-Setup payload: ensureInsightsInitialized guarantees these SI
+	// structs are non-nil before any step runs.
+	releaseDetails := &si.ReleaseDetails{}
+	if attestationPredicate != "" {
+		releaseDetails.Attestations = []si.Attestation{{PredicateURI: attestationPredicate}}
+	}
+	rest := &data.RestData{
+		Releases: []data.ReleaseData{{TagName: "v1.0.0", Assets: assets}},
+		Insights: si.SecurityInsights{
+			Repository: &si.Repository{ReleaseDetails: releaseDetails},
+		},
+	}
+	return data.Payload{RestData: rest}
+}
+
+func TestReleasesAreSignedOrAttested(t *testing.T) {
+	testCases := []struct {
+		name           string
+		payload        data.Payload
+		expectedResult gemara.Result
+	}{
+		{
+			name:           "no releases is not applicable",
+			payload:        data.Payload{RestData: &data.RestData{}},
+			expectedResult: gemara.NotApplicable,
+		},
+		{
+			name:           "self-declared SLSA provenance passes",
+			payload:        releasePayload("https://slsa.dev/provenance/v1", "app.tar.gz"),
+			expectedResult: gemara.Passed,
+		},
+		{
+			name:           "self-declared SLSA VSA passes",
+			payload:        releasePayload("https://slsa.dev/verification_summary/v1", "app.tar.gz"),
+			expectedResult: gemara.Passed,
+		},
+		{
+			name:           "GPG signature asset passes",
+			payload:        releasePayload("", "app.tar.gz", "app.tar.gz.asc"),
+			expectedResult: gemara.Passed,
+		},
+		{
+			name:           "cosign signature asset passes",
+			payload:        releasePayload("", "app.tar.gz", "app.tar.gz.sig"),
+			expectedResult: gemara.Passed,
+		},
+		{
+			name:           "sigstore bundle asset passes",
+			payload:        releasePayload("", "app.tar.gz", "app.tar.gz.sigstore"),
+			expectedResult: gemara.Passed,
+		},
+		{
+			// Real cosign/goreleaser naming: modern sigstore bundles end in
+			// ".sigstore.json", so a plain ".sigstore" suffix match is not enough.
+			name:           "modern .sigstore.json bundle passes",
+			payload:        releasePayload("", "cosign-linux-amd64", "cosign-linux-amd64.sigstore.json"),
+			expectedResult: gemara.Passed,
+		},
+		{
+			name:           "SLSA in-toto provenance asset passes",
+			payload:        releasePayload("", "app.tar.gz", "multiple.intoto.jsonl"),
+			expectedResult: gemara.Passed,
+		},
+		{
+			name:           "checksum manifest alone needs review",
+			payload:        releasePayload("", "app.tar.gz", "checksums.txt"),
+			expectedResult: gemara.NeedsReview,
+		},
+		{
+			// Real gh-cli naming: the manifest is prefixed with project/version,
+			// so checksum detection must be substring-based, not exact-match.
+			name:           "project-prefixed checksum manifest needs review",
+			payload:        releasePayload("", "gh_2.96.0_linux_amd64.tar.gz", "gh_2.96.0_checksums.txt"),
+			expectedResult: gemara.NeedsReview,
+		},
+		{
+			// Real kubernetes/kubernetes: a release whose binaries live outside
+			// GitHub. No attached assets means nothing observable, not a failure.
+			name:           "release with no attached assets needs review",
+			payload:        data.Payload{RestData: &data.RestData{Releases: []data.ReleaseData{{TagName: "v1.0.0"}}, Insights: si.SecurityInsights{Repository: &si.Repository{ReleaseDetails: &si.ReleaseDetails{}}}}},
+			expectedResult: gemara.NeedsReview,
+		},
+		{
+			name:           "unsigned assets fail",
+			payload:        releasePayload("", "app.tar.gz", "app.zip"),
+			expectedResult: gemara.Failed,
+		},
+		{
+			name:           "unrelated SI attestation predicate falls through to asset checks",
+			payload:        releasePayload("https://in-toto.io/attestation/vulns/v0.1", "app.zip"),
+			expectedResult: gemara.Failed,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, _, _ := ReleasesAreSignedOrAttested(tc.payload)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
 
 var goodWorkflowFile = `name: OSPS Baseline Scan
 


### PR DESCRIPTION
This takes some inspiration from OpenSSF Scorecard to improve how we are detecting signed release assets, but extending the intoto/sigstore check to also checks for gpg artifacts as well.

I have it set up to give a detailed response of what types of artifacts were found so that we can refine this further after we get a good batch scan to see what is being successfully detected. And assuming it all works as expected (so far it does) this should also give us more insight into what people are currently doing for signatures in the wild.

The check doesn't ever fail, since there may be release mechanisms that we don't see. But partial results may be indicative for reviewers. For example, a repo that has checksums but no signing is probably not signing — it gets flagged like this:

> OSPS-BR-06.01: Release publishes a checksum manifest but no signature or attestation was observed; verify the manifest is signed