### PR TITLE
fix: report secret scanning as NeedsReview when its status is unreadable

### DIFF
--- a/data/security-posture.go
+++ b/data/security-posture.go
@@ -10,6 +10,12 @@ type SecurityPosture interface {
 	PreventsPushingSecrets() bool
 	ScansForSecrets() bool
 	DefinesPolicyForHandlingSecrets() bool
+	// SecretScanningObservable reports whether we had any basis to judge secret
+	// scanning at all. GitHub returns the security_and_analysis block only to
+	// callers with admin access to the repository, so for repositories we do not
+	// administer the status is unreadable — distinct from being disabled — unless
+	// Security Insights independently declares the tooling.
+	SecretScanningObservable() bool
 }
 
 type RepoSecurityPosture struct {
@@ -17,24 +23,31 @@ type RepoSecurityPosture struct {
 	preventsSecretPushing           bool
 	scansForSecrets                 bool
 	definesPolicyForHandlingSecrets bool
+	secretScanningObservable        bool
 }
 
 func buildSecurityPosture(repository *github.Repository, rd RestData) (SecurityPosture, error) {
 	insightsClaimsSecretsTooling := insightsClaimsSecretsTooling(rd.Insights)
 	securityConfig := repository.GetSecurityAndAnalysis()
 	if securityConfig == nil {
+		// GitHub withholds security_and_analysis unless the token has admin access
+		// to the repository. Absent that block, the secret-scanning status is
+		// unobservable rather than disabled — unless Security Insights declares the
+		// tooling, which is positive evidence in its own right.
 		return &RepoSecurityPosture{
-			restData:              rd,
-			preventsSecretPushing: insightsClaimsSecretsTooling,
-			scansForSecrets:       insightsClaimsSecretsTooling,
+			restData:                 rd,
+			preventsSecretPushing:    insightsClaimsSecretsTooling,
+			scansForSecrets:          insightsClaimsSecretsTooling,
+			secretScanningObservable: insightsClaimsSecretsTooling,
 		}, nil
 	}
 	secretsScanningStatus := securityConfig.GetSecretScanning().GetStatus()
 	pushProtectionStatus := securityConfig.GetSecretScanningPushProtection().GetStatus()
 	return &RepoSecurityPosture{
-		restData:              rd,
-		preventsSecretPushing: pushProtectionStatus == "enabled" || insightsClaimsSecretsTooling,
-		scansForSecrets:       secretsScanningStatus == "enabled" || insightsClaimsSecretsTooling,
+		restData:                 rd,
+		preventsSecretPushing:    pushProtectionStatus == "enabled" || insightsClaimsSecretsTooling,
+		scansForSecrets:          secretsScanningStatus == "enabled" || insightsClaimsSecretsTooling,
+		secretScanningObservable: true,
 		// TODO: consider if SecurityInsights should have a policy doc field in ProjectDocumentation to handle this
 		// definesPolicyForHandlingSecrets: rd.SecurityInsights != nil && ....
 	}, nil
@@ -62,4 +75,8 @@ func (rsp *RepoSecurityPosture) ScansForSecrets() bool {
 
 func (rsp *RepoSecurityPosture) DefinesPolicyForHandlingSecrets() bool {
 	return rsp.definesPolicyForHandlingSecrets
+}
+
+func (rsp *RepoSecurityPosture) SecretScanningObservable() bool {
+	return rsp.secretScanningObservable
 }

--- a/data/security-posture.go
+++ b/data/security-posture.go
@@ -6,16 +6,28 @@ import (
 )
 
 // SecurityPosture defines an interface for accessing security-related metadata about a repository.
+//
+// The secret-scanning signals come from two independent sources kept separate so
+// callers can report which was found: PreventsPushingSecrets/ScansForSecrets are
+// the settings GitHub actually observed, and InsightsDeclaresSecretScanning is a
+// project self-declaration. SecretScanningObservable reports whether GitHub's
+// settings were readable at all.
 type SecurityPosture interface {
+	// PreventsPushingSecrets and ScansForSecrets report the push-protection and
+	// secret-scanning settings observed in GitHub's security_and_analysis block.
+	// They are false when the block was not readable — check SecretScanningObservable.
 	PreventsPushingSecrets() bool
 	ScansForSecrets() bool
 	DefinesPolicyForHandlingSecrets() bool
-	// SecretScanningObservable reports whether we had any basis to judge secret
-	// scanning at all. GitHub returns the security_and_analysis block only to
-	// callers with admin access to the repository, so for repositories we do not
-	// administer the status is unreadable — distinct from being disabled — unless
-	// Security Insights independently declares the tooling.
+	// SecretScanningObservable reports whether GitHub's security_and_analysis block
+	// was readable. GitHub returns it only to callers with admin access to the
+	// repository, so for repositories we do not administer the observed settings
+	// are unreadable — distinct from being disabled.
 	SecretScanningObservable() bool
+	// InsightsDeclaresSecretScanning reports a Security Insights self-declaration of
+	// secret-scanning tooling, independent of (and possibly instead of) GitHub's
+	// native settings.
+	InsightsDeclaresSecretScanning() bool
 }
 
 type RepoSecurityPosture struct {
@@ -24,6 +36,7 @@ type RepoSecurityPosture struct {
 	scansForSecrets                 bool
 	definesPolicyForHandlingSecrets bool
 	secretScanningObservable        bool
+	insightsDeclaresSecretScanning  bool
 }
 
 func buildSecurityPosture(repository *github.Repository, rd RestData) (SecurityPosture, error) {
@@ -31,23 +44,19 @@ func buildSecurityPosture(repository *github.Repository, rd RestData) (SecurityP
 	securityConfig := repository.GetSecurityAndAnalysis()
 	if securityConfig == nil {
 		// GitHub withholds security_and_analysis unless the token has admin access
-		// to the repository. Absent that block, the secret-scanning status is
-		// unobservable rather than disabled — unless Security Insights declares the
-		// tooling, which is positive evidence in its own right.
+		// to the repository. Absent that block the observed settings are unreadable
+		// (not disabled); a Security Insights declaration is the only signal left.
 		return &RepoSecurityPosture{
-			restData:                 rd,
-			preventsSecretPushing:    insightsClaimsSecretsTooling,
-			scansForSecrets:          insightsClaimsSecretsTooling,
-			secretScanningObservable: insightsClaimsSecretsTooling,
+			restData:                       rd,
+			insightsDeclaresSecretScanning: insightsClaimsSecretsTooling,
 		}, nil
 	}
-	secretsScanningStatus := securityConfig.GetSecretScanning().GetStatus()
-	pushProtectionStatus := securityConfig.GetSecretScanningPushProtection().GetStatus()
 	return &RepoSecurityPosture{
-		restData:                 rd,
-		preventsSecretPushing:    pushProtectionStatus == "enabled" || insightsClaimsSecretsTooling,
-		scansForSecrets:          secretsScanningStatus == "enabled" || insightsClaimsSecretsTooling,
-		secretScanningObservable: true,
+		restData:                       rd,
+		preventsSecretPushing:          securityConfig.GetSecretScanningPushProtection().GetStatus() == "enabled",
+		scansForSecrets:                securityConfig.GetSecretScanning().GetStatus() == "enabled",
+		secretScanningObservable:       true,
+		insightsDeclaresSecretScanning: insightsClaimsSecretsTooling,
 		// TODO: consider if SecurityInsights should have a policy doc field in ProjectDocumentation to handle this
 		// definesPolicyForHandlingSecrets: rd.SecurityInsights != nil && ....
 	}, nil
@@ -79,4 +88,8 @@ func (rsp *RepoSecurityPosture) DefinesPolicyForHandlingSecrets() bool {
 
 func (rsp *RepoSecurityPosture) SecretScanningObservable() bool {
 	return rsp.secretScanningObservable
+}
+
+func (rsp *RepoSecurityPosture) InsightsDeclaresSecretScanning() bool {
+	return rsp.insightsDeclaresSecretScanning
 }

--- a/data/security-posture_test.go
+++ b/data/security-posture_test.go
@@ -29,6 +29,9 @@ func TestBuildSecurityPosture_NoSecurityConfig(t *testing.T) {
 	assert.False(t, sp.PreventsPushingSecrets())
 	assert.False(t, sp.ScansForSecrets())
 	assert.False(t, sp.DefinesPolicyForHandlingSecrets())
+	// No security_and_analysis block (e.g. a repo we lack admin access to) and no
+	// Security Insights claim: the status is unobservable, not disabled.
+	assert.False(t, sp.SecretScanningObservable())
 }
 
 func TestBuildSecurityPosture_SecretScanningEnabled(t *testing.T) {
@@ -51,6 +54,7 @@ func TestBuildSecurityPosture_SecretScanningEnabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, sp.PreventsPushingSecrets())
 	assert.True(t, sp.ScansForSecrets())
+	assert.True(t, sp.SecretScanningObservable())
 }
 
 func TestBuildSecurityPosture_NilSecurityConfig_WithInsightsSecretScanning(t *testing.T) {
@@ -70,6 +74,8 @@ func TestBuildSecurityPosture_NilSecurityConfig_WithInsightsSecretScanning(t *te
 	assert.NoError(t, err)
 	assert.True(t, sp.PreventsPushingSecrets())
 	assert.True(t, sp.ScansForSecrets())
+	// A Security Insights declaration is itself positive, observable evidence.
+	assert.True(t, sp.SecretScanningObservable())
 }
 
 func TestBuildSecurityPosture_ScanningEnabledPushProtectionDisabled(t *testing.T) {

--- a/data/security-posture_test.go
+++ b/data/security-posture_test.go
@@ -32,6 +32,7 @@ func TestBuildSecurityPosture_NoSecurityConfig(t *testing.T) {
 	// No security_and_analysis block (e.g. a repo we lack admin access to) and no
 	// Security Insights claim: the status is unobservable, not disabled.
 	assert.False(t, sp.SecretScanningObservable())
+	assert.False(t, sp.InsightsDeclaresSecretScanning())
 }
 
 func TestBuildSecurityPosture_SecretScanningEnabled(t *testing.T) {
@@ -72,10 +73,12 @@ func TestBuildSecurityPosture_NilSecurityConfig_WithInsightsSecretScanning(t *te
 	}
 	sp, err := buildSecurityPosture(repo, rd)
 	assert.NoError(t, err)
-	assert.True(t, sp.PreventsPushingSecrets())
-	assert.True(t, sp.ScansForSecrets())
-	// A Security Insights declaration is itself positive, observable evidence.
-	assert.True(t, sp.SecretScanningObservable())
+	// The GitHub block is unreadable, so the observed settings are false and the
+	// status is unobservable; the declaration is surfaced on its own signal.
+	assert.False(t, sp.PreventsPushingSecrets())
+	assert.False(t, sp.ScansForSecrets())
+	assert.False(t, sp.SecretScanningObservable())
+	assert.True(t, sp.InsightsDeclaresSecretScanning())
 }
 
 func TestBuildSecurityPosture_ScanningEnabledPushProtectionDisabled(t *testing.T) {
@@ -121,8 +124,12 @@ func TestBuildSecurityPosture_SecretScanningDisabledButInsightsTooling(t *testin
 	}
 	sp, err := buildSecurityPosture(repo, rd)
 	assert.NoError(t, err)
-	assert.True(t, sp.PreventsPushingSecrets())
-	assert.True(t, sp.ScansForSecrets())
+	// GitHub observed both settings off, but Security Insights declares tooling —
+	// the observed and declared signals are reported independently.
+	assert.False(t, sp.PreventsPushingSecrets())
+	assert.False(t, sp.ScansForSecrets())
+	assert.True(t, sp.SecretScanningObservable())
+	assert.True(t, sp.InsightsDeclaresSecretScanning())
 }
 
 func TestInsightsClaimsSecretsTooling(t *testing.T) {

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -625,19 +625,32 @@ func DistributionPointsUseHTTPS(payload data.Payload) (result gemara.Result, mes
 
 func SecretScanningInUse(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	sp := payload.SecurityPosture
-	if sp.PreventsPushingSecrets() && sp.ScansForSecrets() {
-		return gemara.Passed, "Secret scanning is enabled and prevents pushing secrets", confidence
+
+	// Strongest evidence: GitHub itself reports both native controls enabled.
+	if sp.ScansForSecrets() && sp.PreventsPushingSecrets() {
+		return gemara.Passed, "GitHub secret scanning and push protection are both enabled", gemara.High
 	}
 
-	// Unobservable is not disabled: lacking the admin access needed to read the
-	// setting (and any Security Insights claim), send it to review rather than
-	// fail on data we never saw. See SecretScanningObservable.
+	// A Security Insights self-declaration counts even when GitHub's native
+	// settings are off or unreadable (the project may use third-party tooling),
+	// but it is self-reported, so lower confidence than an observed setting.
+	if sp.InsightsDeclaresSecretScanning() {
+		return gemara.Passed, "Security Insights declares secret-scanning tooling", gemara.Medium
+	}
+
+	// Partial native coverage: name the control that is missing.
+	if sp.ScansForSecrets() {
+		return gemara.Failed, "GitHub secret scanning is enabled, but push protection is not", gemara.Medium
+	}
+	if sp.PreventsPushingSecrets() {
+		return gemara.Failed, "GitHub push protection is enabled, but secret scanning is not", gemara.Medium
+	}
+
+	// Nothing enabled and nothing declared. Distinguish "we could not read it"
+	// from "it is off": GitHub returns security_and_analysis only to repository
+	// admins, so an unreadable status is unknown rather than a failure.
 	if !sp.SecretScanningObservable() {
 		return gemara.NeedsReview, "Secret scanning status is not observable with the current token; reading it requires repository admin access, and no Security Insights declaration was found", gemara.Low
 	}
-
-	if sp.PreventsPushingSecrets() || sp.ScansForSecrets() {
-		return gemara.Failed, "Secret scanning is only partially enabled", confidence
-	}
-	return gemara.Failed, "Secret scanning is not enabled", confidence
+	return gemara.Failed, "GitHub reports secret scanning and push protection are both disabled", gemara.Medium
 }

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -624,11 +624,20 @@ func DistributionPointsUseHTTPS(payload data.Payload) (result gemara.Result, mes
 }
 
 func SecretScanningInUse(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	if payload.SecurityPosture.PreventsPushingSecrets() && payload.SecurityPosture.ScansForSecrets() {
+	sp := payload.SecurityPosture
+	if sp.PreventsPushingSecrets() && sp.ScansForSecrets() {
 		return gemara.Passed, "Secret scanning is enabled and prevents pushing secrets", confidence
-	} else if payload.SecurityPosture.PreventsPushingSecrets() || payload.SecurityPosture.ScansForSecrets() {
-		return gemara.Failed, "Secret scanning is only partially enabled", confidence
-	} else {
-		return gemara.Failed, "Secret scanning is not enabled", confidence
 	}
+
+	// Unobservable is not disabled: lacking the admin access needed to read the
+	// setting (and any Security Insights claim), send it to review rather than
+	// fail on data we never saw. See SecretScanningObservable.
+	if !sp.SecretScanningObservable() {
+		return gemara.NeedsReview, "Secret scanning status is not observable with the current token; reading it requires repository admin access, and no Security Insights declaration was found", gemara.Low
+	}
+
+	if sp.PreventsPushingSecrets() || sp.ScansForSecrets() {
+		return gemara.Failed, "Secret scanning is only partially enabled", confidence
+	}
+	return gemara.Failed, "Secret scanning is not enabled", confidence
 }

--- a/evaluation_plans/osps/build_release/steps_test.go
+++ b/evaluation_plans/osps/build_release/steps_test.go
@@ -133,6 +133,57 @@ func TestReleasesAreSignedOrAttested(t *testing.T) {
 	}
 }
 
+// mockSecurityPosture implements data.SecurityPosture so step tests can drive
+// SecretScanningInUse without constructing a real (admin-scoped) API payload.
+type mockSecurityPosture struct {
+	preventsPush bool
+	scans        bool
+	observable   bool
+}
+
+func (m mockSecurityPosture) PreventsPushingSecrets() bool          { return m.preventsPush }
+func (m mockSecurityPosture) ScansForSecrets() bool                 { return m.scans }
+func (m mockSecurityPosture) DefinesPolicyForHandlingSecrets() bool { return false }
+func (m mockSecurityPosture) SecretScanningObservable() bool        { return m.observable }
+
+func TestSecretScanningInUse(t *testing.T) {
+	testCases := []struct {
+		name           string
+		posture        mockSecurityPosture
+		expectedResult gemara.Result
+	}{
+		{
+			name:           "fully enabled passes",
+			posture:        mockSecurityPosture{preventsPush: true, scans: true, observable: true},
+			expectedResult: gemara.Passed,
+		},
+		{
+			name:           "partially enabled fails",
+			posture:        mockSecurityPosture{scans: true, observable: true},
+			expectedResult: gemara.Failed,
+		},
+		{
+			name:           "observably disabled fails",
+			posture:        mockSecurityPosture{observable: true},
+			expectedResult: gemara.Failed,
+		},
+		{
+			// The 14k-repo case: no admin access to read security_and_analysis and
+			// no Security Insights claim, so the status is unknown, not off.
+			name:           "unobservable needs review",
+			posture:        mockSecurityPosture{observable: false},
+			expectedResult: gemara.NeedsReview,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, _, _ := SecretScanningInUse(data.Payload{SecurityPosture: tc.posture})
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
 var goodWorkflowFile = `name: OSPS Baseline Scan
 
 on: [workflow_dispatch]

--- a/evaluation_plans/osps/build_release/steps_test.go
+++ b/evaluation_plans/osps/build_release/steps_test.go
@@ -136,50 +136,71 @@ func TestReleasesAreSignedOrAttested(t *testing.T) {
 // mockSecurityPosture implements data.SecurityPosture so step tests can drive
 // SecretScanningInUse without constructing a real (admin-scoped) API payload.
 type mockSecurityPosture struct {
-	preventsPush bool
-	scans        bool
-	observable   bool
+	preventsPush     bool
+	scans            bool
+	observable       bool
+	insightsDeclares bool
 }
 
 func (m mockSecurityPosture) PreventsPushingSecrets() bool          { return m.preventsPush }
 func (m mockSecurityPosture) ScansForSecrets() bool                 { return m.scans }
 func (m mockSecurityPosture) DefinesPolicyForHandlingSecrets() bool { return false }
 func (m mockSecurityPosture) SecretScanningObservable() bool        { return m.observable }
+func (m mockSecurityPosture) InsightsDeclaresSecretScanning() bool  { return m.insightsDeclares }
 
 func TestSecretScanningInUse(t *testing.T) {
 	testCases := []struct {
-		name           string
-		posture        mockSecurityPosture
-		expectedResult gemara.Result
+		name            string
+		posture         mockSecurityPosture
+		expectedResult  gemara.Result
+		expectedMessage string
 	}{
 		{
-			name:           "fully enabled passes",
-			posture:        mockSecurityPosture{preventsPush: true, scans: true, observable: true},
-			expectedResult: gemara.Passed,
+			name:            "GitHub reports both enabled passes",
+			posture:         mockSecurityPosture{preventsPush: true, scans: true, observable: true},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "GitHub secret scanning and push protection are both enabled",
 		},
 		{
-			name:           "partially enabled fails",
-			posture:        mockSecurityPosture{scans: true, observable: true},
-			expectedResult: gemara.Failed,
+			// Native settings off/unreadable, but the project self-declares tooling.
+			name:            "Security Insights declaration passes",
+			posture:         mockSecurityPosture{insightsDeclares: true},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Security Insights declares secret-scanning tooling",
 		},
 		{
-			name:           "observably disabled fails",
-			posture:        mockSecurityPosture{observable: true},
-			expectedResult: gemara.Failed,
+			name:            "scanning without push protection fails and names the gap",
+			posture:         mockSecurityPosture{scans: true, observable: true},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "GitHub secret scanning is enabled, but push protection is not",
+		},
+		{
+			name:            "push protection without scanning fails and names the gap",
+			posture:         mockSecurityPosture{preventsPush: true, observable: true},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "GitHub push protection is enabled, but secret scanning is not",
+		},
+		{
+			name:            "observably disabled fails",
+			posture:         mockSecurityPosture{observable: true},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "GitHub reports secret scanning and push protection are both disabled",
 		},
 		{
 			// The 14k-repo case: no admin access to read security_and_analysis and
 			// no Security Insights claim, so the status is unknown, not off.
-			name:           "unobservable needs review",
-			posture:        mockSecurityPosture{observable: false},
-			expectedResult: gemara.NeedsReview,
+			name:            "unobservable with no declaration needs review",
+			posture:         mockSecurityPosture{observable: false},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "not observable",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, _, _ := SecretScanningInUse(data.Payload{SecurityPosture: tc.posture})
+			result, message, _ := SecretScanningInUse(data.Payload{SecurityPosture: tc.posture})
 			assert.Equal(t, tc.expectedResult, result)
+			assert.Contains(t, message, tc.expectedMessage)
 		})
 	}
 }


### PR DESCRIPTION
GitHub returns the security_and_analysis block only to repo admins, so SecretScanningInUse (BR-07.01) was failing every repo the token doesn't administer. Distinguish unobservable from disabled (mirroring PrivateVulnReporting.Known) and return NeedsReview when the status can't be read.