### PR TITLE
fix: use partial GraphQL data when field-level permissions are denied

### DIFF
--- a/data/payload.go
+++ b/data/payload.go
@@ -133,7 +133,19 @@ func getGraphqlRepoData(config *config.Config, client *githubv4.Client, owner, r
 		return client.Query(context.Background(), &data, variables)
 	})
 	if err != nil {
+		// githubv4 decodes every resolvable field into data before returning a
+		// GraphQL errors-array error, so a field-level permission error still leaves
+		// a usable payload: admin/installation-gated fields (branch protection, the
+		// dependency graph) decode to their zero value while public fields resolve.
+		// Repository.Name is non-null in the schema, so a populated name means the
+		// repository node itself resolved and the error is scoped to those gated
+		// fields — treat it as a soft failure and proceed on the partial data.
+		if data != nil && data.Repository.Name != "" {
+			config.Logger.Warn(fmt.Sprintf("GraphQL repo data query returned partial data; some fields were not accessible with the current token (checks that depend on them will see zero values): %s", err.Error()))
+			return data, nil
+		}
 		config.Logger.Error(fmt.Sprintf("Error querying GitHub GraphQL API: %s", err.Error()))
+		return nil, err
 	}
 	return data, err
 }

--- a/data/payload_test.go
+++ b/data/payload_test.go
@@ -65,6 +65,52 @@ func graphqlServer(t *testing.T, body string) (*githubv4.Client, *int) {
 	return githubv4.NewEnterpriseClient(server.URL, server.Client()), &calls
 }
 
+func TestGetGraphqlRepoData(t *testing.T) {
+	cfg := &config.Config{Logger: hclog.NewNullLogger()}
+
+	t.Run("a clean response is returned as-is", func(t *testing.T) {
+		client, _ := graphqlServer(t, `{"data":{"repository":{"name":"kubernetes","hasIssuesEnabled":true,"dependencyGraphManifests":{"totalCount":39}}}}`)
+
+		data, err := getGraphqlRepoData(cfg, client, "kubernetes", "kubernetes")
+		require.NoError(t, err)
+		require.NotNil(t, data)
+		assert.Equal(t, "kubernetes", data.Repository.Name)
+		assert.Equal(t, 39, data.Repository.DependencyGraphManifests.TotalCount)
+	})
+
+	t.Run("partial data with a field-level permission error is not fatal", func(t *testing.T) {
+		// A GitHub App installation token on a repo the app is not installed on:
+		// GitHub returns the public fields plus a "Resource not accessible by
+		// integration" error for the admin/installation-gated ones. githubv4 has
+		// already decoded the resolvable fields, so the payload must still load.
+		client, _ := graphqlServer(t, `{"data":{"repository":{"name":"kubernetes","hasIssuesEnabled":true,`+
+			`"defaultBranchRef":{"name":"master","branchProtectionRule":null,"refUpdateRule":null},`+
+			`"dependencyGraphManifests":null,"licenseInfo":{"name":"Apache License 2.0"}}},`+
+			`"errors":[{"message":"Resource not accessible by integration"}]}`)
+
+		data, err := getGraphqlRepoData(cfg, client, "kubernetes", "kubernetes")
+		require.NoError(t, err, "a field-level permission error with partial data must not be fatal")
+		require.NotNil(t, data)
+		assert.Equal(t, "kubernetes", data.Repository.Name)
+		assert.True(t, data.Repository.HasIssuesEnabled)
+		assert.Equal(t, "Apache License 2.0", data.Repository.LicenseInfo.Name)
+		// Inaccessible fields degrade to their zero values, exactly as a PAT sees
+		// on a repo it does not admin.
+		assert.Equal(t, 0, data.Repository.DependencyGraphManifests.TotalCount)
+		assert.False(t, data.Repository.DefaultBranchRef.BranchProtectionRule.RequiresApprovingReviews)
+	})
+
+	t.Run("an error with no recoverable repository is still fatal", func(t *testing.T) {
+		// No data object (e.g. the repository could not be resolved at all): there
+		// is nothing to fall back on, so the error must propagate.
+		client, _ := graphqlServer(t, `{"data":null,"errors":[{"message":"Could not resolve to a Repository"}]}`)
+
+		data, err := getGraphqlRepoData(cfg, client, "nope", "nope")
+		require.Error(t, err)
+		assert.Nil(t, data)
+	})
+}
+
 func TestFetchWorkflowFiles(t *testing.T) {
 	cfg := &config.Config{Logger: hclog.NewNullLogger()}
 


### PR DESCRIPTION
A GitHub App installation token on a repo the app is not installed on returns public fields alongside a permission error for admin-gated fields. githubv4 has already decoded the resolvable fields, so treat a populated repository as a soft failure: log a warning and run the public-data checks rather than aborting the whole scan.