### PR TITLE
fix: pass GV-03.02 through to observed contribution guides

### DIFF
--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -134,5 +134,15 @@ func HasContributionReviewPolicy(payload data.Payload) (result gemara.Result, me
 		return gemara.Passed, "Code review guide was specified in Security Insights data", confidence
 	}
 
-	return gemara.Failed, "Code review guide was NOT specified in Security Insights data", confidence
+	// GV-03.02 wants a contributor guide that documents the requirements for
+	// acceptable contributions, which the OSPS recommendation places in
+	// CONTRIBUTING.md. When Security Insights does not declare it but a
+	// contribution guide is observed, that guide may well cover those
+	// requirements — we just cannot confirm the content automatically, so flag it
+	// for review rather than failing a repo that most likely documents this.
+	if evidence := contributionGuideEvidence(payload); evidence != "" {
+		return gemara.NeedsReview, "Contribution guide found via " + evidence + ", but Security Insights does not declare its requirements for acceptable contributions; manual review required to confirm the guide covers them", gemara.Low
+	}
+
+	return gemara.Failed, "No contributor guide documenting requirements for acceptable contributions found in Security Insights data or repository files", gemara.Medium
 }

--- a/evaluation_plans/osps/governance/steps_test.go
+++ b/evaluation_plans/osps/governance/steps_test.go
@@ -123,6 +123,62 @@ func TestHasContributionGuide(t *testing.T) {
 	}
 }
 
+func TestHasContributionReviewPolicy(t *testing.T) {
+	tests := []struct {
+		name            string
+		build           func() data.Payload
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name: "not a code repository is not applicable",
+			build: func() data.Payload {
+				return data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: &data.GraphqlRepoData{}}, nil, 200, nil)
+			},
+			expectedResult:  gemara.NotApplicable,
+			expectedMessage: "Repository contains no code - skipping code contribution policy check",
+		},
+		{
+			name: "Security Insights declares a review policy",
+			build: func() data.Payload {
+				p := data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: &data.GraphqlRepoData{}, IsCodeRepo: true}, nil, 200, nil)
+				p.Insights.Repository.Documentation.ReviewPolicy = stubURL("https://example.com/REVIEW.md")
+				return p
+			},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Code review guide was specified in Security Insights data",
+		},
+		{
+			name: "observed contribution guide with no declared policy needs review",
+			build: func() data.Payload {
+				repo := &data.GraphqlRepoData{}
+				repo.Repository.Object.Tree.Entries = append(repo.Repository.Object.Tree.Entries,
+					treeEntry("CONTRIBUTING.md", "blob", "CONTRIBUTING.md"),
+				)
+				return data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: repo, IsCodeRepo: true}, nil, 200, nil)
+			},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "Contribution guide found via GitHub API (repository file CONTRIBUTING.md), but Security Insights does not declare its requirements for acceptable contributions; manual review required to confirm the guide covers them",
+		},
+		{
+			name: "no guide and no policy fails",
+			build: func() data.Payload {
+				return data.NewPayloadWithHTTPMock(data.Payload{GraphqlRepoData: &data.GraphqlRepoData{}, IsCodeRepo: true}, nil, 200, nil)
+			},
+			expectedResult:  gemara.Failed,
+			expectedMessage: "No contributor guide documenting requirements for acceptable contributions found in Security Insights data or repository files",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message, _ := HasContributionReviewPolicy(test.build())
+			assert.Equal(t, test.expectedResult, result)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}
+
 func file(name, path string) *github.RepositoryContent {
 	return &github.RepositoryContent{
 		Type: github.Ptr("file"),


### PR DESCRIPTION
GV-03.02 (HasContributionReviewPolicy) only checked the Security Insights ReviewPolicy field, failing ~99% of repos even with a CONTRIBUTING.md. Fall back to the same observed-guide evidence GV-03.01 uses; an observed guide yields NeedsReview since file existence can't confirm it documents acceptance requirements.