### PR TITLE
fix: reduce QA-05.02/05.01 binary-check false positives

### DIFF
--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -77,7 +77,10 @@ type binaryChecker struct {
 // generated executable artifacts. Non-executable binaries (e.g. images) are not flagged.
 func (bc *binaryChecker) check(isBinaryPtr *bool, isTruncated bool, path string, mode int) (bool, error) {
 	if isBinaryPtr != nil {
-		if *isBinaryPtr && mode&0111 == 0 {
+		if !*isBinaryPtr {
+			return false, nil
+		}
+		if mode&0111 == 0 {
 			// File is binary but lacks any Unix execute permission bits (owner, group, other).
 			// Git only uses mode 100755 for executables, but the bitwise check is more
 			// robust against non-standard modes from other Git implementations.
@@ -85,7 +88,14 @@ func (bc *binaryChecker) check(isBinaryPtr *bool, isTruncated bool, path string,
 			// per OSPS-QA-05.01 and should not be flagged.
 			return false, nil
 		}
-		return *isBinaryPtr, nil
+		// File is binary with an execute bit set. Acceptable binary formats (images,
+		// audio, video, fonts, documents) are not "generated executable artifacts" per
+		// OSPS-QA-05.01 even when a stray execute bit is present — a common artifact of
+		// checkouts from filesystems without Unix permissions — so they are not flagged.
+		if acceptableBinaryExtension(path) {
+			return false, nil
+		}
+		return true, nil
 	}
 	// If file has a common text extension, assume it's not binary to avoid unnecessary HTTP requests
 	if commonAcceptableFileExtension(path) {
@@ -193,7 +203,8 @@ func commonAcceptableFileExtension(path string) bool {
 }
 
 // acceptableBinaryExtension returns true for binary file types that are considered
-// reviewable or acceptable in a repository, such as images, audio, video, and fonts.
+// reviewable or acceptable in a repository, such as images, audio, video, fonts,
+// documents, and design-tool source files.
 // These are excluded from OSPS-QA-05.02 "unreviewable binary artifacts" checks.
 func acceptableBinaryExtension(path string) bool {
 	ext := fileExtension(path)
@@ -211,7 +222,9 @@ func acceptableBinaryExtension(path string) bool {
 		// Fonts
 		".ttf", ".otf", ".woff", ".woff2", ".eot",
 		// Documents
-		".pdf",
+		".pdf", ".docx", ".doc", ".pptx", ".xlsx",
+		// Design source assets (image / design-tool source files, same category as images)
+		".ai", ".sketch", ".psd", ".graffle",
 	}
 	return slices.Contains(extensions, ext)
 }
@@ -219,7 +232,8 @@ func acceptableBinaryExtension(path string) bool {
 // checkUnreviewable determines whether a file is an unreviewable binary artifact
 // per OSPS-QA-05.02. Unlike check(), which only flags executable binaries,
 // this flags all binary files except those with acceptable extensions (images,
-// audio, video, fonts, PDFs) that are legitimately stored in binary format.
+// audio, video, fonts, documents, design assets) that are legitimately stored
+// in binary format.
 // When isBinaryPtr is nil (GitHub couldn't determine binary status), it falls
 // back to extension checks and partial content fetching for truncated files.
 func (bc *binaryChecker) checkUnreviewable(isBinaryPtr *bool, isTruncated bool, path string) (bool, error) {

--- a/data/graphql-binary-check_test.go
+++ b/data/graphql-binary-check_test.go
@@ -144,6 +144,19 @@ func TestBinaryCheckerIsBinary(t *testing.T) {
 		}
 	})
 
+	t.Run("acceptable binary with stray execute bit not flagged", func(t *testing.T) {
+		for _, path := range []string{"ap-logo.png", "font.woff2", "doc.pdf"} {
+			result, err := bc.check(boolPtr(true), false, path, modeExecutable)
+			if err != nil {
+				t.Errorf("check() error = %v", err)
+				return
+			}
+			if result {
+				t.Errorf("expected acceptable binary %q with execute bit to not be flagged as executable artifact", path)
+			}
+		}
+	})
+
 	t.Run("isBinary false returns false", func(t *testing.T) {
 		result, err := bc.check(boolPtr(false), false, "any-file", modeNonExecutable)
 		if err != nil {
@@ -763,6 +776,16 @@ func TestAcceptableBinaryExtension(t *testing.T) {
 		{name: "woff2 font", path: "font.woff2", expected: true},
 		// Documents — acceptable
 		{name: "pdf document", path: "doc.pdf", expected: true},
+		{name: "docx document", path: "contract-sample.docx", expected: true},
+		{name: "doc document", path: "legacy.doc", expected: true},
+		{name: "pptx document", path: "slides.pptx", expected: true},
+		{name: "xlsx document", path: "budget.xlsx", expected: true},
+		{name: "double dot docx", path: "vFabric..docx", expected: true},
+		// Design source assets — acceptable
+		{name: "ai illustrator", path: "logo.ai", expected: true},
+		{name: "sketch design", path: "nginx-ui-logo-design.sketch", expected: true},
+		{name: "psd photoshop", path: "24pullrequests.psd", expected: true},
+		{name: "graffle diagram", path: "imposter.graffle", expected: true},
 		// Case insensitive
 		{name: "upper PNG", path: "logo.PNG", expected: true},
 	}
@@ -826,6 +849,18 @@ func TestCheckUnreviewable(t *testing.T) {
 		}
 		if result {
 			t.Error("expected binary font to return false (acceptable)")
+		}
+	})
+
+	t.Run("binary design asset not flagged", func(t *testing.T) {
+		for _, path := range []string{"logo.ai", "nginx-ui-logo-design.sketch", "art.psd", "diagram.graffle"} {
+			result, err := bc.checkUnreviewable(boolPtr(true), false, path)
+			if err != nil {
+				t.Errorf("checkUnreviewable() error = %v", err)
+			}
+			if result {
+				t.Errorf("expected binary design asset %q to return false (acceptable)", path)
+			}
 		}
 	})
 


### PR DESCRIPTION
Expand the acceptable-binary allowlist so genuinely reviewable, non-code assets are no longer flagged as unreviewable binary artifacts (OSPS-QA-05.02):

- Design/graphics sources: .ai, .sketch, .psd, .graffle
- Office documents: .docx, .doc, .pptx, .xlsx (same reviewability class as the already-excluded .pdf)

Also fix a QA-05.01 false positive: check() now skips acceptable binary extensions even when a Unix execute bit is set, so an image with a stray execute bit (a common artifact of checkouts from filesystems without Unix permissions) is not reported as a generated executable artifact.

Archives (.tar, .zip), JARs, and compressed scientific data remain flagged by design; those are genuinely unreviewable in-repo.