### PR TITLE
fix: observability + result-semantics for QA-03/QA-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ To use scan results with the OpenSSF Best Practices Badge, see the user guide in
 
 Contributions are welcome! Please see our [Contributing Guidelines](.github/CONTRIBUTING.md) for more information.
 
+When writing or changing an assessment step, follow the result-semantics
+contract in [docs/assessment-result-semantics.md](docs/assessment-result-semantics.md)
+so results stay consistent across controls.
+
 ## License
 
 This project is licensed under the Apache 2.0 License - see the [LICENSE](LICENSE) file for details.

--- a/docs/assessment-result-semantics.md
+++ b/docs/assessment-result-semantics.md
@@ -1,0 +1,119 @@
+# Assessment Result Semantics
+
+This page defines the result-semantics contract every assessment step in this
+plugin is expected to follow. It exists so that a scan result means the same
+thing no matter which control produced it, and so future contributors keep that
+consistency. Read it before writing or changing a step.
+
+The guiding principle is **accuracy, not pass rate**: a result must report only
+what was actually observed with the access the scan had.
+
+## The Result Contract
+
+Each step returns one of five `gemara.Result` values. Choose the one that
+matches what you observed, not the one that produces a nicer score.
+
+| Result | Use when | Never use it to mean |
+| --- | --- | --- |
+| `Passed` | Compliance was **positively observed**. The message names the evidence source. | "Nothing looked wrong." |
+| `Failed` | A violation was **observed** — the data was visible and shows non-compliance. | "We could not see the relevant state." |
+| `NeedsReview` | The control's state is **not observable** with the current access (non-admin token, no `security-insights.yml`), or a genuine human judgment is required. | A polite way to avoid deciding an observable case. |
+| `NotApplicable` | The control's **precondition is absent** (no releases, no code, no workflows). | The control was checked and passed. |
+| `Unknown` | The **scanner itself errored** (a fetch or parse failed). | The repository is missing something. |
+
+The single most important rule: **`Failed` is an observed violation, never an
+absence of visibility.** When protection or configuration data comes back empty
+because the token cannot see it, that is `NeedsReview`, not `Failed`. Passing on
+an unobservable state is equally wrong — do not read a zero value as compliance.
+
+## Evidence-Source Precedence
+
+When more than one source can answer a control, consult them in this order and
+stop at the first that gives a definite answer:
+
+1. **Security Insights declaration** — an explicit statement of project intent
+   from `security-insights.yml`. Prefer it because the project asserted it.
+2. **Direct GitHub observation** — the REST/GraphQL API or repository contents
+   (community files, the root tree, rulesets). Trustworthy for what it can see.
+3. **AI-assisted review** — only when the deterministic sources are
+   inconclusive. It records auditable evidence and returns a `Passed`, `Failed`,
+   or `NeedsReview` verdict; it never silently decides.
+4. **Floor** — if nothing above resolves the control, fall to `NeedsReview` when
+   the state was merely unobservable, or `Failed` when absence was positively
+   observed.
+
+Always name the source in the message (for example, "declared in Security
+Insights", "license file found in the repository root", or the AI verdict), so a
+reader can audit where the verdict came from.
+
+## Chain Semantics For Step Authors
+
+Assessments run their steps in order. The following behavior is verified against
+go-gemara v0.8.0 (`AssessmentLog.Run` and `UpdateAggregateResult`):
+
+- **Only `Failed` halts the chain.** `Passed`, `NeedsReview`, `NotApplicable`,
+  and `Unknown` all let the next step run.
+- **Aggregate severity:** `Failed` > `Unknown` > `NeedsReview` > `Passed`.
+  `NotRun` preserves the previous result, and `NotApplicable` folds harmlessly
+  (it does not lower a `Passed`).
+- **A `NeedsReview` return caps the assessment at `NeedsReview`** without
+  stopping the chain. That is the intended outcome for an unobservable control.
+- **The last executed step's message wins** for the human-readable summary, so
+  order steps such that the most informative message is the one that survives.
+
+The important trap: a guard step that returns `NeedsReview` when
+`security-insights.yml` is absent does **not** stop later steps, but it does cap
+the assessment at `NeedsReview` — so if a later step can `Pass` from a non-SI
+fallback, the guard hides that pass. **Steps that have a non-SI fallback must
+handle SI absence themselves** rather than sitting behind a
+`HasSecurityInsightsFile` guard.
+
+## Observable vs. Admin-Only GitHub Data
+
+Some GitHub data is only returned to a token with admin on the target
+repository. For a non-admin scan those fields come back as **zero values that
+are indistinguishable from "not configured"** — they must never be read as
+`Failed` or as `Passed`.
+
+**Admin-only (treat empty as unobservable → `NeedsReview`):**
+
+- Classic branch protection via the GraphQL `BranchProtectionRule` and
+  `RefUpdateRule` objects.
+- The default workflow token permissions
+  (`/repos/{o}/{r}/actions/permissions/workflow`).
+- `SecurityAndAnalysis` (secret scanning, push protection settings).
+
+**Publicly observable (a definite answer for any token):**
+
+- Repository rulesets (the rules-for-branch REST API).
+- Private vulnerability reporting (`/repos/{o}/{r}/private-vulnerability-reporting`).
+- `IsSecurityPolicyEnabled` (already in the GraphQL query) and community files
+  in the repository tree.
+
+When a control could be satisfied by either an admin-only mechanism or a public
+one, check the public source first — it lets a non-admin scan reach a definite
+`Passed` instead of falling to `NeedsReview`.
+
+## AI-Assisted Steps
+
+AI assistance is an optional, last-resort evidence source. The authoritative
+reference is the SDK guide at
+[`privateer-sdk/docs/ai-assist.md`](https://github.com/privateerproj/privateer-sdk/blob/main/docs/ai-assist.md);
+this section only summarizes the conventions a step must follow.
+
+- **Opt-in configuration.** AI runs only when the `ai_*` config keys are set
+  (`ai_provider`, `ai_model`, `ai_api_key`, and optionally `ai_base_url`,
+  `ai_timeout`, `ai_max_tokens`; each also has a `PVTR_AI_*` environment
+  variable). With none set, `ai.NewClient` returns `(nil, nil)` and steps skip
+  their AI paths.
+- **Deterministic first.** Compute the deterministic verdict before calling the
+  model, and only consult AI when that verdict is inconclusive.
+- **Assist errors keep the deterministic verdict.** A failed or timed-out AI
+  call must not turn into `Failed` or `Unknown` on its own; fall back to what
+  the deterministic check already established.
+- **Bound the material.** Send only what the question needs (on the order of a
+  few tens of thousands of characters). Never put secrets in the material — the
+  prompt and material are recorded verbatim in the evaluation output.
+- **Record the evidence.** Log the question, verdict, and provenance through the
+  payload's evidence collector so every AI-influenced result is auditable. The
+  step, not `Assist`, decides how the verdict folds into its result.

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -154,8 +154,9 @@ var (
 		},
 		"OSPS-QA-04.01": {
 			reusable_steps.IsCodeRepo,
-			reusable_steps.HasSecurityInsightsFile,
 			reusable_steps.IsActive,
+			// InsightsListsRepositories reports SI absence as NeedsReview itself,
+			// so the HasSecurityInsightsFile guard would only mask a Pass.
 			quality.InsightsListsRepositories,
 		},
 		"OSPS-QA-04.02": {

--- a/evaluation_plans/osps/quality/insights_repos_test.go
+++ b/evaluation_plans/osps/quality/insights_repos_test.go
@@ -1,0 +1,86 @@
+package quality
+
+import (
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/si-tooling/v2/si"
+)
+
+func Test_InsightsListsRepositories(t *testing.T) {
+	// presentInsights builds a Security Insights value that was found and parsed:
+	// a non-empty Header.URL is how the plugin marks the file as present.
+	presentInsights := func(repos []si.ProjectRepository) si.SecurityInsights {
+		return si.SecurityInsights{
+			Header:  si.Header{URL: "https://github.com/org/repo/security-insights.yml"},
+			Project: &si.Project{Repositories: repos},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		payload    data.Payload
+		wantResult gemara.Result
+		wantMsg    string
+	}{
+		{
+			name: "SI present and lists repositories - passed",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					Insights: presentInsights([]si.ProjectRepository{
+						{Url: "https://github.com/org/repo"},
+					}),
+				},
+			},
+			wantResult: gemara.Passed,
+			wantMsg:    "Insights contains a list of repositories",
+		},
+		{
+			name: "SI present but omits the list - failed",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					Insights: presentInsights([]si.ProjectRepository{}),
+				},
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Insights does not contain a list of repositories",
+		},
+		{
+			name: "SI absent - needs review",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					Insights: si.SecurityInsights{Project: &si.Project{}},
+				},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Cannot enumerate the project's repositories without a Security Insights declaration",
+		},
+		{
+			name: "SI unparseable - needs review",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					InsightsError: true,
+					// A parse error can leave a stray URL; the error flag still wins.
+					Insights: presentInsights([]si.ProjectRepository{
+						{Url: "https://github.com/org/repo"},
+					}),
+				},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Cannot enumerate the project's repositories without a Security Insights declaration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, gotMsg, _ := InsightsListsRepositories(tt.payload)
+			if gotResult != tt.wantResult {
+				t.Errorf("result = %v, want %v", gotResult, tt.wantResult)
+			}
+			if gotMsg != tt.wantMsg {
+				t.Errorf("message = %q, want %q", gotMsg, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -16,6 +16,14 @@ func RepoIsPublic(payload data.Payload) (result gemara.Result, message string, c
 }
 
 func InsightsListsRepositories(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	// A project's full repository set is only knowable from a project-level
+	// declaration like Security Insights; GitHub cannot tell us a multi-repo
+	// project's intended set. So an absent or unparseable SI file is unknown, not
+	// a violation — return NeedsReview rather than a false Failed.
+	if payload.InsightsError || payload.Insights.Header.URL == "" {
+		return gemara.NeedsReview, "Cannot enumerate the project's repositories without a Security Insights declaration", confidence
+	}
+
 	if len(payload.Insights.Project.Repositories) > 0 {
 		return gemara.Passed, "Insights contains a list of repositories", confidence
 	}

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -23,8 +23,11 @@ func InsightsListsRepositories(payload data.Payload) (result gemara.Result, mess
 	return gemara.Failed, "Insights does not contain a list of repositories", confidence
 }
 
-func StatusChecksAreRequiredByRulesets(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	// get the name of all status checks that were run
+// observedStatusChecks returns the names of the check runs seen on the latest
+// default-branch commit. This is a weak sample: it only reflects checks attached
+// to the most recent pull request, so a repo whose latest default-branch commit
+// did not come from a PR shows zero checks even when CI is configured.
+func observedStatusChecks(payload data.Payload) []string {
 	var statusChecks []string
 	for _, check := range payload.Repository.DefaultBranchRef.Target.Commit.AssociatedPullRequests.Nodes {
 		for _, run := range check.StatusCheckRollup.Commit.CheckSuites.Nodes {
@@ -33,52 +36,14 @@ func StatusChecksAreRequiredByRulesets(payload data.Payload) (result gemara.Resu
 			}
 		}
 	}
-
-	// Branch rulesets are fetched once during payload load.
-	if !payload.RepositoryMetadata.HasBranchRules() {
-		return gemara.Passed, "No rulesets found for default branch, continuing to evaluate branch protection", confidence
-	}
-
-	// get the name of all required status checks
-	requiredChecks := payload.RepositoryMetadata.RequiredStatusCheckContexts()
-
-	// check whether all executed checks are required
-	missingChecks := []string{}
-	for _, check := range statusChecks {
-		found := false
-		for _, requiredCheck := range requiredChecks {
-			if check == requiredCheck {
-				found = true
-				break
-			}
-		}
-		if !found {
-			missingChecks = append(missingChecks, check)
-		}
-	}
-
-	if len(missingChecks) > 0 {
-		return gemara.Failed, fmt.Sprintf("Some executed status checks are not mandatory but all should be: %s (NOTE: Not continuing to evaluate branch protection: combining requirements in rulesets and branch protection is not recommended)", strings.Join(missingChecks, ", ")), confidence
-	}
-
-	return gemara.Passed, "No status checks were run that are not required by the rules", confidence
+	return statusChecks
 }
 
-func StatusChecksAreRequiredByBranchProtection(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	// get the name of all status checks that were run
-	var statusChecks []string
-	for _, check := range payload.Repository.DefaultBranchRef.Target.Commit.AssociatedPullRequests.Nodes {
-		for _, run := range check.StatusCheckRollup.Commit.CheckSuites.Nodes {
-			for _, checkRun := range run.CheckRuns.Nodes {
-				statusChecks = append(statusChecks, checkRun.Name)
-			}
-		}
-	}
-
-	requiredChecks := payload.Repository.DefaultBranchRef.BranchProtectionRule.RequiredStatusCheckContexts
-
-	// check whether all executed checks are required
-	missingChecks := []string{}
+// checksNotRequired returns the observed checks that are absent from the
+// required set. The control treats every executed check as one that should be
+// mandatory, so a non-empty result is a finding.
+func checksNotRequired(statusChecks, requiredChecks []string) []string {
+	missing := []string{}
 	for _, check := range statusChecks {
 		found := false
 		for _, requiredCheck := range requiredChecks {
@@ -88,15 +53,76 @@ func StatusChecksAreRequiredByBranchProtection(payload data.Payload) (result gem
 			}
 		}
 		if !found {
-			missingChecks = append(missingChecks, check)
+			missing = append(missing, check)
 		}
 	}
+	return missing
+}
 
-	if len(missingChecks) > 0 {
-		return gemara.Failed, fmt.Sprintf("Some executed status checks are not mandatory but all should be: %s", strings.Join(missingChecks, ", ")), confidence
+// evaluateStatusCheckRequirement makes the OSPS-QA-03.01 determination in an
+// observability-aware way. Rulesets are publicly readable, so they are the
+// authoritative source when present; otherwise the check falls back to classic
+// branch protection, which GitHub exposes only to admins. When no required-check
+// configuration is observable, the step returns NeedsReview rather than a
+// vacuous Pass (nothing proves checks are required) or a false Fail (the
+// requirement may exist but be invisible to a non-admin token).
+//
+// Both QA-03 steps share this determination so the requirement reports one
+// coherent result and message regardless of which source is authoritative.
+func evaluateStatusCheckRequirement(payload data.Payload) (gemara.Result, string) {
+	statusChecks := observedStatusChecks(payload)
+
+	var requiredChecks []string
+	var source string
+	if payload.RepositoryMetadata.HasBranchRules() {
+		requiredChecks = payload.RepositoryMetadata.RequiredStatusCheckContexts()
+		source = "rulesets"
+	} else {
+		requiredChecks = payload.Repository.DefaultBranchRef.BranchProtectionRule.RequiredStatusCheckContexts
+		source = "branch protection"
 	}
 
-	return gemara.Passed, "No status checks were run that are not required by branch protection", confidence
+	// No observable required-check configuration: the requirement cannot be
+	// confirmed either way.
+	if len(requiredChecks) == 0 {
+		if len(statusChecks) > 0 {
+			return gemara.NeedsReview, "status checks run but requirement configuration is not observable without admin access"
+		}
+		return gemara.NeedsReview, "no status checks observed and status-check requirements are not observable without admin access; the latest default-branch commit may not have come from a pull request"
+	}
+
+	// Required checks are configured; every observed check should be among them.
+	if missing := checksNotRequired(statusChecks, requiredChecks); len(missing) > 0 {
+		return gemara.Failed, fmt.Sprintf("Some executed status checks are not required by %s but all should be: %s", source, strings.Join(missing, ", "))
+	}
+	if len(statusChecks) == 0 {
+		return gemara.Passed, fmt.Sprintf("Status-check requirements are configured in %s", source)
+	}
+	return gemara.Passed, fmt.Sprintf("All executed status checks are required by %s", source)
+}
+
+// StatusChecksAreRequiredByRulesets is the authoritative source for
+// OSPS-QA-03.01 when rulesets apply to the default branch; otherwise it defers
+// to branch protection (NotRun, which the aggregate ignores) while still
+// reporting the shared determination message.
+func StatusChecksAreRequiredByRulesets(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	result, message = evaluateStatusCheckRequirement(payload)
+	if payload.RepositoryMetadata.HasBranchRules() {
+		return result, message, confidence
+	}
+	return gemara.NotRun, message, confidence
+}
+
+// StatusChecksAreRequiredByBranchProtection is the authoritative source for
+// OSPS-QA-03.01 when no rulesets apply to the default branch; when rulesets are
+// present the rulesets step already decided, so this one defers (NotRun) while
+// echoing the shared determination message.
+func StatusChecksAreRequiredByBranchProtection(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	result, message = evaluateStatusCheckRequirement(payload)
+	if !payload.RepositoryMetadata.HasBranchRules() {
+		return result, message, confidence
+	}
+	return gemara.NotRun, message, confidence
 }
 
 func NoBinariesInRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
@@ -151,15 +177,7 @@ func RequiresNonAuthorApproval(payload data.Payload) (result gemara.Result, mess
 }
 
 func HasOneOrMoreStatusChecks(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	// get the name of all status checks that were run
-	var statusChecks []string
-	for _, check := range payload.Repository.DefaultBranchRef.Target.Commit.AssociatedPullRequests.Nodes {
-		for _, run := range check.StatusCheckRollup.Commit.CheckSuites.Nodes {
-			for _, checkRun := range run.CheckRuns.Nodes {
-				statusChecks = append(statusChecks, checkRun.Name)
-			}
-		}
-	}
+	statusChecks := observedStatusChecks(payload)
 
 	if len(statusChecks) > 0 {
 		return gemara.Passed, fmt.Sprintf("%d status checks were run", len(statusChecks)), confidence

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -8,75 +8,10 @@ import (
 	"github.com/gemaraproj/go-gemara"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
-	"github.com/ossf/si-tooling/v2/si"
 	"github.com/privateerproj/privateer-sdk/config"
 )
 
-func Test_InsightsListsRepositories(t *testing.T) {
-	tests := []struct {
-		name       string
-		payload    data.Payload
-		wantResult gemara.Result
-		wantMsg    string
-	}{
-		{
-			name: "insights contains repositories",
-			payload: data.Payload{
-				RestData: &data.RestData{
-					Insights: si.SecurityInsights{
-						Project: &si.Project{
-							Repositories: []si.ProjectRepository{
-								{
-									Url: "https://github.com/org/repo",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantResult: gemara.Passed,
-			wantMsg:    "Insights contains a list of repositories",
-		},
-		{
-			name: "insights does not contain repositories",
-			payload: data.Payload{
-				RestData: &data.RestData{
-					Insights: si.SecurityInsights{
-						Project: &si.Project{
-							Repositories: []si.ProjectRepository{},
-						},
-					},
-				},
-			},
-			wantResult: gemara.Failed,
-			wantMsg:    "Insights does not contain a list of repositories",
-		},
-		{
-			name: "insights is nil",
-			payload: data.Payload{
-				RestData: &data.RestData{
-					Insights: si.SecurityInsights{
-						Project: &si.Project{},
-					},
-				},
-			},
-			wantResult: gemara.Failed,
-			wantMsg:    "Insights does not contain a list of repositories",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotResult, gotMsg, _ := InsightsListsRepositories(tt.payload)
-			if gotResult != tt.wantResult {
-				t.Errorf("result = %v, want %v", gotResult, tt.wantResult)
-			}
-			if gotMsg != tt.wantMsg {
-				t.Errorf("message = %q, want %q", gotMsg, tt.wantMsg)
-			}
-		})
-	}
-}
+// Tests for InsightsListsRepositories live in insights_repos_test.go.
 
 func Test_NoBinariesInRepo(t *testing.T) {
 	tests := []struct {

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -199,51 +199,140 @@ func graphqlWithStatusChecks(t *testing.T, names ...string) *data.GraphqlRepoDat
 	return graphql
 }
 
-func Test_StatusChecksAreRequiredByRulesets(t *testing.T) {
+// graphqlWithChecksAndBranchProtection builds the payload shape the QA-03 steps
+// read: observed check runs plus the required-status-check contexts that classic
+// branch protection reports (visible only to admins in production).
+func graphqlWithChecksAndBranchProtection(t *testing.T, observed, bpRequired []string) *data.GraphqlRepoData {
+	t.Helper()
+	graphql := graphqlWithStatusChecks(t, observed...)
+	graphql.Repository.DefaultBranchRef.BranchProtectionRule.RequiredStatusCheckContexts = bpRequired
+	return graphql
+}
+
+// Test_StatusChecksRequired covers OSPS-QA-03.01 across both steps. Rulesets are
+// authoritative when present; branch protection is the fallback and is only
+// admin-visible. The step that owns the determination returns the result; the
+// other defers with NotRun. Both report the same message so the aggregated
+// requirement stays coherent.
+func Test_StatusChecksRequired(t *testing.T) {
 	tests := []struct {
-		name          string
-		metadata      *fakeRulesetMetadata
-		checksThatRan []string
-		wantResult    gemara.Result
-		wantMsg       string
+		name       string
+		hasRules   bool
+		rulesetReq []string
+		bpRequired []string
+		observed   []string
+		wantResult gemara.Result
+		wantMsg    string
 	}{
 		{
-			name:       "no rulesets configured",
-			metadata:   &fakeRulesetMetadata{hasRules: false},
+			name:       "rulesets require checks, every observed check is required",
+			hasRules:   true,
+			rulesetReq: []string{"build", "lint"},
+			observed:   []string{"build", "lint"},
 			wantResult: gemara.Passed,
-			wantMsg:    "No rulesets found for default branch, continuing to evaluate branch protection",
+			wantMsg:    "All executed status checks are required by rulesets",
 		},
 		{
-			name:          "every check that ran is required",
-			metadata:      &fakeRulesetMetadata{hasRules: true, requiredChecks: []string{"build", "lint"}},
-			checksThatRan: []string{"build", "lint"},
-			wantResult:    gemara.Passed,
-			wantMsg:       "No status checks were run that are not required by the rules",
+			name:       "rulesets require checks, an observed check is not required",
+			hasRules:   true,
+			rulesetReq: []string{"build"},
+			observed:   []string{"build", "lint"},
+			wantResult: gemara.Failed,
+			wantMsg:    "Some executed status checks are not required by rulesets but all should be: lint",
 		},
 		{
-			// The path that produces a non-passing compliance result, and the
-			// one that breaks if RequiredStatusCheckContexts reads the wrong
-			// rules now that they come from metadata rather than REST.
-			name:          "a check ran that the rulesets do not require",
-			metadata:      &fakeRulesetMetadata{hasRules: true, requiredChecks: []string{"build"}},
-			checksThatRan: []string{"build", "lint"},
-			wantResult:    gemara.Failed,
-			wantMsg:       "Some executed status checks are not mandatory but all should be: lint (NOTE: Not continuing to evaluate branch protection: combining requirements in rulesets and branch protection is not recommended)",
+			name:       "rulesets require checks, none observed in sample",
+			hasRules:   true,
+			rulesetReq: []string{"build"},
+			observed:   nil,
+			wantResult: gemara.Passed,
+			wantMsg:    "Status-check requirements are configured in rulesets",
+		},
+		{
+			name:       "rulesets present but require no checks, checks observed",
+			hasRules:   true,
+			rulesetReq: nil,
+			observed:   []string{"build"},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "status checks run but requirement configuration is not observable without admin access",
+		},
+		{
+			name:       "rulesets present but require no checks, none observed",
+			hasRules:   true,
+			rulesetReq: nil,
+			observed:   nil,
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "no status checks observed and status-check requirements are not observable without admin access; the latest default-branch commit may not have come from a pull request",
+		},
+		{
+			name:       "no rulesets, branch protection requires checks, all observed required",
+			hasRules:   false,
+			bpRequired: []string{"build"},
+			observed:   []string{"build"},
+			wantResult: gemara.Passed,
+			wantMsg:    "All executed status checks are required by branch protection",
+		},
+		{
+			name:       "no rulesets, branch protection requires checks, an observed check is not required",
+			hasRules:   false,
+			bpRequired: []string{"build"},
+			observed:   []string{"build", "lint"},
+			wantResult: gemara.Failed,
+			wantMsg:    "Some executed status checks are not required by branch protection but all should be: lint",
+		},
+		{
+			name:       "no rulesets, branch protection requires checks, none observed in sample",
+			hasRules:   false,
+			bpRequired: []string{"build"},
+			observed:   nil,
+			wantResult: gemara.Passed,
+			wantMsg:    "Status-check requirements are configured in branch protection",
+		},
+		{
+			// Non-admin false-fail case: branch protection requires checks but is
+			// invisible, so requiredChecks looks empty while checks are observed.
+			name:       "no rulesets, protection invisible, checks observed",
+			hasRules:   false,
+			bpRequired: nil,
+			observed:   []string{"build"},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "status checks run but requirement configuration is not observable without admin access",
+		},
+		{
+			// Vacuous-pass case: nothing observable and nothing ran.
+			name:       "no rulesets, nothing observable, nothing observed",
+			hasRules:   false,
+			bpRequired: nil,
+			observed:   nil,
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "no status checks observed and status-check requirements are not observable without admin access; the latest default-branch commit may not have come from a pull request",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			payload := data.Payload{
-				GraphqlRepoData:    graphqlWithStatusChecks(t, tt.checksThatRan...),
-				RepositoryMetadata: tt.metadata,
+				GraphqlRepoData:    graphqlWithChecksAndBranchProtection(t, tt.observed, tt.bpRequired),
+				RepositoryMetadata: &fakeRulesetMetadata{hasRules: tt.hasRules, requiredChecks: tt.rulesetReq},
 			}
-			result, message, _ := StatusChecksAreRequiredByRulesets(payload)
-			if result != tt.wantResult {
-				t.Errorf("result = %v, want %v", result, tt.wantResult)
+
+			// The authoritative step depends on whether rulesets apply; the other
+			// step defers with NotRun but reports the same message.
+			rulesetResult, rulesetMsg, _ := StatusChecksAreRequiredByRulesets(payload)
+			bpResult, bpMsg, _ := StatusChecksAreRequiredByBranchProtection(payload)
+
+			authResult, deferResult := rulesetResult, bpResult
+			if !tt.hasRules {
+				authResult, deferResult = bpResult, rulesetResult
 			}
-			if message != tt.wantMsg {
-				t.Errorf("message = %q, want %q", message, tt.wantMsg)
+			if authResult != tt.wantResult {
+				t.Errorf("authoritative result = %v, want %v", authResult, tt.wantResult)
+			}
+			if deferResult != gemara.NotRun {
+				t.Errorf("deferring result = %v, want NotRun", deferResult)
+			}
+			if rulesetMsg != tt.wantMsg || bpMsg != tt.wantMsg {
+				t.Errorf("messages = %q / %q, want both %q", rulesetMsg, bpMsg, tt.wantMsg)
 			}
 		})
 	}


### PR DESCRIPTION
- **fix: make QA-03 status-check evaluation observability-aware**
- **fix: report QA-04 as NeedsReview when Security Insights is absent**
- **docs: document assessment result semantics and evidence precedence**
