### PR TITLE
feat: implement OSPS-BR-07.02 secrets management policy check

### DIFF
--- a/data/security-posture.go
+++ b/data/security-posture.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"strings"
+
 	"github.com/google/go-github/v74/github"
 	"github.com/ossf/si-tooling/v2/si"
 )
@@ -41,25 +43,60 @@ type RepoSecurityPosture struct {
 
 func buildSecurityPosture(repository *github.Repository, rd RestData) (SecurityPosture, error) {
 	insightsClaimsSecretsTooling := insightsClaimsSecretsTooling(rd.Insights)
+	definesSecretsPolicy := definesSecretsHandlingPolicy(rd)
 	securityConfig := repository.GetSecurityAndAnalysis()
 	if securityConfig == nil {
 		// GitHub withholds security_and_analysis unless the token has admin access
 		// to the repository. Absent that block the observed settings are unreadable
 		// (not disabled); a Security Insights declaration is the only signal left.
 		return &RepoSecurityPosture{
-			restData:                       rd,
-			insightsDeclaresSecretScanning: insightsClaimsSecretsTooling,
+			restData:                        rd,
+			definesPolicyForHandlingSecrets: definesSecretsPolicy,
+			insightsDeclaresSecretScanning:  insightsClaimsSecretsTooling,
 		}, nil
 	}
 	return &RepoSecurityPosture{
-		restData:                       rd,
-		preventsSecretPushing:          securityConfig.GetSecretScanningPushProtection().GetStatus() == "enabled",
-		scansForSecrets:                securityConfig.GetSecretScanning().GetStatus() == "enabled",
-		secretScanningObservable:       true,
-		insightsDeclaresSecretScanning: insightsClaimsSecretsTooling,
-		// TODO: consider if SecurityInsights should have a policy doc field in ProjectDocumentation to handle this
-		// definesPolicyForHandlingSecrets: rd.SecurityInsights != nil && ....
+		restData:                        rd,
+		preventsSecretPushing:           securityConfig.GetSecretScanningPushProtection().GetStatus() == "enabled",
+		scansForSecrets:                 securityConfig.GetSecretScanning().GetStatus() == "enabled",
+		definesPolicyForHandlingSecrets: definesSecretsPolicy,
+		secretScanningObservable:        true,
+		insightsDeclaresSecretScanning:  insightsClaimsSecretsTooling,
 	}, nil
+}
+
+// secretsPolicyIndicators are lowercase phrases that, alongside a mention of
+// secrets or credentials, signal a written policy for managing them (how they
+// are stored, accessed, or rotated) rather than an incidental reference such as
+// "we scan for secrets".
+var secretsPolicyIndicators = []string{
+	"rotat", // matches "rotate" and "rotation" of credentials
+	"vault", // HashiCorp Vault and similarly named secret stores
+	"secret manager",
+	"secrets manager",
+	"secret management",
+	"secrets management",
+	"credential management",
+	"key management",
+}
+
+// definesSecretsHandlingPolicy reports whether the repository's SECURITY.md
+// documents how secrets and credentials are managed. GitHub exposes no dedicated
+// setting for this and Security Insights has no field for it, so the policy is
+// only observable when it is written into the security policy we already fetched.
+// It requires both a mention of secrets/credentials and a management indicator so
+// that an incidental reference (e.g. secret-scanning tooling) does not count.
+func definesSecretsHandlingPolicy(rd RestData) bool {
+	content := strings.ToLower(rd.SecurityPolicy.Content)
+	if !strings.Contains(content, "secret") && !strings.Contains(content, "credential") {
+		return false
+	}
+	for _, indicator := range secretsPolicyIndicators {
+		if strings.Contains(content, indicator) {
+			return true
+		}
+	}
+	return false
 }
 
 func insightsClaimsSecretsTooling(insights si.SecurityInsights) bool {

--- a/data/security-posture_test.go
+++ b/data/security-posture_test.go
@@ -153,3 +153,62 @@ func TestInsightsClaimsSecretsTooling(t *testing.T) {
 	insights.Repository.SecurityPosture.Tools = nil
 	assert.False(t, insightsClaimsSecretsTooling(insights))
 }
+
+func TestDefinesSecretsHandlingPolicy(t *testing.T) {
+	testCases := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "empty policy",
+			content:  "",
+			expected: false,
+		},
+		{
+			name:     "secrets mentioned without management guidance",
+			content:  "We enable GitHub secret scanning on this repository.",
+			expected: false,
+		},
+		{
+			name:     "management indicator without secrets term",
+			content:  "Access is granted through our key management process.",
+			expected: false,
+		},
+		{
+			name:     "credentials with rotation guidance",
+			content:  "All credentials must be rotated every 90 days.",
+			expected: true,
+		},
+		{
+			name:     "secrets stored in a vault",
+			content:  "Project secrets are stored in HashiCorp Vault.",
+			expected: true,
+		},
+		{
+			name:     "explicit secret management policy",
+			content:  "This document describes our secret management policy.",
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rd := RestData{SecurityPolicy: SecurityPolicy{Content: tc.content}}
+			assert.Equal(t, tc.expected, definesSecretsHandlingPolicy(rd))
+		})
+	}
+}
+
+func TestBuildSecurityPosture_DefinesSecretsPolicyFromSecurityMd(t *testing.T) {
+	repo := &github.Repository{}
+	rd := RestData{
+		SecurityPolicy: SecurityPolicy{
+			Present: true,
+			Content: "Credentials are stored in a vault and rotated regularly.",
+		},
+	}
+	sp, err := buildSecurityPosture(repo, rd)
+	assert.NoError(t, err)
+	assert.True(t, sp.DefinesPolicyForHandlingSecrets())
+}

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -68,7 +68,7 @@ var (
 			build_release.SecretScanningInUse,
 		},
 		"OSPS-BR-07.02": {
-			reusable_steps.NotImplemented,
+			build_release.SecretsManagementPolicy,
 		},
 		"OSPS-DO-01.01": {
 			reusable_steps.HasSecurityInsightsFile,

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -654,3 +654,15 @@ func SecretScanningInUse(payload data.Payload) (result gemara.Result, message st
 	}
 	return gemara.Failed, "GitHub reports secret scanning and push protection are both disabled", gemara.Medium
 }
+
+func SecretsManagementPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	// A documented secrets-management policy is observable only when the project
+	// publishes it somewhere we can read — today that is the SECURITY.md file.
+	if payload.SecurityPosture.DefinesPolicyForHandlingSecrets() {
+		return gemara.Passed, "A documented policy for managing secrets and credentials was found in the repository's security policy", gemara.Medium
+	}
+
+	// The policy may still live in documentation we cannot observe (an external
+	// wiki, handbook, etc.), so this is unconfirmed rather than a violation.
+	return gemara.NeedsReview, "No documented policy for managing secrets and credentials was found in the repository's security policy; manual review is required to confirm one exists elsewhere", gemara.Low
+}

--- a/evaluation_plans/osps/build_release/steps_test.go
+++ b/evaluation_plans/osps/build_release/steps_test.go
@@ -140,11 +140,12 @@ type mockSecurityPosture struct {
 	scans            bool
 	observable       bool
 	insightsDeclares bool
+	definesPolicy    bool
 }
 
 func (m mockSecurityPosture) PreventsPushingSecrets() bool          { return m.preventsPush }
 func (m mockSecurityPosture) ScansForSecrets() bool                 { return m.scans }
-func (m mockSecurityPosture) DefinesPolicyForHandlingSecrets() bool { return false }
+func (m mockSecurityPosture) DefinesPolicyForHandlingSecrets() bool { return m.definesPolicy }
 func (m mockSecurityPosture) SecretScanningObservable() bool        { return m.observable }
 func (m mockSecurityPosture) InsightsDeclaresSecretScanning() bool  { return m.insightsDeclares }
 
@@ -199,6 +200,38 @@ func TestSecretScanningInUse(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result, message, _ := SecretScanningInUse(data.Payload{SecurityPosture: tc.posture})
+			assert.Equal(t, tc.expectedResult, result)
+			assert.Contains(t, message, tc.expectedMessage)
+		})
+	}
+}
+
+func TestSecretsManagementPolicy(t *testing.T) {
+	testCases := []struct {
+		name            string
+		posture         mockSecurityPosture
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name:            "documented policy passes",
+			posture:         mockSecurityPosture{definesPolicy: true},
+			expectedResult:  gemara.Passed,
+			expectedMessage: "A documented policy for managing secrets and credentials was found",
+		},
+		{
+			// No observable policy: it may live in docs we cannot read, so this is
+			// unconfirmed rather than a violation.
+			name:            "no observable policy needs review",
+			posture:         mockSecurityPosture{definesPolicy: false},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "manual review is required",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, message, _ := SecretsManagementPolicy(data.Payload{SecurityPosture: tc.posture})
 			assert.Equal(t, tc.expectedResult, result)
 			assert.Contains(t, message, tc.expectedMessage)
 		})


### PR DESCRIPTION
## Summary

Implements **OSPS-BR-07.02** — "The project MUST define a policy for managing secrets and credentials used by the project."

Previously this control was wired to `reusable_steps.NotImplemented`. This PR adds a real evaluation step.

## Changes

- **`data/security-posture.go`**: Add `definesSecretsHandlingPolicy()` which inspects the already-fetched `SECURITY.md` content. It requires both a mention of secrets/credentials **and** a management indicator (rotation, vault, secret/credential/key management) so that an incidental reference (e.g. "we scan for secrets") does not count. Wired into both `RepoSecurityPosture` construction paths via the new `definesPolicyForHandlingSecrets` field; removed the stale TODO.
- **`evaluation_plans/osps/build_release/steps.go`**: New `SecretsManagementPolicy` step. Returns `Passed` (Medium) when an observable policy is found, otherwise `NeedsReview` (Low) — the policy may live in documentation we cannot read (external wiki, handbook, etc.), so it is unconfirmed rather than a violation.
- **`evaluation_plans/evaluation-plans.go`**: Map `OSPS-BR-07.02` to `build_release.SecretsManagementPolicy`.
- Tests for the heuristic, the step (Passed/NeedsReview), and end-to-end `buildSecurityPosture`.

## Notes

- Detection is heuristic and intentionally conservative; when nothing is observable the result is `NeedsReview` to prompt manual confirmation rather than failing the control.

## Testing

- `go build ./...`, `go vet ./...`, and `go test ./data/... ./evaluation_plans/...` all pass.
