### PR TITLE
feat: implement OSPS-DO-05.01 security-update support statement check

### DIFF
--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -90,7 +90,7 @@ var (
 			docs.HasSupportDocs,
 		},
 		"OSPS-DO-05.01": {
-			reusable_steps.NotImplemented,
+			docs.DocumentsSecurityUpdatePolicy,
 		},
 		"OSPS-DO-06.01": {
 			reusable_steps.IsCodeRepo,

--- a/evaluation_plans/osps/docs/steps.go
+++ b/evaluation_plans/osps/docs/steps.go
@@ -68,6 +68,31 @@ func HasDependencyManagementPolicy(payload data.Payload) (result gemara.Result, 
 	return gemara.Failed, "Dependency management policy was NOT specified in Security Insights data", gemara.Medium
 }
 
+// DocumentsSecurityUpdatePolicy evaluates OSPS-DO-05.01: once a project has made
+// a release, its documentation must describe when releases or versions will no
+// longer receive security updates.
+//
+// The requirement is conditional on a release existing, so a project with no
+// releases is NotApplicable rather than a failure. Security Insights'
+// support-policy field is the explicit, machine-readable signal; a SUPPORT.md
+// (or README "Support" section) is a weaker fallback that warrants review since
+// its contents cannot be verified to describe a security-update timeline.
+func DocumentsSecurityUpdatePolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if len(payload.Releases) == 0 {
+		return gemara.NotApplicable, "No releases found; the security-update support statement requirement does not apply", confidence
+	}
+
+	if payload.Insights.Project.Documentation.SupportPolicy != nil {
+		return gemara.Passed, "Security update support policy was specified in Security Insights data", gemara.High
+	}
+
+	if payload.HasSupportMarkdown() {
+		return gemara.NeedsReview, "No support-policy field in Security Insights, but a SUPPORT.md file or a Support section in the readme.md was found; manual review required to confirm it states when releases stop receiving security updates", gemara.Medium
+	}
+
+	return gemara.Failed, "No security update support policy was found in Security Insights data and no SUPPORT.md file or Support section in the readme.md was found", gemara.Medium
+}
+
 func HasIdentityVerificationGuide(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if payload.Insights.Project.Documentation.SignatureVerification == nil {
 		return gemara.Failed, "Identity verification guide was NOT specified in Security Insights data (checked signature-verification field)", confidence

--- a/evaluation_plans/osps/docs/steps.go
+++ b/evaluation_plans/osps/docs/steps.go
@@ -1,6 +1,8 @@
 package docs
 
 import (
+	"strings"
+
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 )
@@ -77,12 +79,16 @@ func HasDependencyManagementPolicy(payload data.Payload) (result gemara.Result, 
 // support-policy field is the explicit, machine-readable signal; a SUPPORT.md
 // (or README "Support" section) is a weaker fallback that warrants review since
 // its contents cannot be verified to describe a security-update timeline.
+//
+// A present-but-empty support-policy field decodes to a non-nil *URL of "", so
+// the value is trimmed rather than only nil-checked to avoid crediting an empty
+// entry as documented policy.
 func DocumentsSecurityUpdatePolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if len(payload.Releases) == 0 {
 		return gemara.NotApplicable, "No releases found; the security-update support statement requirement does not apply", confidence
 	}
 
-	if payload.Insights.Project.Documentation.SupportPolicy != nil {
+	if sp := payload.Insights.Project.Documentation.SupportPolicy; sp != nil && strings.TrimSpace(string(*sp)) != "" {
 		return gemara.Passed, "Security update support policy was specified in Security Insights data", gemara.High
 	}
 

--- a/evaluation_plans/osps/docs/steps_test.go
+++ b/evaluation_plans/osps/docs/steps_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
+	"github.com/google/go-github/v74/github"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/ossf/si-tooling/v2/si"
 	"github.com/stretchr/testify/assert"
@@ -71,5 +72,79 @@ func TestAcceptsVulnReports(t *testing.T) {
 			assert.Equal(t, test.expectedResult, result)
 			assert.Equal(t, test.expectedMessage, message)
 		})
+	}
+}
+
+func TestDocumentsSecurityUpdatePolicy(t *testing.T) {
+	supportURL := si.URL("https://example.com/support")
+	releases := []data.ReleaseData{{Id: 1, Name: "v1.0.0", TagName: "v1.0.0"}}
+
+	tests := []struct {
+		name            string
+		releases        []data.ReleaseData
+		supportPolicy   *si.URL
+		rootContents    []*github.RepositoryContent
+		expectedResult  gemara.Result
+		expectedMessage string
+	}{
+		{
+			name:            "No releases is not applicable",
+			releases:        nil,
+			expectedResult:  gemara.NotApplicable,
+			expectedMessage: "No releases found; the security-update support statement requirement does not apply",
+		},
+		{
+			name:            "Release with support policy in Security Insights passes",
+			releases:        releases,
+			supportPolicy:   &supportURL,
+			expectedResult:  gemara.Passed,
+			expectedMessage: "Security update support policy was specified in Security Insights data",
+		},
+		{
+			name:            "Release with SUPPORT.md fallback needs review",
+			releases:        releases,
+			rootContents:    []*github.RepositoryContent{repoFile("SUPPORT.md")},
+			expectedResult:  gemara.NeedsReview,
+			expectedMessage: "No support-policy field in Security Insights, but a SUPPORT.md file or a Support section in the readme.md was found; manual review required to confirm it states when releases stop receiving security updates",
+		},
+		{
+			name:            "Release with no support documentation fails",
+			releases:        releases,
+			expectedResult:  gemara.Failed,
+			expectedMessage: "No security update support policy was found in Security Insights data and no SUPPORT.md file or Support section in the readme.md was found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := data.Payload{
+				RestData: &data.RestData{
+					Insights: si.SecurityInsights{
+						Project: &si.Project{
+							Documentation: &si.ProjectDocumentation{
+								SupportPolicy: test.supportPolicy,
+							},
+						},
+					},
+					Releases: test.releases,
+				},
+				GraphqlRepoData: &data.GraphqlRepoData{},
+			}
+			payload := data.NewPayloadWithRepoContents(base, test.rootContents, nil)
+
+			result, message, _ := DocumentsSecurityUpdatePolicy(payload)
+			assert.Equal(t, test.expectedResult, result)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}
+
+// repoFile builds a minimal file entry for the mocked repository root listing.
+func repoFile(name string) *github.RepositoryContent {
+	fileType := "file"
+	return &github.RepositoryContent{
+		Name: &name,
+		Path: &name,
+		Type: &fileType,
 	}
 }

--- a/evaluation_plans/osps/docs/steps_test.go
+++ b/evaluation_plans/osps/docs/steps_test.go
@@ -77,6 +77,7 @@ func TestAcceptsVulnReports(t *testing.T) {
 
 func TestDocumentsSecurityUpdatePolicy(t *testing.T) {
 	supportURL := si.URL("https://example.com/support")
+	emptySupportURL := si.URL("")
 	releases := []data.ReleaseData{{Id: 1, Name: "v1.0.0", TagName: "v1.0.0"}}
 
 	tests := []struct {
@@ -106,6 +107,13 @@ func TestDocumentsSecurityUpdatePolicy(t *testing.T) {
 			rootContents:    []*github.RepositoryContent{repoFile("SUPPORT.md")},
 			expectedResult:  gemara.NeedsReview,
 			expectedMessage: "No support-policy field in Security Insights, but a SUPPORT.md file or a Support section in the readme.md was found; manual review required to confirm it states when releases stop receiving security updates",
+		},
+		{
+			name:            "Release with empty support policy falls through to failure",
+			releases:        releases,
+			supportPolicy:   &emptySupportURL,
+			expectedResult:  gemara.Failed,
+			expectedMessage: "No security update support policy was found in Security Insights data and no SUPPORT.md file or Support section in the readme.md was found",
 		},
 		{
 			name:            "Release with no support documentation fails",


### PR DESCRIPTION
## Why

`OSPS-DO-05.01` was still a `NotImplemented` stub even though the control-level work was tracked and closed long ago. The control requires that, once a project has made a release, its documentation states when releases or versions will stop receiving security updates.

## What changed

Replaced the stub with a real assessment step, `DocumentsSecurityUpdatePolicy`, in the existing `docs` package. It uses the Security Insights `Project.Documentation.SupportPolicy` field as the primary, machine-readable signal (that field maps exactly to "how releases are supported / end-of-life timelines" and was previously unused), and wires it into `evaluation-plans.go`.

Result logic, following conventions already used by the other docs and release steps:

- No releases -> `NotApplicable` (the requirement is explicitly conditional on a release existing, mirroring `EnsureLatestReleaseHasChangelog`).
- `SupportPolicy` set in Security Insights -> `Passed` (High confidence).
- No SI field but a `SUPPORT.md` / README "Support" section exists -> `NeedsReview` (Medium), since the file's contents cannot be verified to describe a security-update timeline.
- Nothing found -> `Failed` (Medium).

## Notes for reviewers

The `NeedsReview` fallback is intentional: a support document may exist without actually stating an end-of-life policy, so we flag it for a human rather than passing or failing outright. This matches the confidence philosophy in `AcceptsVulnReports`.

## Tests

Added a table-driven `TestDocumentsSecurityUpdatePolicy` covering all four outcomes, using the existing repo-contents mock. `go build ./...`, `go vet ./evaluation_plans/...`, and `go test ./evaluation_plans/...` all pass.

Relates to ossf/pvtr-github-repo-scanner#20 for history.

Fixes: #341