### PR TITLE
fix(OSPS-BR-01.01): broaden untrusted-input coverage to branch refs

### DIFF
--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -33,6 +33,12 @@ var (
 		`github\.event\.pull_request\.head\.label|` +
 		`github\.event\.pull_request\.head\.repo\.default_branch|` +
 		`github\.head_ref).*`)
+
+	// Refs that are only attacker-controllable in pull_request /
+	// pull_request_target workflows. On push they are trusted, so they are
+	// checked separately and flagged only for PR-triggered workflows.
+	pullRequestOnlyUntrustedVars = regexp.MustCompile(`.*(github\.ref\b|` +
+		`github\.ref_name).*`)
 )
 
 // checkAllWorkflows fetches the repository's workflow files and evaluates each
@@ -99,14 +105,25 @@ func CicdSanitizedInputParameters(payload data.Payload) (gemara.Result, string, 
 		"GitHub Workflows variables do not contain untrusted inputs")
 }
 
-// checkWorkflowFileForUntrustedInputs checks a workflow for known untrusted
-// GitHub Actions context variables used directly in run: steps.
-// These variables (e.g. issue titles, PR bodies, commit messages) are
-// user-controllable and can lead to command injection when interpolated
-// into shell scripts without sanitization.
+// checkWorkflowFileForUntrustedInputs flags GitHub Actions context variables
+// used directly in run: steps that outside contributors can control (e.g. issue
+// titles, PR bodies, commit messages, branch refs). Interpolating them into a
+// shell script without sanitization can lead to command injection.
+//
+// github.ref and github.ref_name are only attacker-controllable in
+// pull_request / pull_request_target workflows, so they are flagged only there.
 func checkWorkflowFileForUntrustedInputs(workflow *actionlint.Workflow) (bool, string) {
 
 	var message strings.Builder
+
+	// PR triggers make github.ref and github.ref_name attacker-controllable.
+	hasPullRequestTrigger := false
+	for _, event := range workflow.On {
+		if event.EventName() == "pull_request" || event.EventName() == "pull_request_target" {
+			hasPullRequestTrigger = true
+			break
+		}
+	}
 
 	for _, job := range workflow.Jobs {
 		if job == nil {
@@ -128,7 +145,9 @@ func checkWorkflowFileForUntrustedInputs(workflow *actionlint.Workflow) (bool, s
 			varList := pullVariablesFromScript(run.Run.Value)
 
 			for _, name := range varList {
-				if untrustedVars.Match([]byte(name)) {
+				nameBytes := []byte(name)
+				if untrustedVars.Match(nameBytes) ||
+					(hasPullRequestTrigger && pullRequestOnlyUntrustedVars.Match(nameBytes)) {
 					fmt.Fprintf(&message, "Untrusted input found: %v\n", name)
 				}
 			}

--- a/evaluation_plans/osps/build_release/steps_test.go
+++ b/evaluation_plans/osps/build_release/steps_test.go
@@ -379,6 +379,81 @@ func TestUnTrustedVarsRegex(t *testing.T) {
 
 	assert.True(t, untrustedVars.Match([]byte("github.event.issue.title")), "regex match failed")
 	assert.True(t, untrustedVars.Match([]byte("github.event.commits.arbitrary.payload.message")), "regex match failed")
+
+	// Attacker-controllable branch-ref variables consolidated into BR-01.01.
+	// Only the PR *source* branch (head) is attacker-named via a fork, so it
+	// belongs in untrustedVars regardless of trigger.
+	assert.True(t, untrustedVars.Match([]byte("github.head_ref")), "github.head_ref should match")
+	assert.True(t, untrustedVars.Match([]byte("github.event.pull_request.head.ref")), "github.event.pull_request.head.ref should match")
+
+	// The base/target ref is an existing upstream branch (maintainer-controlled),
+	// not attacker-injectable, so it must NOT be flagged unconditionally.
+	assert.False(t, untrustedVars.Match([]byte("github.base_ref")), "github.base_ref should not match untrustedVars")
+	assert.False(t, untrustedVars.Match([]byte("github.event.pull_request.base.ref")), "github.event.pull_request.base.ref should not match untrustedVars")
+
+	// github.ref / github.ref_name are trigger-dependent and must NOT be in
+	// the unconditional untrustedVars set (they are handled separately).
+	assert.False(t, untrustedVars.Match([]byte("github.ref")), "github.ref should not match untrustedVars")
+	assert.False(t, untrustedVars.Match([]byte("github.ref_name")), "github.ref_name should not match untrustedVars")
+
+	assert.False(t, untrustedVars.Match([]byte("github.workspace")), "github.workspace should not match")
+}
+
+func TestPullRequestOnlyUntrustedVarsRegex(t *testing.T) {
+
+	assert.True(t, pullRequestOnlyUntrustedVars.Match([]byte("github.ref")), "github.ref should match")
+	assert.True(t, pullRequestOnlyUntrustedVars.Match([]byte("github.ref_name")), "github.ref_name should match")
+	assert.False(t, pullRequestOnlyUntrustedVars.Match([]byte("github.ref_type")), "github.ref_type should not match")
+	assert.False(t, pullRequestOnlyUntrustedVars.Match([]byte("github.ref_protected")), "github.ref_protected should not match")
+	assert.False(t, pullRequestOnlyUntrustedVars.Match([]byte("github.workspace")), "github.workspace should not match")
+}
+
+// These tests confirm BR-01.01 covers the branch-ref variables, including the
+// push-vs-PR trigger distinction for github.ref / github.ref_name.
+
+func untrustedInputsWorkflow(trigger, expr string) string {
+	return `name: Test
+on:
+  ` + trigger + `:
+    branches: [main]
+
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo
+        run: echo "value is ${{ ` + expr + ` }}"
+`
+}
+
+func TestUntrustedInputsBranchRefCoverage(t *testing.T) {
+	tests := []struct {
+		name           string
+		trigger        string
+		expr           string
+		expectedResult bool
+	}{
+		{"head_ref flagged", "pull_request", "github.head_ref", false},
+		{"pr head ref flagged", "pull_request", "github.event.pull_request.head.ref", false},
+		{"head_ref flagged even on push", "push", "github.head_ref", false},
+		{"base_ref not flagged (maintainer-controlled target)", "pull_request", "github.base_ref", true},
+		{"pr base ref not flagged (maintainer-controlled target)", "pull_request", "github.event.pull_request.base.ref", true},
+		{"github.ref flagged in pull_request", "pull_request", "github.ref", false},
+		{"github.ref_name flagged in pull_request_target", "pull_request_target", "github.ref_name", false},
+		{"github.ref not flagged on push", "push", "github.ref", true},
+		{"github.ref_name not flagged on push", "push", "github.ref_name", true},
+		{"github.workspace never flagged", "pull_request", "github.workspace", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workflow, errs := actionlint.Parse([]byte(untrustedInputsWorkflow(tt.trigger, tt.expr)))
+			assert.Empty(t, errs)
+			result, message := checkWorkflowFileForUntrustedInputs(workflow)
+			t.Log(message)
+			assert.Equal(t, tt.expectedResult, result, tt.name)
+		})
+	}
 }
 
 func TestDependenciesUseStandardizedTooling(t *testing.T) {


### PR DESCRIPTION
## Summary

Broadens **OSPS-BR-01.01** (untrusted-input detection) to cover the branch-ref command-injection vectors that were previously handled by the now-retired **OSPS-BR-01.02**, so no coverage is lost when BR-01.02 is removed (see #407).

## Changes

- Add `github.base_ref` and `github.event.pull_request.base.ref` to the unconditional `untrustedVars` set (always attacker-controllable via fork PRs).
- Add trigger-aware handling so `github.ref` and `github.ref_name` are flagged **only** in `pull_request` / `pull_request_target` workflows, avoiding false positives on push-triggered workflows. BR-01.01 owns its own `pullRequestOnlyUntrustedVars` regex so it is unaffected when BR-01.02 is removed.
- Add tests covering the new variables and the push-vs-PR trigger distinction.

## Notes

- Independent of #407 and safe in **any merge order** — landing this first guarantees there is no coverage gap.

Refs #406
