### PR TITLE
fix: make the container image able to run scans again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,3 +37,46 @@ jobs:
           expected_count=$(go run ./cmd/list-supported-catalogs | wc -l | tr -d ' ')
           actual_count=$(grep -c '^COMPAT_CONFIG_OK ' integration_output.txt)
           test "$actual_count" -eq "$expected_count"
+
+  image-smoke-test:
+    name: Container Image Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Build image
+        run: docker build -t pvtr-github-repo-scanner:smoke .
+      - name: Run image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Mirror how osps-baseline-action invokes the published image.
+          cat > /tmp/pvtr-config.yml <<EOF
+          loglevel: info
+          write-directory: evaluation_results
+          write: true
+          output: yaml
+          services:
+            pvtr:
+              plugin: github-repo
+              policy:
+                catalogs:
+                  - osps-baseline-2026-02
+                applicability:
+                  - Maturity Level 1
+              vars:
+                owner: ossf
+                repo: pvtr-github-repo-scanner
+                token: ${GITHUB_TOKEN}
+          EOF
+          mkdir -p evaluation_results
+          chmod 777 evaluation_results
+          docker run --rm \
+            -v /tmp/pvtr-config.yml:/.privateer/config.yml \
+            -v "$PWD/evaluation_results:/.privateer/bin/evaluation_results" \
+            pvtr-github-repo-scanner:smoke
+      - name: Verify scan wrote results
+        run: |
+          ls -R evaluation_results
+          test -n "$(find evaluation_results -name '*.log' -type f)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,12 @@ COPY --from=core /app/pvtr .
 COPY --from=plugin /plugin/github-repo .
 COPY --from=plugin /plugin/container-entrypoint.sh .
 
+# Register the plugin in the manifest so pvtr treats it as installed.
+# pvtr only runs plugins listed in plugins.json; without this, `pvtr run`
+# exits with "requested plugin that is not installed: github-repo".
+# Keep in sync with the manifest written by .github/scripts/ci.sh.
+RUN printf '%s\n' '{"plugins":[{"name":"github-repo","version":"local","binaryPath":"github-repo"}]}' > plugins.json
+
 # The config file must be provided at run time.
 # example: docker run -v /path/to/config.yml:/.privateer/config.yml privateer-image
 CMD ["./container-entrypoint.sh"]

--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -1,4 +1,23 @@
 #!/bin/sh
-./pvtr run --binaries-path . --config /.privateer/config.yml > /dev/null 2>&1
+# The binaries path must be absolute: pvtr resolves the plugin binary as
+# filepath.Join(binaries-path, binaryPath), and a bare relative name like
+# "github-repo" would be looked up in $PATH instead of this directory.
+#
+# Keep the console quiet during the run; the full log is written to
+# evaluation_results and printed below. Output is captured (not discarded)
+# so it can be surfaced if pvtr crashes before writing any logs.
+OUTPUT=$(./pvtr run --binaries-path /.privateer/bin --config /.privateer/config.yml 2>&1)
+STATUS=$?
 
-for file in evaluation_results/**/*.log; do echo $file; cat $file; echo; done
+for file in evaluation_results/**/*.log; do echo "$file"; cat "$file"; echo; done
+
+# Exit 0 (all checks passed) and exit 1 (some checks failed) both mean the
+# scan ran to completion; the container reports results rather than failing.
+# Any other exit code means pvtr crashed, so surface its output and propagate.
+if [ "$STATUS" -ne 0 ] && [ "$STATUS" -ne 1 ]; then
+  echo "ERROR: pvtr run exited with code $STATUS" >&2
+  echo "$OUTPUT" >&2
+  exit "$STATUS"
+fi
+
+exit 0


### PR DESCRIPTION
## What/Why

The published container image cannot run scans: it ships `pvtr` and the `github-repo` plugin binary but no `plugins.json` manifest, so since privateer began resolving installed plugins from the manifest, `pvtr run` exits with `requested plugin that is not installed: github-repo` before writing any results. The entrypoint discarded all output (`> /dev/null 2>&1`), so the container exited 0 while producing nothing, which surfaces downstream as revanite-io/osps-baseline-action CI failing with "OSPS scanner produced no log file".

Broken downstream runs (started when the action bumped the image from v0.22.0 to v0.27.0):
- [CI on main](https://github.com/revanite-io/osps-baseline-action/actions/runs/30169921818) -- first failure after the bump
- [CI on revanite-io/osps-baseline-action#43](https://github.com/revanite-io/osps-baseline-action/actions/runs/30530511040) -- an unrelated dependency PR failing the same way

Changes:
- Write `plugins.json` into `/.privateer/bin` in the Dockerfile (same manifest `.github/scripts/ci.sh` already creates for the plugin test)
- Pass an absolute `--binaries-path`: `filepath.Join(".", "github-repo")` cleans to a bare name, which `exec` resolves via `$PATH` instead of the binaries directory
- Capture pvtr output instead of discarding it; on crash (exit code > 1) print it to stderr and propagate the exit code. Exit 0/1 (checks passed/failed) still exit 0, preserving current consumer behavior
- Add an `image-smoke-test` CI job that builds the image and runs it exactly the way osps-baseline-action does, asserting a log file is written. The existing plugin test exercises the raw binaries with a hand-built manifest, which is how the broken image shipped unnoticed

## Proof it works

Built the image locally (`--build-arg PLATFORM=Linux_arm64`) and ran it with a mounted config and results directory against this repo:
- Before the `--binaries-path` fix, the entrypoint surfaced `exec: "github-repo": executable file not found in $PATH` (previously hidden by `/dev/null`)
- After: scan completes, `evaluation_results/pvtr/pvtr.log` and `pvtr.yaml` are written to the host mount, log contents printed, exit 0 (`17 Passed, 0 Warnings, 0 Failed`)
- Crash path: config requesting a nonexistent plugin prints `requested plugin that is not installed` to stderr and the container exits with pvtr's exit code
- The new `image-smoke-test` job repeats the happy-path verification in CI on x86_64

## Risk + AI role

Low -- touches only the container packaging, entrypoint, and CI; no plugin or evaluation logic. Diagnosed and written with AI assistance, manually verified end to end.

## Review focus

- Whether exit 0 on "some checks failed" (exit 1) is the contract we want for the container going forward
- The smoke test scans this repo with the workflow's `GITHUB_TOKEN`; confirm that token's rate limits/permissions are acceptable for every CI run

