### PR TITLE
fix(OSPS-LE-02.01): handle SPDX WITH exceptions, + suffix, and grouping parens

### DIFF
--- a/evaluation_plans/osps/legal/steps.go
+++ b/evaluation_plans/osps/legal/steps.go
@@ -42,10 +42,23 @@ func getLicenseList(payload data.Payload, makeApiCall func(string, bool) ([]byte
 }
 
 func splitSpdxExpression(expression string) (spdx_ids []string) {
+	// Remove grouping parentheses; they affect evaluation order, not approval.
+	expression = strings.ReplaceAll(expression, "(", " ")
+	expression = strings.ReplaceAll(expression, ")", " ")
 	a := strings.Split(expression, " AND ")
 	for _, aa := range a {
 		b := strings.Split(aa, " OR ")
-		spdx_ids = append(spdx_ids, b...)
+		for _, token := range b {
+			token = strings.TrimSpace(token)
+			// Strip " WITH <exception>" — the exception clause is irrelevant to
+			// OSI/FSF approval; only the base license ID matters.
+			if idx := strings.Index(token, " WITH "); idx != -1 {
+				token = token[:idx]
+			}
+			// Strip deprecated "+" (or-later) suffix so "GPL-2.0+" resolves to "GPL-2.0".
+			token = strings.TrimSuffix(token, "+")
+			spdx_ids = append(spdx_ids, token)
+		}
 	}
 	return
 }

--- a/evaluation_plans/osps/legal/steps.go
+++ b/evaluation_plans/osps/legal/steps.go
@@ -55,7 +55,8 @@ func splitSpdxExpression(expression string) (spdx_ids []string) {
 			if idx := strings.Index(token, " WITH "); idx != -1 {
 				token = token[:idx]
 			}
-			// Strip deprecated "+" (or-later) suffix so "GPL-2.0+" resolves to "GPL-2.0".
+			// Strip the "+" (or-later) operator so any "id+" form (e.g. "Apache-2.0+")
+			// resolves to its base license ID.
 			token = strings.TrimSuffix(token, "+")
 			spdx_ids = append(spdx_ids, token)
 		}

--- a/evaluation_plans/osps/legal/steps_test.go
+++ b/evaluation_plans/osps/legal/steps_test.go
@@ -273,6 +273,26 @@ func TestSplitSpdxExpression(t *testing.T) {
 			input:    "",
 			expected: []string{""},
 		},
+		{
+			name:     "WITH exception suffix",
+			input:    "Apache-2.0 WITH LLVM-exception",
+			expected: []string{"Apache-2.0"},
+		},
+		{
+			name:     "WITH exception inside grouped OR",
+			input:    "(GPL-2.0 WITH Classpath-exception-2.0) OR MIT",
+			expected: []string{"GPL-2.0", "MIT"},
+		},
+		{
+			name:     "Deprecated + suffix",
+			input:    "GPL-2.0+",
+			expected: []string{"GPL-2.0"},
+		},
+		{
+			name:     "Parentheses grouping",
+			input:    "(MIT OR Apache-2.0)",
+			expected: []string{"MIT", "Apache-2.0"},
+		},
 	}
 
 	for _, test := range tests {
@@ -463,6 +483,21 @@ func TestGoodLicense(t *testing.T) {
 			apiError:        nil,
 			expectedResult:  gemara.Failed,
 			expectedMessage: "These licenses are not OSI or FSF approved: DeprecatedBadLicense",
+		},
+		{
+			name: "OSI approved license with WITH exception clause (Kokkos pattern)",
+			payload: data.Payload{
+				GraphqlRepoData: func() *data.GraphqlRepoData {
+					repo := stubGraphqlRepo("")
+					repo.Repository.LicenseInfo.SpdxId = "Apache-2.0 WITH LLVM-exception"
+					return repo
+				}(),
+				Config: &config.Config{},
+			},
+			apiResponse:     []byte(`{"licenses":[{"licenseId":"Apache-2.0","isOsiApproved":true,"isFsfLibre":false}]}`),
+			apiError:        nil,
+			expectedResult:  gemara.Passed,
+			expectedMessage: "All license found are OSI or FSF approved",
 		},
 	}
 


### PR DESCRIPTION
## Problem

Projects with valid SPDX licenses that include `WITH <exception>` clauses (e.g. `Apache-2.0 WITH LLVM-exception`) were incorrectly failing `OSPS-LE-02.01`. The `splitSpdxExpression` tokenizer only split on ` AND ` / ` OR `, so exception-bearing expressions were passed verbatim to the SPDX license list lookup — which naturally found no exact match and flagged them as unapproved.

The same tokenizer also failed silently on:
- Grouped expressions with parentheses, e.g. `(MIT OR Apache-2.0)`
- Deprecated `+` (or-later) suffix, e.g. `GPL-2.0+`

Closes #234
Helps close linuxfoundation/insights#1928

## Changes

`splitSpdxExpression` (`evaluation_plans/osps/legal/steps.go`) now normalizes expressions before splitting:

1. Strips grouping `(` / `)` (no semantic effect on approval)
2. Strips ` WITH <exception>` suffix per token — exception clauses don't affect OSI/FSF approval of the base license
3. Strips deprecated `+` (or-later) suffix per token

`NOASSERTION` handling was already in place and is unchanged.

## Tests

Four new cases added to `TestSplitSpdxExpression` and one to `TestGoodLicense` (Kokkos-pattern `Apache-2.0 WITH LLVM-exception` → `Passed`). All existing tests continue to pass.

## Local verification against kokkos/kokkos

Running the scanner against `kokkos/kokkos` (the repo cited in #234) returns `Needs Review` rather than `Passed`. This is expected and unrelated to this fix.

GitHub uses [licensee](https://github.com/licensee/licensee) to detect licenses and returns `spdx_id: NOASSERTION` for kokkos because the `LICENSE` file is Apache-2.0 text with LLVM exception clauses appended — the modified text doesn't match licensee's known templates. The scanner falls through to the `NeedsReview` path (license file present, identity unknown) regardless of this fix.

This fix applies when the SPDX expression reaches the scanner as a string — either via GitHub's API (for repos whose license text licensee *can* classify) or via a Security Insights file that explicitly declares `license.expression: Apache-2.0 WITH LLVM-exception`. For kokkos to reach `Passed`, the kokkos maintainers would need to add a Security Insights file with the correct expression.

## Background

Initial fix attempt for the same underlying issue was started in #355. This PR supersedes it with a broader fix covering the full class of SPDX expression constructs that break the tokenizer.