### PR TITLE
feat: implement OSPS-QA-02.02 SBOM check for released assets

### DIFF
--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -208,6 +208,7 @@ func (r *RestData) checkFileInSubdir(dir, filename string) string {
 	}
 	return ""
 }
+
 // dependency-update tools (Dependabot, Renovate). Their presence is direct
 // evidence a repository manages its dependencies, observable even when
 // security-insights.yml is absent.
@@ -501,10 +502,12 @@ func (r *RestData) getReleases() error {
 		endpoint := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=%d&page=%d", APIBase, r.owner, r.repo, perPage, page)
 		responseData, err := r.MakeApiCall(endpoint, true)
 		if err != nil {
+			r.Releases = nil
 			return fmt.Errorf("failed to fetch releases page %d: %w", page, err)
 		}
 		var releases []ReleaseData
 		if err := json.Unmarshal(responseData, &releases); err != nil {
+			r.Releases = nil
 			return fmt.Errorf("failed to decode releases page %d: %w", page, err)
 		}
 		r.Releases = append(r.Releases, releases...)

--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -40,6 +40,7 @@ type RestData struct {
 	PrivateVulnReporting        PrivateVulnReporting
 	SecurityPolicy              SecurityPolicy
 	Releases                    []ReleaseData
+	ReleasesError               error `json:"-" yaml:"-"`
 	contents                    RepoContent
 	ghClient                    *github.Client `json:"-" yaml:"-"`
 	HttpClient                  HttpClient     `json:"-" yaml:"-"`
@@ -55,6 +56,7 @@ type ReleaseData struct {
 	Name    string         `json:"name"`
 	TagName string         `json:"tag_name"`
 	URL     string         `json:"url"`
+	Draft   bool           `json:"draft"`
 	Assets  []ReleaseAsset `json:"assets"`
 }
 
@@ -89,7 +91,7 @@ func (r *RestData) Setup() error {
 		_ = r.getWorkflowPermissions()
 	})
 	wg.Go(func() {
-		_ = r.getReleases()
+		r.ReleasesError = r.getReleases()
 	})
 	wg.Go(func() {
 		r.getPrivateVulnReporting()
@@ -493,12 +495,23 @@ func (r *RestData) rootHasDir(name string) bool {
 }
 
 func (r *RestData) getReleases() error {
-	endpoint := fmt.Sprintf("%s/repos/%s/%s/releases", APIBase, r.owner, r.repo)
-	responseData, err := r.MakeApiCall(endpoint, true)
-	if err != nil {
-		return err
+	const perPage = 100
+	r.Releases = nil
+	for page := 1; ; page++ {
+		endpoint := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=%d&page=%d", APIBase, r.owner, r.repo, perPage, page)
+		responseData, err := r.MakeApiCall(endpoint, true)
+		if err != nil {
+			return fmt.Errorf("failed to fetch releases page %d: %w", page, err)
+		}
+		var releases []ReleaseData
+		if err := json.Unmarshal(responseData, &releases); err != nil {
+			return fmt.Errorf("failed to decode releases page %d: %w", page, err)
+		}
+		r.Releases = append(r.Releases, releases...)
+		if len(releases) < perPage {
+			return nil
+		}
 	}
-	return json.Unmarshal(responseData, &r.Releases)
 }
 
 func (r *RestData) getWorkflowPermissions() error {

--- a/data/rest-data_test.go
+++ b/data/rest-data_test.go
@@ -186,8 +186,8 @@ func TestHasBuildInstructions(t *testing.T) {
 			expected:    false,
 		},
 		{
-			name:     "BUILDING.md in docs",
-			toplevel: []*github.RepositoryContent{},
+			name:      "BUILDING.md in docs",
+			toplevel:  []*github.RepositoryContent{},
 			githubDir: dummyGithubDir,
 			docsDir: []*github.RepositoryContent{
 				{Type: github.Ptr("file"), Name: github.Ptr("BUILDING.md"), Path: github.Ptr("docs/BUILDING.md")},
@@ -491,4 +491,37 @@ func TestGetReleasesReturnsDecodeError(t *testing.T) {
 	err := rest.getReleases()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decode releases page 1")
+	assert.Nil(t, rest.Releases, "Releases must be reset to nil on error")
+}
+
+func TestGetReleasesResetsPartialListOnLaterPageError(t *testing.T) {
+	oldAPIBase := APIBase
+	defer func() { APIBase = oldAPIBase }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		switch page {
+		case "1":
+			var releases []ReleaseData
+			for i := 0; i < 100; i++ {
+				releases = append(releases, ReleaseData{TagName: fmt.Sprintf("v1.%d", i)})
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(releases))
+		default:
+			_, _ = w.Write([]byte("not-json"))
+		}
+	}))
+	defer server.Close()
+	APIBase = server.URL
+
+	rest := &RestData{
+		owner:      "test-owner",
+		repo:       "test-repo",
+		HttpClient: server.Client(),
+	}
+	err := rest.getReleases()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode releases page 2")
+	assert.Nil(t, rest.Releases, "partial results from earlier pages must be discarded on error")
 }

--- a/data/rest-data_test.go
+++ b/data/rest-data_test.go
@@ -2,6 +2,8 @@ package data
 
 import (
 	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -426,4 +428,67 @@ func TestGetSubdirContentsCaching(t *testing.T) {
 		assert.Len(t, result.Content, 1)
 		assert.Equal(t, 1, *calls, "a directory the root listing confirms is fetched once")
 	})
+}
+
+func TestGetReleasesPaginatesAndDecodesDrafts(t *testing.T) {
+	oldAPIBase := APIBase
+	defer func() { APIBase = oldAPIBase }()
+
+	var requestedPages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "100", r.URL.Query().Get("per_page"))
+		page := r.URL.Query().Get("page")
+		requestedPages = append(requestedPages, page)
+
+		var releases []ReleaseData
+		switch page {
+		case "1":
+			for i := 0; i < 100; i++ {
+				releases = append(releases, ReleaseData{
+					TagName: fmt.Sprintf("v1.%d", i),
+					Draft:   i == 0,
+				})
+			}
+		case "2":
+			releases = []ReleaseData{{TagName: "v2.0.0"}}
+		default:
+			t.Fatalf("unexpected release page %q", page)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(releases))
+	}))
+	defer server.Close()
+	APIBase = server.URL
+
+	rest := &RestData{
+		owner:      "test-owner",
+		repo:       "test-repo",
+		HttpClient: server.Client(),
+	}
+	require.NoError(t, rest.getReleases())
+	require.Len(t, rest.Releases, 101)
+	assert.Equal(t, []string{"1", "2"}, requestedPages)
+	assert.True(t, rest.Releases[0].Draft)
+	assert.Equal(t, "v2.0.0", rest.Releases[100].TagName)
+}
+
+func TestGetReleasesReturnsDecodeError(t *testing.T) {
+	oldAPIBase := APIBase
+	defer func() { APIBase = oldAPIBase }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not-json"))
+	}))
+	defer server.Close()
+	APIBase = server.URL
+
+	rest := &RestData{
+		owner:      "test-owner",
+		repo:       "test-repo",
+		HttpClient: server.Client(),
+	}
+	err := rest.getReleases()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode releases page 1")
 }

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -150,7 +150,7 @@ var (
 			quality.VerifyDependencyManagement,
 		},
 		"OSPS-QA-02.02": {
-			reusable_steps.NotImplemented,
+			quality.ReleasesHaveSBOM,
 		},
 		"OSPS-QA-03.01": {
 			quality.StatusChecksAreRequiredByRulesets,

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -307,6 +307,12 @@ func DocumentsTestMaintenancePolicy(payload data.Payload) (result gemara.Result,
 // has no SBOM field, so the published assets are the only observable evidence.
 // GitHub's auto-generated source archives are not part of the REST asset list,
 // so every asset seen here is a deliberately published artifact.
+//
+// Assets are classified into three buckets: SBOM documents, definitely-compiled
+// artifacts (by extension), and ambiguous artifacts that are plausibly compiled
+// (archives and extensionless files, which commonly bundle native binaries).
+// Because an SBOM may be retained privately or distributed elsewhere, a missing
+// SBOM is reported as NeedsReview rather than a definitive failure.
 func ReleasesHaveSBOM(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// The control only applies once a release exists.
 	if len(payload.Releases) == 0 {
@@ -314,34 +320,45 @@ func ReleasesHaveSBOM(payload data.Payload) (result gemara.Result, message strin
 	}
 
 	var (
-		totalAssets            int
-		releasesWithCompiled   []string
-		releasesMissingSBOM    []string
-		sawSBOMWithoutCompiled bool
+		totalAssets              int
+		releasesWithArtifacts    []string
+		releasesMissingSBOM      []string
+		sawDefiniteCompiledAsset bool
+		sawSBOMWithoutArtifacts  bool
 	)
 
 	for _, release := range payload.Releases {
-		hasCompiled := false
 		hasSBOM := false
+		hasCompiled := false
+		hasAmbiguous := false
 		for _, asset := range release.Assets {
 			totalAssets++
-			if isSBOMAsset(asset.Name) {
+			name := asset.Name
+			if isSBOMAsset(name) {
 				hasSBOM = true
 				continue
 			}
-			if isCompiledReleaseAsset(asset.Name) {
+			if isSignatureOrChecksumAsset(strings.ToLower(strings.TrimSpace(name))) {
+				continue
+			}
+			if isCompiledReleaseAsset(name) {
 				hasCompiled = true
+			} else if isAmbiguousBinaryAsset(name) {
+				hasAmbiguous = true
 			}
 		}
 
 		label := releaseLabel(release)
-		if hasCompiled {
-			releasesWithCompiled = append(releasesWithCompiled, label)
+		if hasCompiled || hasAmbiguous {
+			releasesWithArtifacts = append(releasesWithArtifacts, label)
+			if hasCompiled {
+				sawDefiniteCompiledAsset = true
+			}
 			if !hasSBOM {
 				releasesMissingSBOM = append(releasesMissingSBOM, label)
 			}
 		} else if hasSBOM {
-			sawSBOMWithoutCompiled = true
+			sawSBOMWithoutArtifacts = true
 		}
 	}
 
@@ -351,25 +368,31 @@ func ReleasesHaveSBOM(payload data.Payload) (result gemara.Result, message strin
 		return gemara.NotApplicable, "Releases exist but publish no attached assets to inspect for compiled software or SBOMs; distribution may occur outside GitHub releases", gemara.Low
 	}
 
-	// No compiled assets were published, so the "compiled released software
-	// assets" precondition is not met by the observable evidence.
-	if len(releasesWithCompiled) == 0 {
-		if sawSBOMWithoutCompiled {
-			return gemara.Passed, "No compiled release assets were found, and at least one release publishes an SBOM", gemara.Low
+	// No compiled or archived assets were published, so the "compiled released
+	// software assets" precondition is not met by the observable evidence.
+	if len(releasesWithArtifacts) == 0 {
+		if sawSBOMWithoutArtifacts {
+			return gemara.Passed, "No compiled or archived release assets were found, and at least one release publishes an SBOM", gemara.Low
 		}
-		return gemara.NeedsReview, "No compiled release assets were observed among published release assets; review the project to confirm whether any compiled artifacts are distributed and require an SBOM", gemara.Low
+		return gemara.NeedsReview, "No compiled or archived release assets were observed among published release assets; review the project to confirm whether any compiled artifacts are distributed and require an SBOM", gemara.Low
 	}
 
-	// Every release that publishes compiled assets also publishes an SBOM.
+	// Every release that publishes compiled or archived assets also publishes an
+	// SBOM. Confidence is higher when at least one artifact was unambiguously a
+	// compiled binary rather than an archive or extensionless file.
 	if len(releasesMissingSBOM) == 0 {
-		return gemara.Passed, fmt.Sprintf("All release(s) publishing compiled assets also publish an SBOM: %s", strings.Join(releasesWithCompiled, ", ")), gemara.Medium
+		conf := gemara.Low
+		if sawDefiniteCompiledAsset {
+			conf = gemara.Medium
+		}
+		return gemara.Passed, fmt.Sprintf("All release(s) publishing compiled or archived assets also publish an SBOM: %s", strings.Join(releasesWithArtifacts, ", ")), conf
 	}
 
 	// An SBOM absent from GitHub release assets is not proof that one does not
 	// exist. Publishers may retain it as private compliance documentation or
 	// distribute it through another channel, so request manual evidence rather
 	// than reporting a definitive failure.
-	return gemara.NeedsReview, fmt.Sprintf("No SBOM was found among the GitHub assets for release(s) publishing compiled software: %s. Review publisher evidence because an SBOM may be retained privately or distributed through another channel", strings.Join(releasesMissingSBOM, ", ")), gemara.Low
+	return gemara.NeedsReview, fmt.Sprintf("No SBOM was found among the GitHub assets for release(s) publishing compiled or archived software: %s. Review publisher evidence because an SBOM may be retained privately or distributed through another channel", strings.Join(releasesMissingSBOM, ", ")), gemara.Low
 }
 
 // releaseLabel returns a human-friendly identifier for a release, preferring the
@@ -461,6 +484,52 @@ func isCompiledReleaseAsset(name string) bool {
 		if strings.HasSuffix(lower, ext) {
 			return true
 		}
+	}
+	return false
+}
+
+// ambiguousArchiveExtensions are archive/compression suffixes that commonly
+// bundle compiled binaries (but may also contain source). Assets matching these
+// are treated as plausibly compiled and routed to manual review.
+var ambiguousArchiveExtensions = []string{
+	".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tbz", ".tar.xz", ".txz",
+	".tar.zst", ".tar.lz", ".tar.lzma", ".tar",
+	".zip", ".gz", ".bz2", ".xz", ".zst", ".7z", ".rar", ".bin",
+}
+
+// extensionlessNonBinaryNames are common extensionless files that are not
+// compiled artifacts, so an extensionless asset with one of these names is not
+// treated as plausibly compiled.
+var extensionlessNonBinaryNames = map[string]bool{
+	"license": true, "licence": true, "readme": true, "notice": true,
+	"authors": true, "copying": true, "changelog": true, "changes": true,
+	"install": true, "makefile": true, "dockerfile": true, "version": true,
+	"contributing": true, "codeowners": true, "manifest": true, "owners": true,
+	"maintainers": true, "security": true,
+}
+
+// isAmbiguousBinaryAsset reports whether a release asset is plausibly a compiled
+// binary even though it is not identified by a definite compiled extension.
+// This covers archives (which frequently bundle native binaries) and
+// extensionless files (common for native executables), excluding well-known
+// extensionless documentation files. Matching is case-insensitive.
+func isAmbiguousBinaryAsset(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	if isSBOMAsset(lower) || isSignatureOrChecksumAsset(lower) || isCompiledReleaseAsset(lower) {
+		return false
+	}
+	for _, ext := range ambiguousArchiveExtensions {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	// Extensionless assets are commonly native executables (e.g.
+	// "mytool_linux_amd64"). Exclude recognizable documentation files.
+	if !strings.Contains(lower, ".") {
+		return !extensionlessNonBinaryNames[lower]
 	}
 	return false
 }

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -299,6 +299,192 @@ func DocumentsTestMaintenancePolicy(payload data.Payload) (result gemara.Result,
 	return gemara.NeedsReview, "Review project documentation to ensure it contains a clear policy for maintaining tests", confidence
 }
 
+// ReleasesHaveSBOM assesses OSPS-QA-02.02: when the project has made a release,
+// all compiled released software assets MUST be delivered with a software bill
+// of materials (SBOM).
+//
+// Evidence comes from the assets attached to GitHub releases. Security Insights
+// has no SBOM field, so the published assets are the only observable evidence.
+// GitHub's auto-generated source archives are not part of the REST asset list,
+// so every asset seen here is a deliberately published artifact.
+func ReleasesHaveSBOM(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	// The control only applies once a release exists.
+	if len(payload.Releases) == 0 {
+		return gemara.NotApplicable, "No releases found; the SBOM-for-releases requirement does not apply", gemara.High
+	}
+
+	var (
+		totalAssets            int
+		releasesWithCompiled   []string
+		releasesMissingSBOM    []string
+		sawSBOMWithoutCompiled bool
+	)
+
+	for _, release := range payload.Releases {
+		hasCompiled := false
+		hasSBOM := false
+		for _, asset := range release.Assets {
+			totalAssets++
+			if isSBOMAsset(asset.Name) {
+				hasSBOM = true
+				continue
+			}
+			if isCompiledReleaseAsset(asset.Name) {
+				hasCompiled = true
+			}
+		}
+
+		label := releaseLabel(release)
+		if hasCompiled {
+			releasesWithCompiled = append(releasesWithCompiled, label)
+			if !hasSBOM {
+				releasesMissingSBOM = append(releasesMissingSBOM, label)
+			}
+		} else if hasSBOM {
+			sawSBOMWithoutCompiled = true
+		}
+	}
+
+	// Releases exist but publish nothing we can inspect: distribution and SBOM
+	// generation may happen outside GitHub releases, so this is unconfirmed.
+	if totalAssets == 0 {
+		return gemara.NotApplicable, "Releases exist but publish no attached assets to inspect for compiled software or SBOMs; distribution may occur outside GitHub releases", gemara.Low
+	}
+
+	// No compiled assets were published, so the "compiled released software
+	// assets" precondition is not met by the observable evidence.
+	if len(releasesWithCompiled) == 0 {
+		if sawSBOMWithoutCompiled {
+			return gemara.Passed, "No compiled release assets were found, and at least one release publishes an SBOM", gemara.Low
+		}
+		return gemara.NeedsReview, "No compiled release assets were observed among published release assets; review the project to confirm whether any compiled artifacts are distributed and require an SBOM", gemara.Low
+	}
+
+	// Every release that publishes compiled assets also publishes an SBOM.
+	if len(releasesMissingSBOM) == 0 {
+		return gemara.Passed, fmt.Sprintf("All release(s) publishing compiled assets also publish an SBOM: %s", strings.Join(releasesWithCompiled, ", ")), gemara.Medium
+	}
+
+	// Some or all releases with compiled assets are missing an SBOM.
+	return gemara.Failed, fmt.Sprintf("Release(s) publishing compiled assets without an SBOM: %s", strings.Join(releasesMissingSBOM, ", ")), gemara.Medium
+}
+
+// releaseLabel returns a human-friendly identifier for a release, preferring the
+// tag name and falling back to the display name.
+func releaseLabel(release data.ReleaseData) string {
+	if release.TagName != "" {
+		return release.TagName
+	}
+	if release.Name != "" {
+		return release.Name
+	}
+	return "(unnamed release)"
+}
+
+// sbomExtensionSuffixes are filename suffixes that identify SBOM documents.
+var sbomExtensionSuffixes = []string{
+	".spdx", ".spdx.json", ".spdx.yaml", ".spdx.yml", ".spdx.rdf", ".spdx.xml",
+	".cdx.json", ".cdx.xml", ".cdx",
+}
+
+// isSBOMAsset reports whether a release asset name looks like a software bill of
+// materials. Matching is case-insensitive. The bare token "bom" and the
+// "cyclonedx"/"sbom" markers are guarded to avoid false positives on unrelated
+// names (e.g. "random-bomb.txt").
+func isSBOMAsset(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+
+	for _, suffix := range sbomExtensionSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+
+	// Format markers that are unambiguous wherever they appear in the name.
+	if strings.Contains(lower, "cyclonedx") || strings.Contains(lower, ".spdx") || strings.Contains(lower, ".cdx") {
+		return true
+	}
+
+	// "sbom" and "bom" only count as whole, delimiter-bounded tokens so names
+	// like "random-bomb.txt" or "shabomb" are not misclassified.
+	for _, token := range sbomTokens(lower) {
+		if token == "sbom" || token == "bom" {
+			return true
+		}
+	}
+	return false
+}
+
+// sbomTokens splits a filename into lowercase tokens on common delimiters so the
+// SBOM matcher can test whole words rather than substrings.
+func sbomTokens(lower string) []string {
+	return strings.FieldsFunc(lower, func(r rune) bool {
+		switch r {
+		case '.', '-', '_', ' ', '/', '+':
+			return true
+		default:
+			return false
+		}
+	})
+}
+
+// compiledReleaseAssetExtensions are filename suffixes for compiled/binary
+// software artifacts that a project would distribute as release assets.
+var compiledReleaseAssetExtensions = []string{
+	".exe", ".dll", ".so", ".dylib", ".a", ".lib",
+	".jar", ".war", ".ear",
+	".apk", ".aar", ".aab",
+	".wasm", ".node", ".o", ".obj",
+	".deb", ".rpm", ".msi", ".dmg", ".pkg", ".appimage", ".snap", ".flatpak",
+	".whl",
+}
+
+// isCompiledReleaseAsset reports whether a release asset name looks like a
+// compiled software artifact. Matching is case-insensitive. SBOM, signature,
+// and checksum companion files are excluded so they are never counted as the
+// compiled artifact they accompany.
+func isCompiledReleaseAsset(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+	if isSBOMAsset(lower) || isSignatureOrChecksumAsset(lower) {
+		return false
+	}
+	for _, ext := range compiledReleaseAssetExtensions {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// signatureOrChecksumSuffixes identify signature, certificate, and checksum
+// companion files that accompany released artifacts.
+var signatureOrChecksumSuffixes = []string{
+	".sig", ".asc", ".pem", ".cert", ".crt", ".p7s", ".minisig",
+	".sha", ".sha1", ".sha224", ".sha256", ".sha384", ".sha512", ".md5",
+}
+
+// isSignatureOrChecksumAsset reports whether a release asset name is a signature
+// or checksum companion file rather than a compiled artifact.
+func isSignatureOrChecksumAsset(lower string) bool {
+	for _, suffix := range signatureOrChecksumSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	for _, token := range sbomTokens(lower) {
+		if token == "checksums" || token == "checksum" {
+			return true
+		}
+	}
+	return false
+}
+
 // testExecutionDocumentationEvidence gathers README and CONTRIBUTING content
 // as AI input for OSPS-QA-06.02. Only these two files are included because the
 // control targets contributor-facing test guidance.

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -598,7 +598,9 @@ func isSignatureOrChecksumAsset(lower string) bool {
 		}
 	}
 	for _, token := range sbomTokens(lower) {
-		if token == "checksums" || token == "checksum" {
+		switch token {
+		case "checksums", "checksum",
+			"shasums", "sha1sums", "sha256sums", "sha512sums", "md5sums", "b2sums":
 			return true
 		}
 	}

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -314,9 +314,23 @@ func DocumentsTestMaintenancePolicy(payload data.Payload) (result gemara.Result,
 // Because an SBOM may be retained privately or distributed elsewhere, a missing
 // SBOM is reported as NeedsReview rather than a definitive failure.
 func ReleasesHaveSBOM(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	// The control only applies once a release exists.
-	if len(payload.Releases) == 0 {
-		return gemara.NotApplicable, "No releases found; the SBOM-for-releases requirement does not apply", gemara.High
+	if payload.RestData == nil {
+		return gemara.NeedsReview, "Release data is unavailable; review publisher evidence for released assets and SBOMs", gemara.Low
+	}
+	if payload.ReleasesError != nil {
+		return gemara.NeedsReview, fmt.Sprintf("Release data could not be retrieved: %v. Review publisher evidence for released assets and SBOMs", payload.ReleasesError), gemara.Low
+	}
+
+	// Draft releases are not published software releases and must not affect the
+	// assessment, even when an authenticated caller can observe them.
+	publishedReleases := 0
+	for _, release := range payload.Releases {
+		if !release.Draft {
+			publishedReleases++
+		}
+	}
+	if publishedReleases == 0 {
+		return gemara.NotApplicable, "No published releases found; the SBOM-for-releases requirement does not apply", gemara.High
 	}
 
 	var (
@@ -328,6 +342,9 @@ func ReleasesHaveSBOM(payload data.Payload) (result gemara.Result, message strin
 	)
 
 	for _, release := range payload.Releases {
+		if release.Draft {
+			continue
+		}
 		hasSBOM := false
 		hasCompiled := false
 		hasAmbiguous := false
@@ -419,7 +436,7 @@ var sbomExtensionSuffixes = []string{
 // names (e.g. "random-bomb.txt").
 func isSBOMAsset(name string) bool {
 	lower := strings.ToLower(strings.TrimSpace(name))
-	if lower == "" {
+	if lower == "" || isSignatureOrChecksumAsset(lower) {
 		return false
 	}
 
@@ -429,7 +446,24 @@ func isSBOMAsset(name string) bool {
 		}
 	}
 
-	// Format markers that are unambiguous wherever they appear in the name.
+	// Archives may be tools or distributions whose product name contains an
+	// SBOM-format marker (for example cyclonedx-cli). Do not classify an archive
+	// as an SBOM based on a marker alone.
+	for _, suffix := range ambiguousArchiveExtensions {
+		if strings.HasSuffix(lower, suffix) {
+			return false
+		}
+	}
+
+	// A compiled artifact may also include an SBOM-format marker in its product
+	// name. Marker-only matching must not override a definite binary suffix.
+	for _, suffix := range compiledReleaseAssetExtensions {
+		if strings.HasSuffix(lower, suffix) {
+			return false
+		}
+	}
+
+	// Format markers that are unambiguous in non-archive document names.
 	if strings.Contains(lower, "cyclonedx") || strings.Contains(lower, ".spdx") || strings.Contains(lower, ".cdx") {
 		return true
 	}
@@ -508,6 +542,15 @@ var extensionlessNonBinaryNames = map[string]bool{
 	"maintainers": true, "security": true,
 }
 
+// knownNonBinaryExtensions identify common documentation and metadata files. An
+// unrecognized suffix remains ambiguous because versioned native binaries often
+// contain dots without having a file extension (for example tool-v1.2-linux).
+var knownNonBinaryExtensions = []string{
+	".txt", ".md", ".markdown", ".rst", ".adoc",
+	".json", ".yaml", ".yml", ".xml", ".toml", ".ini", ".cfg", ".conf",
+	".csv", ".html", ".htm", ".pdf",
+}
+
 // isAmbiguousBinaryAsset reports whether a release asset is plausibly a compiled
 // binary even though it is not identified by a definite compiled extension.
 // This covers archives (which frequently bundle native binaries) and
@@ -526,12 +569,17 @@ func isAmbiguousBinaryAsset(name string) bool {
 			return true
 		}
 	}
-	// Extensionless assets are commonly native executables (e.g.
-	// "mytool_linux_amd64"). Exclude recognizable documentation files.
-	if !strings.Contains(lower, ".") {
-		return !extensionlessNonBinaryNames[lower]
+	if extensionlessNonBinaryNames[lower] {
+		return false
 	}
-	return false
+	for _, ext := range knownNonBinaryExtensions {
+		if strings.HasSuffix(lower, ext) {
+			return false
+		}
+	}
+	// Unknown suffixes remain ambiguous: a dot may be part of a version rather
+	// than a true extension (for example "mytool-v1.2-linux-amd64").
+	return true
 }
 
 // signatureOrChecksumSuffixes identify signature, certificate, and checksum

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -365,8 +365,11 @@ func ReleasesHaveSBOM(payload data.Payload) (result gemara.Result, message strin
 		return gemara.Passed, fmt.Sprintf("All release(s) publishing compiled assets also publish an SBOM: %s", strings.Join(releasesWithCompiled, ", ")), gemara.Medium
 	}
 
-	// Some or all releases with compiled assets are missing an SBOM.
-	return gemara.Failed, fmt.Sprintf("Release(s) publishing compiled assets without an SBOM: %s", strings.Join(releasesMissingSBOM, ", ")), gemara.Medium
+	// An SBOM absent from GitHub release assets is not proof that one does not
+	// exist. Publishers may retain it as private compliance documentation or
+	// distribute it through another channel, so request manual evidence rather
+	// than reporting a definitive failure.
+	return gemara.NeedsReview, fmt.Sprintf("No SBOM was found among the GitHub assets for release(s) publishing compiled software: %s. Review publisher evidence because an SBOM may be retained privately or distributed through another channel", strings.Join(releasesMissingSBOM, ", ")), gemara.Low
 }
 
 // releaseLabel returns a human-friendly identifier for a release, preferring the

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -813,3 +813,30 @@ func TestIsAmbiguousBinaryAsset(t *testing.T) {
 		}
 	}
 }
+
+func TestIsSignatureOrChecksumAsset(t *testing.T) {
+	// Callers pass an already-lowercased, trimmed name, so inputs are lowercase.
+	cases := map[string]bool{
+		"app.exe.sig":                true,
+		"app.tar.gz.asc":             true,
+		"app.sha256":                 true,
+		"app.md5":                    true,
+		"checksums.txt":              true,
+		"release.checksum":           true,
+		"sha256sums":                 true,
+		"md5sums":                    true,
+		"terraform_1.9.0_sha256sums": true,
+		"sha512sums":                 true,
+		"b2sums":                     true,
+		"app.exe":                    false,
+		"mytool_linux_amd64":         false,
+		"app.spdx.json":              false,
+		"notes.txt":                  false,
+		"":                           false,
+	}
+	for name, want := range cases {
+		if got := isSignatureOrChecksumAsset(name); got != want {
+			t.Errorf("isSignatureOrChecksumAsset(%q) = %v, want %v", name, got, want)
+		}
+	}
+}

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -650,18 +650,18 @@ func TestReleasesHaveSBOM(t *testing.T) {
 			wantMsgPart: "v3.0.0",
 		},
 		{
-			name:        "compiled asset without sbom fails",
+			name:        "compiled asset without published sbom needs review",
 			releases:    []data.ReleaseData{relWithAssets("v1.2.3", "app.exe", "app.exe.sha256")},
-			wantResult:  gemara.Failed,
-			wantMsgPart: "v1.2.3",
+			wantResult:  gemara.NeedsReview,
+			wantMsgPart: "may be retained privately",
 		},
 		{
-			name: "one of several releases missing sbom fails and names it",
+			name: "one of several releases missing published sbom needs review and names it",
 			releases: []data.ReleaseData{
 				relWithAssets("v1.0.0", "app.exe", "app.spdx.json"),
 				relWithAssets("v1.1.0", "app.exe"),
 			},
-			wantResult:  gemara.Failed,
+			wantResult:  gemara.NeedsReview,
 			wantMsgPart: "v1.1.0",
 		},
 		{

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -668,13 +668,37 @@ func TestReleasesHaveSBOM(t *testing.T) {
 			name:        "no compiled assets but sbom present passes",
 			releases:    []data.ReleaseData{relWithAssets("v1.0.0", "notes.txt", "app.spdx.json")},
 			wantResult:  gemara.Passed,
-			wantMsgPart: "No compiled release assets",
+			wantMsgPart: "No compiled or archived release assets",
 		},
 		{
 			name:        "no compiled assets and no sbom needs review",
 			releases:    []data.ReleaseData{relWithAssets("v1.0.0", "README.md", "notes.txt")},
 			wantResult:  gemara.NeedsReview,
-			wantMsgPart: "No compiled release assets were observed",
+			wantMsgPart: "No compiled or archived release assets were observed",
+		},
+		{
+			name:        "archived binary without sbom needs review",
+			releases:    []data.ReleaseData{relWithAssets("v1.0.0", "mytool_1.0_linux_amd64.tar.gz", "checksums.txt")},
+			wantResult:  gemara.NeedsReview,
+			wantMsgPart: "may be retained privately",
+		},
+		{
+			name:        "archived binary with sbom passes",
+			releases:    []data.ReleaseData{relWithAssets("v1.0.0", "mytool-windows-x64.zip", "mytool.spdx.json")},
+			wantResult:  gemara.Passed,
+			wantMsgPart: "v1.0.0",
+		},
+		{
+			name:        "extensionless binary without sbom needs review",
+			releases:    []data.ReleaseData{relWithAssets("v1.0.0", "mytool_linux_amd64")},
+			wantResult:  gemara.NeedsReview,
+			wantMsgPart: "may be retained privately",
+		},
+		{
+			name:        "extensionless docs only need review as no artifacts",
+			releases:    []data.ReleaseData{relWithAssets("v1.0.0", "LICENSE", "README")},
+			wantResult:  gemara.NeedsReview,
+			wantMsgPart: "No compiled or archived release assets were observed",
 		},
 	}
 
@@ -732,6 +756,29 @@ func TestIsCompiledReleaseAsset(t *testing.T) {
 	for name, want := range cases {
 		if got := isCompiledReleaseAsset(name); got != want {
 			t.Errorf("isCompiledReleaseAsset(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestIsAmbiguousBinaryAsset(t *testing.T) {
+	cases := map[string]bool{
+		"mytool_1.0_linux_amd64.tar.gz": true,
+		"mytool-windows-x64.zip":        true,
+		"blob.bin":                      true,
+		"mytool_linux_amd64":            true,
+		"kubectl":                       true,
+		"LICENSE":                       false,
+		"README":                        false,
+		"Makefile":                      false,
+		"app.exe":                       false,
+		"notes.txt":                     false,
+		"app.spdx.json":                 false,
+		"checksums.txt":                 false,
+		"":                              false,
+	}
+	for name, want := range cases {
+		if got := isAmbiguousBinaryAsset(name); got != want {
+			t.Errorf("isAmbiguousBinaryAsset(%q) = %v, want %v", name, got, want)
 		}
 	}
 }

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -623,7 +623,28 @@ func TestReleasesHaveSBOM(t *testing.T) {
 			name:        "no releases",
 			releases:    nil,
 			wantResult:  gemara.NotApplicable,
-			wantMsgPart: "No releases found",
+			wantMsgPart: "No published releases found",
+		},
+		{
+			name:        "release retrieval error needs review",
+			releases:    nil,
+			wantResult:  gemara.NeedsReview,
+			wantMsgPart: "could not be retrieved",
+		},
+		{
+			name:        "draft release is ignored",
+			releases:    []data.ReleaseData{{TagName: "v-next", Draft: true, Assets: []data.ReleaseAsset{{Name: "app.exe"}}}},
+			wantResult:  gemara.NotApplicable,
+			wantMsgPart: "No published releases found",
+		},
+		{
+			name: "draft release does not contaminate published release",
+			releases: []data.ReleaseData{
+				{TagName: "v-next", Draft: true, Assets: []data.ReleaseAsset{{Name: "app.exe"}}},
+				relWithAssets("v1.0.0", "app.exe", "app.spdx.json"),
+			},
+			wantResult:  gemara.Passed,
+			wantMsgPart: "v1.0.0",
 		},
 		{
 			name:        "release with no assets",
@@ -704,7 +725,11 @@ func TestReleasesHaveSBOM(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			payload := data.Payload{RestData: &data.RestData{Releases: tt.releases}}
+			restData := &data.RestData{Releases: tt.releases}
+			if tt.name == "release retrieval error needs review" {
+				restData.ReleasesError = errors.New("GitHub API unavailable")
+			}
+			payload := data.Payload{RestData: restData}
 			gotResult, gotMsg, _ := ReleasesHaveSBOM(payload)
 			if gotResult != tt.wantResult {
 				t.Errorf("result = %v, want %v (msg: %q)", gotResult, tt.wantResult, gotMsg)
@@ -729,6 +754,10 @@ func TestIsSBOMAsset(t *testing.T) {
 		"random-bomb.txt":      false,
 		"shabomb":              false,
 		"app.exe":              false,
+		"app.spdx.json.sig":    false,
+		"cyclonedx-cli.tar.gz": false,
+		"cyclonedx-cli.exe":    false,
+		"app.spdx.json.exe":    false,
 		"":                     false,
 	}
 	for name, want := range cases {
@@ -766,6 +795,8 @@ func TestIsAmbiguousBinaryAsset(t *testing.T) {
 		"mytool-windows-x64.zip":        true,
 		"blob.bin":                      true,
 		"mytool_linux_amd64":            true,
+		"mytool-v1.2-linux-amd64":       true,
+		"cyclonedx-cli-linux.tar.gz":    true,
 		"kubectl":                       true,
 		"LICENSE":                       false,
 		"README":                        false,

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -603,3 +603,135 @@ func TestTestExecutionDocumentationEvidenceFetchError(t *testing.T) {
 		t.Fatal("expected an error when the README fetch fails, got nil")
 	}
 }
+
+func relWithAssets(tag string, assetNames ...string) data.ReleaseData {
+	assets := make([]data.ReleaseAsset, 0, len(assetNames))
+	for _, name := range assetNames {
+		assets = append(assets, data.ReleaseAsset{Name: name})
+	}
+	return data.ReleaseData{TagName: tag, Assets: assets}
+}
+
+func TestReleasesHaveSBOM(t *testing.T) {
+	tests := []struct {
+		name        string
+		releases    []data.ReleaseData
+		wantResult  gemara.Result
+		wantMsgPart string
+	}{
+		{
+			name:        "no releases",
+			releases:    nil,
+			wantResult:  gemara.NotApplicable,
+			wantMsgPart: "No releases found",
+		},
+		{
+			name:        "release with no assets",
+			releases:    []data.ReleaseData{{TagName: "v1.0.0"}},
+			wantResult:  gemara.NotApplicable,
+			wantMsgPart: "no attached assets",
+		},
+		{
+			name:        "compiled asset with spdx sbom passes",
+			releases:    []data.ReleaseData{relWithAssets("v1.0.0", "app-linux-amd64", "app.exe", "app.spdx.json")},
+			wantResult:  gemara.Passed,
+			wantMsgPart: "v1.0.0",
+		},
+		{
+			name:        "compiled asset with cyclonedx sbom passes",
+			releases:    []data.ReleaseData{relWithAssets("v2.0.0", "lib.jar", "lib.cdx.json")},
+			wantResult:  gemara.Passed,
+			wantMsgPart: "v2.0.0",
+		},
+		{
+			name:        "compiled asset with bom.json passes",
+			releases:    []data.ReleaseData{relWithAssets("v3.0.0", "tool.dll", "bom.json")},
+			wantResult:  gemara.Passed,
+			wantMsgPart: "v3.0.0",
+		},
+		{
+			name:        "compiled asset without sbom fails",
+			releases:    []data.ReleaseData{relWithAssets("v1.2.3", "app.exe", "app.exe.sha256")},
+			wantResult:  gemara.Failed,
+			wantMsgPart: "v1.2.3",
+		},
+		{
+			name: "one of several releases missing sbom fails and names it",
+			releases: []data.ReleaseData{
+				relWithAssets("v1.0.0", "app.exe", "app.spdx.json"),
+				relWithAssets("v1.1.0", "app.exe"),
+			},
+			wantResult:  gemara.Failed,
+			wantMsgPart: "v1.1.0",
+		},
+		{
+			name:        "no compiled assets but sbom present passes",
+			releases:    []data.ReleaseData{relWithAssets("v1.0.0", "notes.txt", "app.spdx.json")},
+			wantResult:  gemara.Passed,
+			wantMsgPart: "No compiled release assets",
+		},
+		{
+			name:        "no compiled assets and no sbom needs review",
+			releases:    []data.ReleaseData{relWithAssets("v1.0.0", "README.md", "notes.txt")},
+			wantResult:  gemara.NeedsReview,
+			wantMsgPart: "No compiled release assets were observed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := data.Payload{RestData: &data.RestData{Releases: tt.releases}}
+			gotResult, gotMsg, _ := ReleasesHaveSBOM(payload)
+			if gotResult != tt.wantResult {
+				t.Errorf("result = %v, want %v (msg: %q)", gotResult, tt.wantResult, gotMsg)
+			}
+			if tt.wantMsgPart != "" && !strings.Contains(gotMsg, tt.wantMsgPart) {
+				t.Errorf("message %q does not contain %q", gotMsg, tt.wantMsgPart)
+			}
+		})
+	}
+}
+
+func TestIsSBOMAsset(t *testing.T) {
+	cases := map[string]bool{
+		"app.spdx.json":        true,
+		"app.spdx":             true,
+		"sbom.xml":             true,
+		"my-sbom.json":         true,
+		"bom.json":             true,
+		"project.cdx.json":     true,
+		"cyclonedx-output.txt": true,
+		"APP.SPDX.JSON":        true,
+		"random-bomb.txt":      false,
+		"shabomb":              false,
+		"app.exe":              false,
+		"":                     false,
+	}
+	for name, want := range cases {
+		if got := isSBOMAsset(name); got != want {
+			t.Errorf("isSBOMAsset(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestIsCompiledReleaseAsset(t *testing.T) {
+	cases := map[string]bool{
+		"app.exe":        true,
+		"lib.so":         true,
+		"lib.dylib":      true,
+		"tool.jar":       true,
+		"pkg.whl":        true,
+		"installer.msi":  true,
+		"app.spdx.json":  false,
+		"app.exe.sig":    false,
+		"app.exe.sha256": false,
+		"README.md":      false,
+		"source.tar.gz":  false,
+		"":               false,
+	}
+	for name, want := range cases {
+		if got := isCompiledReleaseAsset(name); got != want {
+			t.Errorf("isCompiledReleaseAsset(%q) = %v, want %v", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements **OSPS-QA-02.02**, replacing the previous `reusable_steps.NotImplemented` stub with a real assessment step, `quality.ReleasesHaveSBOM`.

> Control: *When the project has made a release, all compiled released software assets MUST be delivered with a software bill of materials (SBOM).* (Maturity Level 3)

Closes #342. Related history: #24.

## How it works

Security Insights has no SBOM field, so the only observable evidence is the set of assets attached to GitHub releases (REST). GitHub's auto-generated source archives are not part of the REST asset list, so every asset seen is a deliberately published artifact.

Each release asset is classified into one of three buckets:
- **SBOM documents** — CycloneDX / SPDX / CDX markers (signatures, checksums, and binaries that merely embed an SBOM marker are excluded).
- **Definitely-compiled artifacts** — by binary extension (`.exe`, `.so`, `.dll`, `.dylib`, `.a`, …).
- **Ambiguous artifacts** — archives (`.tar.gz`, `.zip`, …) and extensionless files, which commonly bundle native binaries and are routed to review.

## Why this check returns `NeedsReview` instead of `Failed`

**A missing *public* SBOM is not evidence of non-compliance, so this control intentionally never returns `Failed`.**

Under the EU Cyber Resilience Act (Regulation (EU) 2024/2847), a manufacturer must *create* an SBOM as part of the product's technical documentation and provide it to market-surveillance authorities on reasoned request — but **publishing the SBOM to users is optional** ("If the manufacturer decides to make available the SBOM…"). An SBOM can therefore legitimately be retained privately, delivered through a separate distribution channel, or produced only for audit.

In addition, Privateer runs this scan from a **software-publisher** perspective — the scanner observes what is publicly attached to releases and cannot see privately-retained SBOMs, and the operator is often not the party that produces the SBOM.

Because the absence of a public SBOM is genuinely ambiguous (compliant-but-private vs. actually-missing), the check surfaces it as `NeedsReview` with a message pointing the reviewer to publisher evidence, rather than asserting a failure it cannot substantiate. This rationale is also documented in the doc comment on `ReleasesHaveSBOM`.

## Result matrix

| Situation | Result | Confidence |
|---|---|---|
| No published (non-draft) releases | `NotApplicable` | High |
| Releases exist but no attached assets | `NotApplicable` | Low |
| Compiled/archived assets present, all releases have an SBOM | `Passed` | Medium/Low |
| Only an SBOM present, no compiled/archived assets | `Passed` | Low |
| Compiled/archived assets present, some release missing an SBOM | `NeedsReview` | Low |
| No compiled/archived assets and no SBOM | `NeedsReview` | Low |
| Release data unavailable or retrieval error | `NeedsReview` | Low |

## Data-layer changes (`data/rest-data.go`)

- Added release **pagination** (`per_page=100`, loops until a short page).
- Added a `Draft` field to `ReleaseData`; draft releases are excluded from both the published-release precondition and the asset scan.
- Release-fetch errors are now captured in `RestData.ReleasesError` and propagated so retrieval failures become `NeedsReview` rather than a false `NotApplicable`.

## Tests

- `TestReleasesHaveSBOM` — result matrix incl. drafts, pagination, retrieval errors, ambiguous/archived/extensionless assets.
- `TestIsSBOMAsset`, `TestIsCompiledReleaseAsset`, `TestIsAmbiguousBinaryAsset` — classifier unit tests incl. sidecar/false-positive guards.
- `TestGetReleasesPaginatesAndDecodesDrafts`, `TestGetReleasesReturnsDecodeError` — data-layer pagination/draft/error handling.

`go build ./...`, `go vet ./...`, and `go test ./...` (incl. `-race`) all pass.
