### PR TITLE
feat(OSPS-VM-06.02): enforce SAST checks on code changes

### DIFF
--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -229,8 +229,7 @@ var (
 		},
 		"OSPS-VM-06.02": {
 			reusable_steps.IsCodeRepo,
-			reusable_steps.HasSecurityInsightsFile,
-			vuln_management.SastToolDefined,
+			vuln_management.SastEnforcedOnChanges,
 		},
 	}
 )

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -3,11 +3,12 @@ package vuln_management
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/si-tooling/v2/si"
+	"github.com/rhysd/actionlint"
 )
 
 var (
@@ -73,19 +74,239 @@ func HasSecContact(payload data.Payload) (result gemara.Result, message string, 
 	return gemara.Failed, "No security contact found in Security Insights data, a SECURITY.md file, or GitHub private vulnerability reporting", gemara.Medium
 }
 
-func SastToolDefined(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	for _, tool := range payload.Insights.Repository.SecurityPosture.Tools {
-		if tool.Type == "SAST" {
+// knownSastIdentifiers are lowercase substrings that identify a Static
+// Application Security Testing tool by its action reference, invoked command, or
+// the status-check name it publishes. Kept deliberately narrow to SAST: secret
+// scanners, dependency/SCA tools, and container/IaC misconfiguration scanners
+// are intentionally excluded so they cannot be mistaken for a code-analysis gate.
+var knownSastIdentifiers = []string{
+	"codeql",
+	"semgrep",
+	"opengrep",
+	"sonarcloud",
+	"sonarqube",
+	"sonar-scanner",
+	"sonarsource",
+	"checkmarx",
+	"snyk code",
+	"bandit",
+	"gosec",
+	"brakeman",
+	"bearer",
+	"horusec",
+	"deepsource",
+}
 
-			enabled := []bool{tool.Integration.Adhoc, tool.Integration.Ci, tool.Integration.Release}
+// matchSast returns the first known SAST identifier that appears in text, or the
+// empty string when none is present. Matching is case-insensitive.
+func matchSast(text string) string {
+	lower := strings.ToLower(text)
+	for _, id := range knownSastIdentifiers {
+		if strings.Contains(lower, id) {
+			return id
+		}
+	}
+	return ""
+}
 
-			if slices.Contains(enabled, true) {
-				return gemara.Passed, "Static Application Security Testing documented in Security Insights", confidence
+// isWorkflowYAML reports whether a file name is a GitHub Actions workflow
+// definition by extension.
+func isWorkflowYAML(name string) bool {
+	return strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml")
+}
+
+// workflowRunsOnChanges reports whether a workflow is triggered by an event that
+// fires on changes to the codebase, i.e. a pull request or a push. Only these
+// can act as a gate on incoming changes; scheduled or manual runs cannot.
+func workflowRunsOnChanges(workflow *actionlint.Workflow) bool {
+	for _, event := range workflow.On {
+		switch event.EventName() {
+		case "pull_request", "pull_request_target", "push":
+			return true
+		}
+	}
+	return false
+}
+
+// detectSastToolInInsights returns correlation names for every Security Insights
+// tool declared as a SAST tool integrated into continuous integration. Adhoc or
+// release-only integrations are ignored because they do not evaluate incoming
+// changes.
+func detectSastToolInInsights(tools []si.SecurityTool) []string {
+	var names []string
+	for _, tool := range tools {
+		if strings.EqualFold(tool.Type, "SAST") && tool.Integration.Ci {
+			name := strings.TrimSpace(tool.Name)
+			if name == "" {
+				name = "SAST"
+			}
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// detectSastInWorkflows inspects workflow files for a known SAST tool invoked by
+// a workflow that runs on changes. It returns correlation names (the identifier,
+// the workflow name, and the job name/ID) that a required status-check context
+// can be matched against. Files that cannot be read or parsed are skipped rather
+// than treated as evidence.
+func detectSastInWorkflows(files []data.WorkflowFile) []string {
+	var sources []string
+	for _, file := range files {
+		if !isWorkflowYAML(file.Name) || file.Truncated {
+			continue
+		}
+		workflow, err := actionlint.Parse([]byte(file.Content))
+		if err != nil || workflow == nil {
+			continue
+		}
+		if !workflowRunsOnChanges(workflow) {
+			continue
+		}
+
+		workflowName := ""
+		if workflow.Name != nil {
+			workflowName = workflow.Name.Value
+		}
+
+		for _, job := range workflow.Jobs {
+			if job == nil {
+				continue
+			}
+			id := jobUsesSast(job)
+			if id == "" {
+				continue
+			}
+			sources = append(sources, id)
+			if workflowName != "" {
+				sources = append(sources, workflowName)
+			}
+			if job.Name != nil && job.Name.Value != "" {
+				sources = append(sources, job.Name.Value)
+			}
+			if job.ID != nil && job.ID.Value != "" {
+				sources = append(sources, job.ID.Value)
 			}
 		}
 	}
+	return sources
+}
 
-	return gemara.Failed, "No Static Application Security Testing documented in Security Insights", confidence
+// jobUsesSast returns the SAST identifier a job invokes via a step's `uses:`
+// action, `run:` command, or step name, or the empty string when none is found.
+func jobUsesSast(job *actionlint.Job) string {
+	for _, step := range job.Steps {
+		if step == nil {
+			continue
+		}
+		switch exec := step.Exec.(type) {
+		case *actionlint.ExecAction:
+			if exec.Uses != nil {
+				if id := matchSast(exec.Uses.Value); id != "" {
+					return id
+				}
+			}
+		case *actionlint.ExecRun:
+			if exec.Run != nil {
+				if id := matchSast(exec.Run.Value); id != "" {
+					return id
+				}
+			}
+		}
+		if step.Name != nil {
+			if id := matchSast(step.Name.Value); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// requiredCheckMatchesSast reports whether any required status-check context
+// corresponds to a detected SAST tool: either the context name itself carries a
+// known SAST identifier, or it correlates with one of the SAST source names
+// (workflow/job names) that produced the check.
+func requiredCheckMatchesSast(requiredContexts, sastSources []string) bool {
+	for _, context := range requiredContexts {
+		trimmed := strings.TrimSpace(context)
+		if trimmed == "" {
+			continue
+		}
+		if matchSast(trimmed) != "" {
+			return true
+		}
+		lowerContext := strings.ToLower(trimmed)
+		for _, source := range sastSources {
+			lowerSource := strings.ToLower(strings.TrimSpace(source))
+			// Guard against short, generic tokens producing spurious substring
+			// matches (e.g. a job called "ci").
+			if len(lowerSource) < 4 {
+				continue
+			}
+			if strings.Contains(lowerContext, lowerSource) || strings.Contains(lowerSource, lowerContext) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// gatherRequiredCheckContexts unions the status-check contexts required on the
+// default branch from both sources the scanner can observe: classic branch
+// protection (admin-only) and repository rulesets (publicly readable).
+func gatherRequiredCheckContexts(payload data.Payload) []string {
+	var contexts []string
+	if payload.GraphqlRepoData != nil {
+		contexts = append(contexts, payload.Repository.DefaultBranchRef.BranchProtectionRule.RequiredStatusCheckContexts...)
+	}
+	if payload.RepositoryMetadata != nil {
+		contexts = append(contexts, payload.RepositoryMetadata.RequiredStatusCheckContexts()...)
+	}
+	return contexts
+}
+
+// SastEnforcedOnChanges implements OSPS-VM-06.02: all changes to the codebase
+// must be automatically evaluated for security weaknesses and blocked on
+// violations. It confirms both that a SAST tool runs on changes (in CI, per
+// Security Insights or a workflow triggered by pull_request/push) and that it is
+// enforced as a required status check that blocks merges to the default branch.
+func SastEnforcedOnChanges(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	var sastSources []string
+	if payload.RestData != nil && payload.Insights.Repository != nil {
+		sastSources = append(sastSources, detectSastToolInInsights(payload.Insights.Repository.SecurityPosture.Tools)...)
+	}
+	if files, err := payload.GetWorkflowFiles(); err == nil {
+		sastSources = append(sastSources, detectSastInWorkflows(files)...)
+	}
+
+	requiredContexts := gatherRequiredCheckContexts(payload)
+	adminObservable := payload.RepositoryMetadata != nil && payload.RepositoryMetadata.ViewerCanAdminister()
+
+	return evaluateSastEnforcement(sastSources, requiredContexts, adminObservable)
+}
+
+// evaluateSastEnforcement applies the OSPS-VM-06.02 decision matrix to the
+// gathered signals, kept separate from data access so it can be unit tested with
+// plain inputs.
+func evaluateSastEnforcement(sastSources, requiredContexts []string, adminObservable bool) (gemara.Result, string, gemara.ConfidenceLevel) {
+	if len(sastSources) == 0 {
+		return gemara.Failed, "No Static Application Security Testing runs on changes, in Security Insights or a CI workflow triggered by pull requests or pushes", gemara.Medium
+	}
+
+	if requiredCheckMatchesSast(requiredContexts, sastSources) {
+		return gemara.Passed, "A SAST tool runs in CI and is enforced as a required status check on the default branch, blocking merges on violations", gemara.High
+	}
+
+	if len(requiredContexts) > 0 {
+		return gemara.NeedsReview, "A SAST tool runs in CI and required status checks are configured on the default branch, but none could be matched to the SAST tool; confirm the SAST check must pass before merging", gemara.Medium
+	}
+
+	if adminObservable {
+		return gemara.Failed, "A SAST tool runs in CI but no required status check enforces it on the default branch, so violations do not block merges", gemara.High
+	}
+
+	return gemara.NeedsReview, "A SAST tool runs in CI but default branch protection is not observable with the current token; confirm a required status check enforces the SAST tool before merging", gemara.Low
 }
 
 func HasVulnerabilityDisclosurePolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -109,8 +109,11 @@ func matchSast(text string) string {
 	return ""
 }
 
-// matchesGitHubGlob matches the branch-filter glob syntax needed here: *, **,
-// and ?. Character classes and extglobs are conservatively treated as no match.
+// matchesGitHubGlob matches the branch-filter glob syntax needed here: * and **.
+// GitHub's ref-filter grammar treats ?, +, and character classes as quantifiers
+// or extended patterns whose semantics differ from ordinary globbing, so those
+// are conservatively treated as no match rather than risking a false coverage
+// claim for a branch GitHub would not actually match.
 func matchesGitHubGlob(value, pattern string) bool {
 	var expression strings.Builder
 	expression.WriteByte('^')
@@ -123,9 +126,7 @@ func matchesGitHubGlob(value, pattern string) bool {
 			} else {
 				expression.WriteString("[^/]*")
 			}
-		case '?':
-			expression.WriteString("[^/]")
-		case '[', ']', '+':
+		case '?', '+', '[', ']':
 			return false
 		default:
 			expression.WriteString(regexp.QuoteMeta(pattern[i : i+1]))
@@ -218,9 +219,18 @@ func workflowCoversChanges(workflow *actionlint.Workflow, defaultBranch string) 
 	return false, uncertain
 }
 
+// sastSource is a detected signal that SAST runs on changes: either a tool
+// identifier or a complete workflow/job status-check context. policyDocumented
+// records whether that specific source carries a documented SAST ruleset or
+// policy (only Security Insights sources can), so a Pass is only granted when
+// the enforced check corresponds to a source whose policy is documented.
+type sastSource struct {
+	name             string
+	policyDocumented bool
+}
+
 type sastDetection struct {
-	sources           []string
-	policyDocumented  bool
+	sources           []sastSource
 	inspectionBlocked bool
 	coverageProven    bool
 }
@@ -236,10 +246,10 @@ func detectSastToolInInsights(tools []si.SecurityTool) sastDetection {
 			if name == "" {
 				name = "SAST"
 			}
-			detection.sources = append(detection.sources, name)
-			if len(tool.Rulesets) > 0 {
-				detection.policyDocumented = true
-			}
+			detection.sources = append(detection.sources, sastSource{
+				name:             name,
+				policyDocumented: len(tool.Rulesets) > 0,
+			})
 		}
 	}
 	return detection
@@ -351,17 +361,18 @@ func detectSastInWorkflows(files []data.WorkflowFile, defaultBranch string) sast
 			for _, source := range sources {
 				// Tool identifiers are reliable exact contexts in their own
 				// right. Generic job names are only retained as part of the
-				// complete workflow/job context below.
+				// complete workflow/job context below. Workflow-detected sources
+				// never carry documented-policy evidence on their own.
 				if matchSast(source) != "" {
-					detection.sources = append(detection.sources, source)
+					detection.sources = append(detection.sources, sastSource{name: source})
 				}
 			}
 			if workflowName != "" && jobName != "" {
-				detection.sources = append(detection.sources, workflowName+" / "+jobName)
+				detection.sources = append(detection.sources, sastSource{name: workflowName + " / " + jobName})
 				for _, calledJob := range sources[1:] {
 					calledJob = strings.TrimSpace(calledJob)
 					if calledJob != "" && matchSast(calledJob) == "" {
-						detection.sources = append(detection.sources, workflowName+" / "+jobName+" / "+calledJob)
+						detection.sources = append(detection.sources, sastSource{name: workflowName + " / " + jobName + " / " + calledJob})
 					}
 				}
 			}
@@ -401,20 +412,26 @@ func jobUsesSast(job *actionlint.Job) string {
 }
 
 // requiredCheckMatchesSast reports whether a required status-check context
-// exactly matches a detected tool or complete workflow/job context.
-func requiredCheckMatchesSast(requiredContexts, sastSources []string) bool {
+// exactly matches a detected tool or complete workflow/job context. withPolicy
+// is true only when at least one matched source carries a documented SAST
+// ruleset or policy, so enforcement of a policy-less tool is not mistaken for a
+// documented gate even when an unrelated tool does document one.
+func requiredCheckMatchesSast(requiredContexts []string, sastSources []sastSource) (matched bool, withPolicy bool) {
 	for _, context := range requiredContexts {
 		normalizedContext := strings.ToLower(strings.TrimSpace(context))
 		if normalizedContext == "" {
 			continue
 		}
 		for _, source := range sastSources {
-			if normalizedContext == strings.ToLower(strings.TrimSpace(source)) {
-				return true
+			if normalizedContext == strings.ToLower(strings.TrimSpace(source.name)) {
+				matched = true
+				if source.policyDocumented {
+					withPolicy = true
+				}
 			}
 		}
 	}
-	return false
+	return matched, withPolicy
 }
 
 // SastEnforcedOnChanges implements OSPS-VM-06.02: all changes to the codebase
@@ -427,7 +444,6 @@ func SastEnforcedOnChanges(payload data.Payload) (result gemara.Result, message 
 	if payload.RestData != nil && payload.Insights.Repository != nil {
 		insightsDetection := detectSastToolInInsights(payload.Insights.Repository.SecurityPosture.Tools)
 		detection.sources = append(detection.sources, insightsDetection.sources...)
-		detection.policyDocumented = insightsDetection.policyDocumented
 	}
 	files, err := payload.GetWorkflowFiles()
 	if err != nil {
@@ -470,8 +486,8 @@ func evaluateSastEnforcement(detection sastDetection, requiredContexts []string,
 		return gemara.Failed, "No Static Application Security Testing runs on changes, in Security Insights or a CI workflow triggered by pull requests or pushes", gemara.Medium
 	}
 
-	if requiredCheckMatchesSast(requiredContexts, detection.sources) {
-		if !detection.policyDocumented {
+	if matched, matchedWithPolicy := requiredCheckMatchesSast(requiredContexts, detection.sources); matched {
+		if !matchedWithPolicy {
 			return gemara.NeedsReview, "A SAST tool runs in CI and is enforced as a required status check, but no documented SAST ruleset or policy was found in Security Insights", gemara.Medium
 		}
 		return gemara.Passed, "A SAST tool runs in CI and is enforced as a required status check on the default branch, blocking merges on violations", gemara.High

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -109,6 +109,90 @@ func matchSast(text string) string {
 	return ""
 }
 
+// commandSeparatorPattern splits a `run:` script into individual command
+// invocations so each command's leading token can be inspected in isolation.
+var commandSeparatorPattern = regexp.MustCompile("[\n;&|`]+")
+
+// commandWrapperTokens are prefixes that delegate to a following command whose
+// own leading token should still be inspected for a SAST invocation.
+var commandWrapperTokens = map[string]bool{
+	"sudo": true,
+	"npx":  true,
+	"time": true,
+	"env":  true,
+}
+
+// sastCommandIdentifiers map a SAST tool's shell invocation to the canonical
+// identifier used elsewhere. Unlike action references, these are matched only at
+// a command-token boundary so that ordinary text mentioning a tool name (for
+// example a bearer auth header) is not mistaken for running it.
+var sastCommandIdentifiers = []struct{ phrase, id string }{
+	{"codeql", "codeql"},
+	{"semgrep", "semgrep"},
+	{"opengrep", "opengrep"},
+	{"sonar-scanner", "sonar-scanner"},
+	{"bandit", "bandit"},
+	{"gosec", "gosec"},
+	{"brakeman", "brakeman"},
+	{"horusec", "horusec"},
+	{"deepsource", "deepsource"},
+	{"snyk code", "snyk code"},
+	{"bearer scan", "bearer"},
+	{"checkmarx", "checkmarx"},
+}
+
+// matchSastCommand returns the SAST identifier invoked by a `run:` script, or
+// the empty string. Each command segment is normalized to its leading
+// executable (dropping wrappers such as sudo/npx and env assignments, and any
+// directory prefix) and matched against a known invocation at a token boundary.
+func matchSastCommand(runText string) string {
+	for _, segment := range commandSeparatorPattern.Split(runText, -1) {
+		command := normalizeCommand(segment)
+		if command == "" {
+			continue
+		}
+		for _, candidate := range sastCommandIdentifiers {
+			if command == candidate.phrase || strings.HasPrefix(command, candidate.phrase+" ") {
+				return candidate.id
+			}
+		}
+	}
+	return ""
+}
+
+// normalizeCommand lowercases a command segment, strips leading env assignments
+// and wrapper commands, and reduces the executable to its basename so that, for
+// example, `/usr/bin/gosec ./...` normalizes to `gosec ./...`.
+func normalizeCommand(segment string) string {
+	command := strings.ToLower(strings.TrimSpace(segment))
+	for command != "" {
+		token, rest := splitFirstToken(command)
+		if strings.Contains(token, "=") || commandWrapperTokens[token] {
+			command = rest
+			continue
+		}
+		break
+	}
+	token, rest := splitFirstToken(command)
+	if idx := strings.LastIndexAny(token, "/\\"); idx >= 0 {
+		token = token[idx+1:]
+	}
+	if rest == "" {
+		return token
+	}
+	return token + " " + rest
+}
+
+// splitFirstToken returns the first whitespace-delimited token and the trimmed
+// remainder of s.
+func splitFirstToken(s string) (string, string) {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, " \t"); i >= 0 {
+		return s[:i], strings.TrimSpace(s[i+1:])
+	}
+	return s, ""
+}
+
 func canonicalSastToolID(id string) string {
 	if strings.HasPrefix(id, "sonar") {
 		return "sonar"
@@ -117,11 +201,12 @@ func canonicalSastToolID(id string) string {
 }
 
 // matchesGitHubGlob matches the branch-filter glob syntax needed here: * and **.
-// GitHub's ref-filter grammar treats ?, +, and character classes as quantifiers
-// or extended patterns whose semantics differ from ordinary globbing, so those
-// are conservatively treated as no match rather than risking a false coverage
-// claim for a branch GitHub would not actually match.
-func matchesGitHubGlob(value, pattern string) bool {
+// GitHub's ref-filter grammar also treats ?, +, and character classes as
+// quantifiers or extended patterns whose semantics differ from ordinary
+// globbing. Those are reported as unsupported (supported=false) so callers can
+// decide, per direction, whether an undecidable pattern means "not covered"
+// (include lists) or "possibly excluded" (ignore lists).
+func matchesGitHubGlob(value, pattern string) (matched bool, supported bool) {
 	var expression strings.Builder
 	expression.WriteByte('^')
 	for i := 0; i < len(pattern); i++ {
@@ -134,20 +219,19 @@ func matchesGitHubGlob(value, pattern string) bool {
 				expression.WriteString("[^/]*")
 			}
 		case '?', '+', '[', ']':
-			return false
+			return false, false
 		default:
 			expression.WriteString(regexp.QuoteMeta(pattern[i : i+1]))
 		}
 	}
 	expression.WriteByte('$')
-	return regexp.MustCompile(expression.String()).MatchString(value)
+	return regexp.MustCompile(expression.String()).MatchString(value), true
 }
 
-func branchFilterIncludes(filter *actionlint.WebhookEventFilter, branch string) bool {
+func branchFilterIncludes(filter *actionlint.WebhookEventFilter, branch string) (included bool, uncertain bool) {
 	if filter.IsEmpty() {
-		return true
+		return true, false
 	}
-	included := false
 	for _, pattern := range filter.Values {
 		if pattern == nil {
 			continue
@@ -155,23 +239,40 @@ func branchFilterIncludes(filter *actionlint.WebhookEventFilter, branch string) 
 		value := pattern.Value
 		negated := strings.HasPrefix(value, "!")
 		value = strings.TrimPrefix(value, "!")
-		if matchesGitHubGlob(branch, value) {
+		matched, supported := matchesGitHubGlob(branch, value)
+		if !supported {
+			// The pattern could admit or reject the branch; we cannot prove
+			// inclusion, so record uncertainty rather than guessing.
+			uncertain = true
+			continue
+		}
+		if matched {
 			included = !negated
 		}
 	}
-	return included
+	return included, uncertain
 }
 
-func branchFilterExcludes(filter *actionlint.WebhookEventFilter, branch string) bool {
+func branchFilterExcludes(filter *actionlint.WebhookEventFilter, branch string) (excluded bool, uncertain bool) {
 	if filter.IsEmpty() {
-		return false
+		return false, false
 	}
 	for _, pattern := range filter.Values {
-		if pattern != nil && matchesGitHubGlob(branch, pattern.Value) {
-			return true
+		if pattern == nil {
+			continue
+		}
+		matched, supported := matchesGitHubGlob(branch, pattern.Value)
+		if !supported {
+			// An undecidable ignore pattern may exclude the default branch, so
+			// coverage cannot be proven; treat it as uncertain.
+			uncertain = true
+			continue
+		}
+		if matched {
+			excluded = true
 		}
 	}
-	return false
+	return excluded, uncertain
 }
 
 // workflowCoversChanges reports whether a workflow runs for every pull request
@@ -215,10 +316,10 @@ func workflowCoversChanges(workflow *actionlint.Workflow, defaultBranch string) 
 		}
 
 		typesCoverChanges := len(types) == 0 || (types["opened"] && types["synchronize"])
-		branchCovered := defaultBranch != "" &&
-			branchFilterIncludes(webhook.Branches, defaultBranch) &&
-			!branchFilterExcludes(webhook.BranchesIgnore, defaultBranch)
-		if typesCoverChanges && !pathsFiltered && branchCovered {
+		included, includeUncertain := branchFilterIncludes(webhook.Branches, defaultBranch)
+		excluded, excludeUncertain := branchFilterExcludes(webhook.BranchesIgnore, defaultBranch)
+		branchCovered := defaultBranch != "" && included && !excluded
+		if typesCoverChanges && !pathsFiltered && branchCovered && !includeUncertain && !excludeUncertain {
 			return true, false
 		}
 		uncertain = true
@@ -330,10 +431,11 @@ func detectSastInWorkflows(files []data.WorkflowFile, defaultBranch string) sast
 			sources, callBlocked := inspectJob(calledJob, visiting)
 			blocked = blocked || callBlocked
 			if len(sources) > 0 {
+				// GitHub publishes a called job's check as its name, or its ID
+				// when unnamed, matching the caller-side preference below.
 				if calledJob.Name != nil && calledJob.Name.Value != "" {
 					sources = append(sources, calledJob.Name.Value)
-				}
-				if calledJob.ID != nil && calledJob.ID.Value != "" {
+				} else if calledJob.ID != nil && calledJob.ID.Value != "" {
 					sources = append(sources, calledJob.ID.Value)
 				}
 				return sources, blocked
@@ -420,7 +522,12 @@ func associateSastPolicies(sources []sastSource) {
 }
 
 // jobUsesSast returns the SAST identifier a job invokes via a step's `uses:`
-// action, `run:` command, or step name, or the empty string when none is found.
+// action reference or `run:` command, or the empty string when none is found. A
+// `uses:` reference names the tool directly, so a substring match is definite.
+// `run:` scripts are free text, so the identifier must appear as a command token
+// (see matchSastCommand); a mere mention such as an echoed TODO or an
+// Authorization: Bearer header is deliberately not treated as an invocation.
+// Step names are cosmetic and are intentionally not used as evidence.
 func jobUsesSast(job *actionlint.Job) string {
 	for _, step := range job.Steps {
 		if step == nil {
@@ -435,14 +542,9 @@ func jobUsesSast(job *actionlint.Job) string {
 			}
 		case *actionlint.ExecRun:
 			if exec.Run != nil {
-				if id := matchSast(exec.Run.Value); id != "" {
+				if id := matchSastCommand(exec.Run.Value); id != "" {
 					return id
 				}
-			}
-		}
-		if step.Name != nil {
-			if id := matchSast(step.Name.Value); id != "" {
-				return id
 			}
 		}
 	}
@@ -497,6 +599,12 @@ func SastEnforcedOnChanges(payload data.Payload) (result gemara.Result, message 
 		detection.coverageProven = workflowDetection.coverageProven
 	}
 	associateSastPolicies(detection.sources)
+
+	// A Security Insights file that failed to parse may itself declare the SAST
+	// tool, so an absence of evidence here is inconclusive rather than a failure.
+	if payload.InsightsError {
+		detection.inspectionBlocked = true
+	}
 
 	// Union the status-check contexts required on the default branch from both
 	// sources the scanner can observe: classic branch protection (admin-only)

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -109,6 +109,13 @@ func matchSast(text string) string {
 	return ""
 }
 
+func canonicalSastToolID(id string) string {
+	if strings.HasPrefix(id, "sonar") {
+		return "sonar"
+	}
+	return id
+}
+
 // matchesGitHubGlob matches the branch-filter glob syntax needed here: * and **.
 // GitHub's ref-filter grammar treats ?, +, and character classes as quantifiers
 // or extended patterns whose semantics differ from ordinary globbing, so those
@@ -220,12 +227,14 @@ func workflowCoversChanges(workflow *actionlint.Workflow, defaultBranch string) 
 }
 
 // sastSource is a detected signal that SAST runs on changes: either a tool
-// identifier or a complete workflow/job status-check context. policyDocumented
-// records whether that specific source carries a documented SAST ruleset or
-// policy (only Security Insights sources can), so a Pass is only granted when
-// the enforced check corresponds to a source whose policy is documented.
+// identifier or a workflow/job status-check context. toolID links workflow
+// aliases to policy evidence for the same tool in Security Insights.
+// workflowAlias prevents separate Insights declarations in the same tool family
+// from lending policy evidence to each other.
 type sastSource struct {
 	name             string
+	toolID           string
+	workflowAlias    bool
 	policyDocumented bool
 }
 
@@ -246,8 +255,13 @@ func detectSastToolInInsights(tools []si.SecurityTool) sastDetection {
 			if name == "" {
 				name = "SAST"
 			}
+			toolID := canonicalSastToolID(matchSast(name))
+			if toolID == "" {
+				toolID = strings.ToLower(name)
+			}
 			detection.sources = append(detection.sources, sastSource{
 				name:             name,
+				toolID:           toolID,
 				policyDocumented: len(tool.Rulesets) > 0,
 			})
 		}
@@ -346,39 +360,63 @@ func detectSastInWorkflows(files []data.WorkflowFile, defaultBranch string) sast
 			}
 			detection.coverageProven = true
 
-			workflowName := ""
-			if workflow.Name != nil {
-				workflowName = strings.TrimSpace(workflow.Name.Value)
-			}
 			jobName := ""
 			if job.Name != nil {
 				jobName = strings.TrimSpace(job.Name.Value)
 			}
-			if jobName == "" && job.ID != nil {
-				jobName = strings.TrimSpace(job.ID.Value)
+			jobID := ""
+			if job.ID != nil {
+				jobID = strings.TrimSpace(job.ID.Value)
 			}
+			checkName := jobName
+			if checkName == "" {
+				checkName = jobID
+			}
+			toolID := canonicalSastToolID(matchSast(sources[0]))
 
 			for _, source := range sources {
 				// Tool identifiers are reliable exact contexts in their own
-				// right. Generic job names are only retained as part of the
-				// complete workflow/job context below. Workflow-detected sources
-				// never carry documented-policy evidence on their own.
+				// right. Workflow-detected aliases receive policy evidence later
+				// only when Security Insights documents this same tool.
 				if matchSast(source) != "" {
-					detection.sources = append(detection.sources, sastSource{name: source})
+					detection.sources = append(detection.sources, sastSource{name: source, toolID: toolID, workflowAlias: true})
 				}
 			}
-			if workflowName != "" && jobName != "" {
-				detection.sources = append(detection.sources, sastSource{name: workflowName + " / " + jobName})
+			if job.WorkflowCall == nil {
+				if checkName != "" {
+					detection.sources = append(detection.sources, sastSource{name: checkName, toolID: toolID, workflowAlias: true})
+				}
+			} else if checkName != "" {
 				for _, calledJob := range sources[1:] {
 					calledJob = strings.TrimSpace(calledJob)
-					if calledJob != "" && matchSast(calledJob) == "" {
-						detection.sources = append(detection.sources, sastSource{name: workflowName + " / " + jobName + " / " + calledJob})
+					if calledJob != "" {
+						detection.sources = append(detection.sources, sastSource{
+							name:          checkName + " / " + calledJob,
+							toolID:        toolID,
+							workflowAlias: true,
+						})
 					}
 				}
 			}
 		}
 	}
 	return detection
+}
+
+// associateSastPolicies propagates documented policy evidence from Security
+// Insights to workflow check aliases for the same canonical SAST tool.
+func associateSastPolicies(sources []sastSource) {
+	documentedTools := make(map[string]bool)
+	for _, source := range sources {
+		if source.toolID != "" && source.policyDocumented {
+			documentedTools[source.toolID] = true
+		}
+	}
+	for i := range sources {
+		if sources[i].workflowAlias && documentedTools[sources[i].toolID] {
+			sources[i].policyDocumented = true
+		}
+	}
 }
 
 // jobUsesSast returns the SAST identifier a job invokes via a step's `uses:`
@@ -458,6 +496,7 @@ func SastEnforcedOnChanges(payload data.Payload) (result gemara.Result, message 
 		detection.inspectionBlocked = workflowDetection.inspectionBlocked
 		detection.coverageProven = workflowDetection.coverageProven
 	}
+	associateSastPolicies(detection.sources)
 
 	// Union the status-check contexts required on the default branch from both
 	// sources the scanner can observe: classic branch protection (admin-only)

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -109,83 +109,265 @@ func matchSast(text string) string {
 	return ""
 }
 
-// workflowRunsOnChanges reports whether a workflow is triggered by an event that
-// fires on changes to the codebase, i.e. a pull request or a push. Only these
-// can act as a gate on incoming changes; scheduled or manual runs cannot.
-func workflowRunsOnChanges(workflow *actionlint.Workflow) bool {
-	for _, event := range workflow.On {
-		switch event.EventName() {
-		case "pull_request", "pull_request_target", "push":
+// matchesGitHubGlob matches the branch-filter glob syntax needed here: *, **,
+// and ?. Character classes and extglobs are conservatively treated as no match.
+func matchesGitHubGlob(value, pattern string) bool {
+	var expression strings.Builder
+	expression.WriteByte('^')
+	for i := 0; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				expression.WriteString(".*")
+				i++
+			} else {
+				expression.WriteString("[^/]*")
+			}
+		case '?':
+			expression.WriteString("[^/]")
+		case '[', ']', '+':
+			return false
+		default:
+			expression.WriteString(regexp.QuoteMeta(pattern[i : i+1]))
+		}
+	}
+	expression.WriteByte('$')
+	return regexp.MustCompile(expression.String()).MatchString(value)
+}
+
+func branchFilterIncludes(filter *actionlint.WebhookEventFilter, branch string) bool {
+	if filter.IsEmpty() {
+		return true
+	}
+	included := false
+	for _, pattern := range filter.Values {
+		if pattern == nil {
+			continue
+		}
+		value := pattern.Value
+		negated := strings.HasPrefix(value, "!")
+		value = strings.TrimPrefix(value, "!")
+		if matchesGitHubGlob(branch, value) {
+			included = !negated
+		}
+	}
+	return included
+}
+
+func branchFilterExcludes(filter *actionlint.WebhookEventFilter, branch string) bool {
+	if filter.IsEmpty() {
+		return false
+	}
+	for _, pattern := range filter.Values {
+		if pattern != nil && matchesGitHubGlob(branch, pattern.Value) {
 			return true
 		}
 	}
 	return false
 }
 
-// detectSastToolInInsights returns correlation names for every Security Insights
-// tool declared as a SAST tool integrated into continuous integration. Adhoc or
-// release-only integrations are ignored because they do not evaluate incoming
-// changes.
-func detectSastToolInInsights(tools []si.SecurityTool) []string {
-	var names []string
+// workflowCoversChanges reports whether a workflow runs for every pull request
+// targeting the default branch or every pushed commit. The second return value
+// marks relevant triggers whose filters prevent proving full coverage.
+func workflowCoversChanges(workflow *actionlint.Workflow, defaultBranch string) (bool, bool) {
+	uncertain := false
+	for _, event := range workflow.On {
+		switch event.EventName() {
+		case "pull_request_target":
+			// This event runs in the base repository context and does not prove
+			// that the pull request's code is what the SAST tool analyzes.
+			uncertain = true
+			continue
+		case "pull_request", "push":
+		default:
+			continue
+		}
+
+		webhook, ok := event.(*actionlint.WebhookEvent)
+		if !ok {
+			uncertain = true
+			continue
+		}
+		types := make(map[string]bool)
+		for _, eventType := range webhook.Types {
+			if eventType != nil {
+				types[eventType.Value] = true
+			}
+		}
+		pathsFiltered := !webhook.Paths.IsEmpty() || !webhook.PathsIgnore.IsEmpty()
+
+		if event.EventName() == "push" {
+			branchesUnfiltered := webhook.Branches.IsEmpty() && webhook.BranchesIgnore.IsEmpty()
+			tagsUnfiltered := webhook.Tags.IsEmpty() && webhook.TagsIgnore.IsEmpty()
+			if pathsFiltered || !branchesUnfiltered || !tagsUnfiltered {
+				uncertain = true
+				continue
+			}
+			return true, false
+		}
+
+		typesCoverChanges := len(types) == 0 || (types["opened"] && types["synchronize"])
+		branchCovered := defaultBranch != "" &&
+			branchFilterIncludes(webhook.Branches, defaultBranch) &&
+			!branchFilterExcludes(webhook.BranchesIgnore, defaultBranch)
+		if typesCoverChanges && !pathsFiltered && branchCovered {
+			return true, false
+		}
+		uncertain = true
+	}
+	return false, uncertain
+}
+
+type sastDetection struct {
+	sources           []string
+	policyDocumented  bool
+	inspectionBlocked bool
+	coverageProven    bool
+}
+
+// detectSastToolInInsights identifies SAST tools integrated into continuous
+// integration. A non-empty rulesets declaration documents the policy applied by
+// the tool; adhoc or release-only integrations do not evaluate incoming changes.
+func detectSastToolInInsights(tools []si.SecurityTool) sastDetection {
+	var detection sastDetection
 	for _, tool := range tools {
 		if strings.EqualFold(tool.Type, "SAST") && tool.Integration.Ci {
 			name := strings.TrimSpace(tool.Name)
 			if name == "" {
 				name = "SAST"
 			}
-			names = append(names, name)
+			detection.sources = append(detection.sources, name)
+			if len(tool.Rulesets) > 0 {
+				detection.policyDocumented = true
+			}
 		}
 	}
-	return names
+	return detection
 }
 
 // detectSastInWorkflows inspects workflow files for a known SAST tool invoked by
-// a workflow that runs on changes. It returns correlation names (the identifier,
-// the workflow name, and the job name/ID) that a required status-check context
-// can be matched against. Files that cannot be read or parsed are skipped rather
-// than treated as evidence.
-func detectSastInWorkflows(files []data.WorkflowFile) []string {
-	var sources []string
+// a workflow that runs on changes. Local reusable workflows are resolved from
+// the fetched files, while recognizable remote workflow names are detected
+// directly. Any file or remote call that cannot be inspected is recorded so an
+// absence of SAST evidence cannot be reported as a definitive failure.
+func detectSastInWorkflows(files []data.WorkflowFile, defaultBranch string) sastDetection {
+	var detection sastDetection
+	parsed := make(map[string]*actionlint.Workflow)
 	for _, file := range files {
 		isWorkflowYAML := strings.HasSuffix(file.Name, ".yml") || strings.HasSuffix(file.Name, ".yaml")
-		if !isWorkflowYAML || file.Truncated {
+		if !isWorkflowYAML {
+			continue
+		}
+		if file.Truncated {
+			detection.inspectionBlocked = true
 			continue
 		}
 		workflow, err := actionlint.Parse([]byte(file.Content))
 		if err != nil || workflow == nil {
+			detection.inspectionBlocked = true
 			continue
 		}
-		if !workflowRunsOnChanges(workflow) {
-			continue
+		parsed[strings.TrimPrefix(file.Path, "./")] = workflow
+	}
+
+	var inspectJob func(*actionlint.Job, map[string]bool) ([]string, bool)
+	inspectJob = func(job *actionlint.Job, visiting map[string]bool) ([]string, bool) {
+		if id := jobUsesSast(job); id != "" {
+			return []string{id}, false
+		}
+		if job.WorkflowCall == nil || job.WorkflowCall.Uses == nil {
+			return nil, false
 		}
 
-		workflowName := ""
-		if workflow.Name != nil {
-			workflowName = workflow.Name.Value
+		uses := strings.TrimSpace(job.WorkflowCall.Uses.Value)
+		if id := matchSast(uses); id != "" {
+			return []string{id}, false
+		}
+		if !strings.HasPrefix(uses, "./") {
+			return nil, true
+		}
+
+		path := strings.TrimPrefix(uses, "./")
+		if visiting[path] {
+			return nil, true
+		}
+		called, ok := parsed[path]
+		if !ok {
+			return nil, true
+		}
+		visiting[path] = true
+		defer delete(visiting, path)
+
+		blocked := false
+		for _, calledJob := range called.Jobs {
+			if calledJob == nil {
+				continue
+			}
+			sources, callBlocked := inspectJob(calledJob, visiting)
+			blocked = blocked || callBlocked
+			if len(sources) > 0 {
+				if calledJob.Name != nil && calledJob.Name.Value != "" {
+					sources = append(sources, calledJob.Name.Value)
+				}
+				if calledJob.ID != nil && calledJob.ID.Value != "" {
+					sources = append(sources, calledJob.ID.Value)
+				}
+				return sources, blocked
+			}
+		}
+		return nil, blocked
+	}
+
+	for path, workflow := range parsed {
+		coversChanges, coverageUncertain := workflowCoversChanges(workflow, defaultBranch)
+		detection.inspectionBlocked = detection.inspectionBlocked || coverageUncertain
+		if !coversChanges {
+			continue
 		}
 
 		for _, job := range workflow.Jobs {
 			if job == nil {
 				continue
 			}
-			id := jobUsesSast(job)
-			if id == "" {
+			sources, blocked := inspectJob(job, map[string]bool{path: true})
+			detection.inspectionBlocked = detection.inspectionBlocked || blocked
+			if len(sources) == 0 {
 				continue
 			}
-			sources = append(sources, id)
-			if workflowName != "" {
-				sources = append(sources, workflowName)
+			detection.coverageProven = true
+
+			workflowName := ""
+			if workflow.Name != nil {
+				workflowName = strings.TrimSpace(workflow.Name.Value)
 			}
-			if job.Name != nil && job.Name.Value != "" {
-				sources = append(sources, job.Name.Value)
+			jobName := ""
+			if job.Name != nil {
+				jobName = strings.TrimSpace(job.Name.Value)
 			}
-			if job.ID != nil && job.ID.Value != "" {
-				sources = append(sources, job.ID.Value)
+			if jobName == "" && job.ID != nil {
+				jobName = strings.TrimSpace(job.ID.Value)
+			}
+
+			for _, source := range sources {
+				// Tool identifiers are reliable exact contexts in their own
+				// right. Generic job names are only retained as part of the
+				// complete workflow/job context below.
+				if matchSast(source) != "" {
+					detection.sources = append(detection.sources, source)
+				}
+			}
+			if workflowName != "" && jobName != "" {
+				detection.sources = append(detection.sources, workflowName+" / "+jobName)
+				for _, calledJob := range sources[1:] {
+					calledJob = strings.TrimSpace(calledJob)
+					if calledJob != "" && matchSast(calledJob) == "" {
+						detection.sources = append(detection.sources, workflowName+" / "+jobName+" / "+calledJob)
+					}
+				}
 			}
 		}
 	}
-	return sources
+	return detection
 }
 
 // jobUsesSast returns the SAST identifier a job invokes via a step's `uses:`
@@ -218,28 +400,16 @@ func jobUsesSast(job *actionlint.Job) string {
 	return ""
 }
 
-// requiredCheckMatchesSast reports whether any required status-check context
-// corresponds to a detected SAST tool: either the context name itself carries a
-// known SAST identifier, or it correlates with one of the SAST source names
-// (workflow/job names) that produced the check.
+// requiredCheckMatchesSast reports whether a required status-check context
+// exactly matches a detected tool or complete workflow/job context.
 func requiredCheckMatchesSast(requiredContexts, sastSources []string) bool {
 	for _, context := range requiredContexts {
-		trimmed := strings.TrimSpace(context)
-		if trimmed == "" {
+		normalizedContext := strings.ToLower(strings.TrimSpace(context))
+		if normalizedContext == "" {
 			continue
 		}
-		if matchSast(trimmed) != "" {
-			return true
-		}
-		lowerContext := strings.ToLower(trimmed)
 		for _, source := range sastSources {
-			lowerSource := strings.ToLower(strings.TrimSpace(source))
-			// Guard against short, generic tokens producing spurious substring
-			// matches (e.g. a job called "ci").
-			if len(lowerSource) < 4 {
-				continue
-			}
-			if strings.Contains(lowerContext, lowerSource) || strings.Contains(lowerSource, lowerContext) {
+			if normalizedContext == strings.ToLower(strings.TrimSpace(source)) {
 				return true
 			}
 		}
@@ -253,12 +423,24 @@ func requiredCheckMatchesSast(requiredContexts, sastSources []string) bool {
 // Security Insights or a workflow triggered by pull_request/push) and that it is
 // enforced as a required status check that blocks merges to the default branch.
 func SastEnforcedOnChanges(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
-	var sastSources []string
+	var detection sastDetection
 	if payload.RestData != nil && payload.Insights.Repository != nil {
-		sastSources = append(sastSources, detectSastToolInInsights(payload.Insights.Repository.SecurityPosture.Tools)...)
+		insightsDetection := detectSastToolInInsights(payload.Insights.Repository.SecurityPosture.Tools)
+		detection.sources = append(detection.sources, insightsDetection.sources...)
+		detection.policyDocumented = insightsDetection.policyDocumented
 	}
-	if files, err := payload.GetWorkflowFiles(); err == nil {
-		sastSources = append(sastSources, detectSastInWorkflows(files)...)
+	files, err := payload.GetWorkflowFiles()
+	if err != nil {
+		detection.inspectionBlocked = true
+	} else {
+		defaultBranch := ""
+		if payload.GraphqlRepoData != nil {
+			defaultBranch = payload.Repository.DefaultBranchRef.Name
+		}
+		workflowDetection := detectSastInWorkflows(files, defaultBranch)
+		detection.sources = append(detection.sources, workflowDetection.sources...)
+		detection.inspectionBlocked = workflowDetection.inspectionBlocked
+		detection.coverageProven = workflowDetection.coverageProven
 	}
 
 	// Union the status-check contexts required on the default branch from both
@@ -274,18 +456,24 @@ func SastEnforcedOnChanges(payload data.Payload) (result gemara.Result, message 
 
 	adminObservable := payload.RepositoryMetadata != nil && payload.RepositoryMetadata.ViewerCanAdminister()
 
-	return evaluateSastEnforcement(sastSources, requiredContexts, adminObservable)
+	return evaluateSastEnforcement(detection, requiredContexts, adminObservable)
 }
 
 // evaluateSastEnforcement applies the OSPS-VM-06.02 decision matrix to the
 // gathered signals, kept separate from data access so it can be unit tested with
 // plain inputs.
-func evaluateSastEnforcement(sastSources, requiredContexts []string, adminObservable bool) (gemara.Result, string, gemara.ConfidenceLevel) {
-	if len(sastSources) == 0 {
+func evaluateSastEnforcement(detection sastDetection, requiredContexts []string, adminObservable bool) (gemara.Result, string, gemara.ConfidenceLevel) {
+	if detection.inspectionBlocked && !detection.coverageProven {
+		return gemara.NeedsReview, "Workflow inspection was incomplete, so the scanner could not determine whether SAST runs on all changes", gemara.Low
+	}
+	if len(detection.sources) == 0 {
 		return gemara.Failed, "No Static Application Security Testing runs on changes, in Security Insights or a CI workflow triggered by pull requests or pushes", gemara.Medium
 	}
 
-	if requiredCheckMatchesSast(requiredContexts, sastSources) {
+	if requiredCheckMatchesSast(requiredContexts, detection.sources) {
+		if !detection.policyDocumented {
+			return gemara.NeedsReview, "A SAST tool runs in CI and is enforced as a required status check, but no documented SAST ruleset or policy was found in Security Insights", gemara.Medium
+		}
 		return gemara.Passed, "A SAST tool runs in CI and is enforced as a required status check on the default branch, blocking merges on violations", gemara.High
 	}
 

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -109,12 +109,6 @@ func matchSast(text string) string {
 	return ""
 }
 
-// isWorkflowYAML reports whether a file name is a GitHub Actions workflow
-// definition by extension.
-func isWorkflowYAML(name string) bool {
-	return strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml")
-}
-
 // workflowRunsOnChanges reports whether a workflow is triggered by an event that
 // fires on changes to the codebase, i.e. a pull request or a push. Only these
 // can act as a gate on incoming changes; scheduled or manual runs cannot.
@@ -154,7 +148,8 @@ func detectSastToolInInsights(tools []si.SecurityTool) []string {
 func detectSastInWorkflows(files []data.WorkflowFile) []string {
 	var sources []string
 	for _, file := range files {
-		if !isWorkflowYAML(file.Name) || file.Truncated {
+		isWorkflowYAML := strings.HasSuffix(file.Name, ".yml") || strings.HasSuffix(file.Name, ".yaml")
+		if !isWorkflowYAML || file.Truncated {
 			continue
 		}
 		workflow, err := actionlint.Parse([]byte(file.Content))
@@ -252,20 +247,6 @@ func requiredCheckMatchesSast(requiredContexts, sastSources []string) bool {
 	return false
 }
 
-// gatherRequiredCheckContexts unions the status-check contexts required on the
-// default branch from both sources the scanner can observe: classic branch
-// protection (admin-only) and repository rulesets (publicly readable).
-func gatherRequiredCheckContexts(payload data.Payload) []string {
-	var contexts []string
-	if payload.GraphqlRepoData != nil {
-		contexts = append(contexts, payload.Repository.DefaultBranchRef.BranchProtectionRule.RequiredStatusCheckContexts...)
-	}
-	if payload.RepositoryMetadata != nil {
-		contexts = append(contexts, payload.RepositoryMetadata.RequiredStatusCheckContexts()...)
-	}
-	return contexts
-}
-
 // SastEnforcedOnChanges implements OSPS-VM-06.02: all changes to the codebase
 // must be automatically evaluated for security weaknesses and blocked on
 // violations. It confirms both that a SAST tool runs on changes (in CI, per
@@ -280,7 +261,17 @@ func SastEnforcedOnChanges(payload data.Payload) (result gemara.Result, message 
 		sastSources = append(sastSources, detectSastInWorkflows(files)...)
 	}
 
-	requiredContexts := gatherRequiredCheckContexts(payload)
+	// Union the status-check contexts required on the default branch from both
+	// sources the scanner can observe: classic branch protection (admin-only)
+	// and repository rulesets (publicly readable).
+	var requiredContexts []string
+	if payload.GraphqlRepoData != nil {
+		requiredContexts = append(requiredContexts, payload.Repository.DefaultBranchRef.BranchProtectionRule.RequiredStatusCheckContexts...)
+	}
+	if payload.RepositoryMetadata != nil {
+		requiredContexts = append(requiredContexts, payload.RepositoryMetadata.RequiredStatusCheckContexts()...)
+	}
+
 	adminObservable := payload.RepositoryMetadata != nil && payload.RepositoryMetadata.ViewerCanAdminister()
 
 	return evaluateSastEnforcement(sastSources, requiredContexts, adminObservable)

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/ossf/si-tooling/v2/si"
+	"github.com/rhysd/actionlint"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -150,6 +151,36 @@ jobs:
       - run: make build
 `
 
+const mentionOnlyWorkflow = `name: Security
+on: [pull_request]
+jobs:
+  note:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "TODO wire up CodeQL and semgrep"
+`
+
+const bearerHeaderWorkflow = `name: Publish
+on: [pull_request]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'curl -H "Authorization: Bearer $TOKEN" https://api.example.com'
+`
+
+const unsupportedBranchIgnoreWorkflow = `name: CodeQL
+on:
+  pull_request:
+    branches-ignore:
+      - mai+n
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/codeql-action/analyze@v3
+`
+
 const reusableCallerWorkflow = `name: Security
 on: [pull_request]
 jobs:
@@ -237,6 +268,22 @@ func TestDetectSastInWorkflows(t *testing.T) {
 			name:      "workflow without a SAST tool is not detected",
 			files:     []data.WorkflowFile{{Name: "build.yml", Path: ".github/workflows/build.yml", Content: nonSastWorkflow}},
 			wantEmpty: true,
+		},
+		{
+			name:      "a run step that only mentions a tool is not an invocation",
+			files:     []data.WorkflowFile{{Name: "sec.yml", Path: ".github/workflows/sec.yml", Content: mentionOnlyWorkflow}},
+			wantEmpty: true,
+		},
+		{
+			name:      "a bearer auth header is not a SAST invocation",
+			files:     []data.WorkflowFile{{Name: "pub.yml", Path: ".github/workflows/pub.yml", Content: bearerHeaderWorkflow}},
+			wantEmpty: true,
+		},
+		{
+			name:        "an undecidable branches-ignore pattern cannot prove coverage",
+			files:       []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: unsupportedBranchIgnoreWorkflow}},
+			wantEmpty:   true,
+			wantBlocked: true,
 		},
 		{
 			name:        "truncated workflow records incomplete inspection",
@@ -421,23 +468,69 @@ func TestDocumentedPolicyMatchesReusableWorkflowCheck(t *testing.T) {
 
 func TestMatchesGitHubGlob(t *testing.T) {
 	tests := []struct {
-		name    string
-		value   string
-		pattern string
-		want    bool
+		name          string
+		value         string
+		pattern       string
+		want          bool
+		wantSupported bool
 	}{
-		{name: "exact match", value: "main", pattern: "main", want: true},
-		{name: "single star stays within a path segment", value: "release-1", pattern: "release-*", want: true},
-		{name: "single star does not cross a slash", value: "feature/x", pattern: "feature*", want: false},
-		{name: "double star crosses slashes", value: "feature/x/y", pattern: "feature/**", want: true},
-		{name: "question mark is treated conservatively as no match", value: "release-x", pattern: "release-?", want: false},
-		{name: "plus is treated conservatively as no match", value: "release-x", pattern: "release-+", want: false},
-		{name: "character class is treated conservatively as no match", value: "release-1", pattern: "release-[0-9]", want: false},
+		{name: "exact match", value: "main", pattern: "main", want: true, wantSupported: true},
+		{name: "single star stays within a path segment", value: "release-1", pattern: "release-*", want: true, wantSupported: true},
+		{name: "single star does not cross a slash", value: "feature/x", pattern: "feature*", want: false, wantSupported: true},
+		{name: "double star crosses slashes", value: "feature/x/y", pattern: "feature/**", want: true, wantSupported: true},
+		{name: "question mark is reported unsupported", value: "release-x", pattern: "release-?", want: false, wantSupported: false},
+		{name: "plus is reported unsupported", value: "release-x", pattern: "release-+", want: false, wantSupported: false},
+		{name: "character class is reported unsupported", value: "release-1", pattern: "release-[0-9]", want: false, wantSupported: false},
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.want, matchesGitHubGlob(test.value, test.pattern), test.name)
+		got, supported := matchesGitHubGlob(test.value, test.pattern)
+		assert.Equal(t, test.want, got, test.name)
+		assert.Equal(t, test.wantSupported, supported, test.name)
 	}
+}
+
+func TestMatchSastCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		runText string
+		want    string
+	}{
+		{name: "semgrep invocation is detected", runText: "semgrep ci", want: "semgrep"},
+		{name: "gosec with a path prefix is detected", runText: "/usr/bin/gosec ./...", want: "gosec"},
+		{name: "sudo wrapper is stripped", runText: "sudo bandit -r .", want: "bandit"},
+		{name: "env assignment prefix is stripped", runText: "FOO=bar sonar-scanner -Dsonar.foo=1", want: "sonar-scanner"},
+		{name: "snyk code is detected but plain snyk is not", runText: "snyk code test", want: "snyk code"},
+		{name: "plain snyk test is not SAST", runText: "snyk test", want: ""},
+		{name: "bearer scan is detected", runText: "bearer scan", want: "bearer"},
+		{name: "bearer auth header is not an invocation", runText: `curl -H "Authorization: Bearer $TOKEN" https://api`, want: ""},
+		{name: "echoed tool mention is not an invocation", runText: `echo "TODO wire up CodeQL"`, want: ""},
+		{name: "second command after && is detected", runText: "make build && gosec ./...", want: "gosec"},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.want, matchSastCommand(test.runText), test.name)
+	}
+}
+
+func TestBranchFilterUncertainty(t *testing.T) {
+	unsupportedIgnore := &actionlint.WebhookEventFilter{
+		Values: []*actionlint.String{{Value: "mai+n"}},
+	}
+	excluded, uncertain := branchFilterExcludes(unsupportedIgnore, "main")
+	assert.False(t, excluded, "an undecidable ignore pattern must not be reported as a definite exclude")
+	assert.True(t, uncertain, "an undecidable ignore pattern must be reported as uncertain")
+
+	supportedIgnore := &actionlint.WebhookEventFilter{
+		Values: []*actionlint.String{{Value: "release/**"}},
+	}
+	excluded, uncertain = branchFilterExcludes(supportedIgnore, "main")
+	assert.False(t, excluded)
+	assert.False(t, uncertain)
+
+	included, uncertain := branchFilterIncludes(unsupportedIgnore, "main")
+	assert.False(t, included)
+	assert.True(t, uncertain, "an undecidable include pattern must be reported as uncertain")
 }
 
 func TestRequiredCheckMatchesSast(t *testing.T) {

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -11,102 +11,232 @@ import (
 
 func ptrTo[T any](v T) *T { return &v }
 
-type testingData struct {
-	expectedResult   gemara.Result
-	expectedMessage  string
-	payload          data.Payload
-	assertionMessage string
+func TestDetectSastToolInInsights(t *testing.T) {
+	tests := []struct {
+		name  string
+		tools []si.SecurityTool
+		want  []string
+	}{
+		{
+			name: "SAST tool integrated in CI is detected by name",
+			tools: []si.SecurityTool{{
+				Name:        "CodeQL",
+				Type:        "SAST",
+				Integration: si.SecurityToolIntegration{Ci: true},
+			}},
+			want: []string{"CodeQL"},
+		},
+		{
+			name: "SAST tool without a name falls back to a generic label",
+			tools: []si.SecurityTool{{
+				Type:        "SAST",
+				Integration: si.SecurityToolIntegration{Ci: true},
+			}},
+			want: []string{"SAST"},
+		},
+		{
+			name: "SAST tool only run adhoc or at release is not CI evidence",
+			tools: []si.SecurityTool{{
+				Name:        "CodeQL",
+				Type:        "SAST",
+				Integration: si.SecurityToolIntegration{Adhoc: true, Release: true},
+			}},
+			want: nil,
+		},
+		{
+			name: "Non-SAST tool is ignored",
+			tools: []si.SecurityTool{{
+				Name:        "Dependabot",
+				Type:        "SCA",
+				Integration: si.SecurityToolIntegration{Ci: true},
+			}},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		got := detectSastToolInInsights(test.tools)
+		assert.Equal(t, test.want, got, test.name)
+	}
 }
 
-func TestSastToolDefined(t *testing.T) {
+const codeqlWorkflow = `name: CodeQL
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/analyze@v3
+`
 
-	testData := []testingData{
+const semgrepRunWorkflow = `name: Security
+on: [push]
+jobs:
+  sast:
+    runs-on: ubuntu-latest
+    steps:
+      - run: semgrep ci
+`
+
+const scheduledCodeqlWorkflow = `name: Scheduled CodeQL
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/codeql-action/analyze@v3
+`
+
+const nonSastWorkflow = `name: Build
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: make build
+`
+
+func TestDetectSastInWorkflows(t *testing.T) {
+	tests := []struct {
+		name         string
+		files        []data.WorkflowFile
+		wantContains []string
+		wantEmpty    bool
+	}{
 		{
-			expectedResult:   gemara.Passed,
-			expectedMessage:  "Static Application Security Testing documented in Security Insights",
-			assertionMessage: "Test for SAST integration enabled",
-			payload: data.Payload{
-				RestData: &data.RestData{
-					Insights: si.SecurityInsights{
-						Repository: &si.Repository{
-							SecurityPosture: si.SecurityPosture{
-								Tools: []si.SecurityTool{
-									{
-										Type: "SAST",
-										Integration: si.SecurityToolIntegration{
-											Adhoc: true,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:         "CodeQL action on pull_request is detected with job correlation names",
+			files:        []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: codeqlWorkflow}},
+			wantContains: []string{"codeql", "CodeQL", "Analyze"},
 		},
 		{
-			expectedResult:   gemara.Failed,
-			expectedMessage:  "No Static Application Security Testing documented in Security Insights",
-			assertionMessage: "Test for SAST integration present but not explicitly enabled",
-			payload: data.Payload{
-				RestData: &data.RestData{
-					Insights: si.SecurityInsights{
-						Repository: &si.Repository{
-							SecurityPosture: si.SecurityPosture{
-								Tools: []si.SecurityTool{
-									{
-										Type: "SAST",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:         "semgrep run command on push is detected",
+			files:        []data.WorkflowFile{{Name: "sec.yml", Path: ".github/workflows/sec.yml", Content: semgrepRunWorkflow}},
+			wantContains: []string{"semgrep"},
 		},
 		{
-			expectedResult:   gemara.Failed,
-			expectedMessage:  "No Static Application Security Testing documented in Security Insights",
-			assertionMessage: "Test for Non SAST tool defined",
-			payload: data.Payload{
-				RestData: &data.RestData{
-					Insights: si.SecurityInsights{
-						Repository: &si.Repository{
-							SecurityPosture: si.SecurityPosture{
-								Tools: []si.SecurityTool{
-									{
-										Type: "NotSast",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:      "SAST that only runs on a schedule is not evidence of a gate on changes",
+			files:     []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: scheduledCodeqlWorkflow}},
+			wantEmpty: true,
 		},
 		{
-			expectedResult:   gemara.Failed,
-			expectedMessage:  "No Static Application Security Testing documented in Security Insights",
-			assertionMessage: "Test for no tools defined",
-			payload: data.Payload{
-				RestData: &data.RestData{
-					Insights: si.SecurityInsights{
-						Repository: &si.Repository{
-							SecurityPosture: si.SecurityPosture{},
-						},
-					},
-				},
-			},
+			name:      "workflow without a SAST tool is not detected",
+			files:     []data.WorkflowFile{{Name: "build.yml", Path: ".github/workflows/build.yml", Content: nonSastWorkflow}},
+			wantEmpty: true,
+		},
+		{
+			name:      "truncated and non-workflow files are skipped",
+			files:     []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Truncated: true}, {Name: "README.md", Content: codeqlWorkflow}},
+			wantEmpty: true,
 		},
 	}
 
-	for _, test := range testData {
-		result, message, _ := SastToolDefined(test.payload)
+	for _, test := range tests {
+		got := detectSastInWorkflows(test.files)
+		if test.wantEmpty {
+			assert.Empty(t, got, test.name)
+			continue
+		}
+		for _, want := range test.wantContains {
+			assert.Contains(t, got, want, test.name)
+		}
+	}
+}
 
-		assert.Equal(t, test.expectedResult, result, test.assertionMessage)
-		assert.Equal(t, test.expectedMessage, message, test.assertionMessage)
+func TestRequiredCheckMatchesSast(t *testing.T) {
+	tests := []struct {
+		name             string
+		requiredContexts []string
+		sastSources      []string
+		want             bool
+	}{
+		{
+			name:             "check context carrying a known SAST identifier matches",
+			requiredContexts: []string{"CodeQL"},
+			sastSources:      []string{"some-other-source"},
+			want:             true,
+		},
+		{
+			name:             "check context matching a SAST job name matches",
+			requiredContexts: []string{"Analyze"},
+			sastSources:      []string{"codeql", "Analyze"},
+			want:             true,
+		},
+		{
+			name:             "unrelated required check does not match",
+			requiredContexts: []string{"build", "unit-tests"},
+			sastSources:      []string{"codeql", "Analyze"},
+			want:             false,
+		},
+		{
+			name:             "short generic source token does not produce a spurious match",
+			requiredContexts: []string{"lint"},
+			sastSources:      []string{"ci"},
+			want:             false,
+		},
+		{
+			name:             "no required contexts cannot match",
+			requiredContexts: nil,
+			sastSources:      []string{"codeql"},
+			want:             false,
+		},
 	}
 
+	for _, test := range tests {
+		got := requiredCheckMatchesSast(test.requiredContexts, test.sastSources)
+		assert.Equal(t, test.want, got, test.name)
+	}
+}
+
+func TestEvaluateSastEnforcement(t *testing.T) {
+	tests := []struct {
+		name             string
+		sastSources      []string
+		requiredContexts []string
+		adminObservable  bool
+		wantResult       gemara.Result
+	}{
+		{
+			name:             "SAST in CI enforced by a matching required check passes",
+			sastSources:      []string{"codeql", "Analyze"},
+			requiredContexts: []string{"Analyze"},
+			wantResult:       gemara.Passed,
+		},
+		{
+			name:             "SAST in CI with required checks but no match needs review",
+			sastSources:      []string{"codeql", "Analyze"},
+			requiredContexts: []string{"build"},
+			wantResult:       gemara.NeedsReview,
+		},
+		{
+			name:            "SAST in CI with admin-observable absence of required checks fails",
+			sastSources:     []string{"codeql"},
+			adminObservable: true,
+			wantResult:      gemara.Failed,
+		},
+		{
+			name:            "SAST in CI with unobservable branch protection needs review",
+			sastSources:     []string{"codeql"},
+			adminObservable: false,
+			wantResult:      gemara.NeedsReview,
+		},
+		{
+			name:        "no SAST in CI fails",
+			sastSources: nil,
+			wantResult:  gemara.Failed,
+		},
+	}
+
+	for _, test := range tests {
+		result, message, _ := evaluateSastEnforcement(test.sastSources, test.requiredContexts, test.adminObservable)
+		assert.Equal(t, test.wantResult, result, test.name)
+		assert.NotEmpty(t, message, test.name)
+	}
 }
 
 func TestHasVulnerabilityDisclosurePolicy(t *testing.T) {

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -26,7 +26,7 @@ func TestDetectSastToolInInsights(t *testing.T) {
 				Rulesets:    []string{"default"},
 				Integration: si.SecurityToolIntegration{Ci: true},
 			}},
-			want: []sastSource{{name: "CodeQL", policyDocumented: true}},
+			want: []sastSource{{name: "CodeQL", toolID: "codeql", policyDocumented: true}},
 		},
 		{
 			name: "SAST tool without rulesets carries no documented policy",
@@ -35,7 +35,7 @@ func TestDetectSastToolInInsights(t *testing.T) {
 				Type:        "SAST",
 				Integration: si.SecurityToolIntegration{Ci: true},
 			}},
-			want: []sastSource{{name: "CodeQL", policyDocumented: false}},
+			want: []sastSource{{name: "CodeQL", toolID: "codeql", policyDocumented: false}},
 		},
 		{
 			name: "SAST tool without a name falls back to a generic label",
@@ -43,7 +43,7 @@ func TestDetectSastToolInInsights(t *testing.T) {
 				Type:        "SAST",
 				Integration: si.SecurityToolIntegration{Ci: true},
 			}},
-			want: []sastSource{{name: "SAST", policyDocumented: false}},
+			want: []sastSource{{name: "SAST", toolID: "sast", policyDocumented: false}},
 		},
 		{
 			name: "SAST tool only run adhoc or at release is not CI evidence",
@@ -200,12 +200,12 @@ func TestDetectSastInWorkflows(t *testing.T) {
 		{
 			name:         "CodeQL action on pull_request is detected with job correlation names",
 			files:        []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: codeqlWorkflow}},
-			wantContains: []string{"codeql", "CodeQL / Analyze"},
+			wantContains: []string{"codeql", "Analyze"},
 		},
 		{
-			name:         "semgrep run command on pull request is detected",
+			name:         "semgrep run command includes job ID when no display name exists",
 			files:        []data.WorkflowFile{{Name: "sec.yml", Path: ".github/workflows/sec.yml", Content: semgrepRunWorkflow}},
-			wantContains: []string{"semgrep"},
+			wantContains: []string{"semgrep", "sast"},
 		},
 		{
 			name:         "SAST run on every pushed commit is detected",
@@ -226,12 +226,12 @@ func TestDetectSastInWorkflows(t *testing.T) {
 		{
 			name:         "unfiltered push covers changes despite a filtered pull request trigger",
 			files:        []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: filteredPullRequestWithPushWorkflow}},
-			wantContains: []string{"codeql", "CodeQL / analyze"},
+			wantContains: []string{"codeql", "analyze"},
 		},
 		{
 			name:         "branch ignore that does not exclude default branch still covers changes",
 			files:        []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: branchIgnoreCodeqlWorkflow}},
-			wantContains: []string{"codeql", "CodeQL / analyze"},
+			wantContains: []string{"codeql", "analyze"},
 		},
 		{
 			name:      "workflow without a SAST tool is not detected",
@@ -256,12 +256,12 @@ func TestDetectSastInWorkflows(t *testing.T) {
 				{Name: "caller.yml", Path: ".github/workflows/caller.yml", Content: reusableCallerWorkflow},
 				{Name: "reusable-sast.yml", Path: ".github/workflows/reusable-sast.yml", Content: reusableSastWorkflow},
 			},
-			wantContains: []string{"codeql", "Security / SAST gate", "Security / SAST gate / analyze"},
+			wantContains: []string{"codeql", "SAST gate / analyze"},
 		},
 		{
 			name:         "recognizable remote reusable SAST workflow is detected",
 			files:        []data.WorkflowFile{{Name: "caller.yml", Path: ".github/workflows/caller.yml", Content: remoteReusableSastWorkflow}},
-			wantContains: []string{"codeql", "Security / Code scan"},
+			wantContains: []string{"codeql"},
 		},
 		{
 			name:        "uninspectable remote reusable workflow records uncertainty",
@@ -296,8 +296,127 @@ func TestDetectSastInWorkflows(t *testing.T) {
 		}
 		if test.name == "CodeQL action on pull_request is detected with job correlation names" {
 			assert.NotContains(t, sourceNames, "CodeQL", "workflow name must not be used as status-check evidence")
+			assert.NotContains(t, sourceNames, "CodeQL / Analyze", "direct check context must not include workflow name")
+			assert.NotContains(t, sourceNames, "analyze", "job ID must not be an alias when a display name is set")
+		}
+		if test.name == "local reusable SAST workflow is resolved recursively" {
+			assert.NotContains(t, sourceNames, "Security / SAST gate / analyze", "reusable check context must not include workflow name")
+		}
+		if test.name == "recognizable remote reusable SAST workflow is detected" {
+			assert.NotContains(t, sourceNames, "Code scan", "unknown called jobs cannot be inferred from the caller name")
 		}
 	}
+}
+
+func TestAssociateSastPolicies(t *testing.T) {
+	sources := []sastSource{
+		{name: "Semgrep", toolID: "semgrep", policyDocumented: true},
+		{name: "SAST", toolID: "semgrep", workflowAlias: true},
+		{name: "Security / SAST", toolID: "semgrep", workflowAlias: true},
+		{name: "CodeQL", toolID: "codeql"},
+		{name: "Analyze", toolID: "codeql", workflowAlias: true},
+		{name: "SonarQube", toolID: "sonar", policyDocumented: true},
+		{name: "SonarCloud", toolID: "sonar"},
+	}
+
+	associateSastPolicies(sources)
+
+	assert.True(t, sources[1].policyDocumented, "bare Semgrep job alias should inherit Semgrep policy")
+	assert.True(t, sources[2].policyDocumented, "composite Semgrep alias should inherit Semgrep policy")
+	assert.False(t, sources[3].policyDocumented, "CodeQL tool must not inherit unrelated Semgrep policy")
+	assert.False(t, sources[4].policyDocumented, "CodeQL job alias must not inherit unrelated Semgrep policy")
+	assert.False(t, sources[6].policyDocumented, "Insights entries must not inherit policy from a peer in the same tool family")
+}
+
+func TestDocumentedPolicyMatchesWorkflowCheckForSameTool(t *testing.T) {
+	tests := []struct {
+		name            string
+		insightsTool    si.SecurityTool
+		workflow        string
+		requiredContext string
+		expectedResult  gemara.Result
+	}{
+		{
+			name: "documented Semgrep policy backs the required Semgrep job",
+			insightsTool: si.SecurityTool{
+				Name:        "Semgrep",
+				Type:        "SAST",
+				Rulesets:    []string{"default"},
+				Integration: si.SecurityToolIntegration{Ci: true},
+			},
+			workflow:        semgrepRunWorkflow,
+			requiredContext: "sast",
+			expectedResult:  gemara.Passed,
+		},
+		{
+			name: "documented Semgrep policy does not back the required CodeQL job",
+			insightsTool: si.SecurityTool{
+				Name:        "Semgrep",
+				Type:        "SAST",
+				Rulesets:    []string{"default"},
+				Integration: si.SecurityToolIntegration{Ci: true},
+			},
+			workflow:        codeqlWorkflow,
+			requiredContext: "Analyze",
+			expectedResult:  gemara.NeedsReview,
+		},
+		{
+			name: "SonarQube policy backs a sonar-scanner workflow job",
+			insightsTool: si.SecurityTool{
+				Name:        "SonarQube",
+				Type:        "SAST",
+				Rulesets:    []string{"default"},
+				Integration: si.SecurityToolIntegration{Ci: true},
+			},
+			workflow: `name: Security
+on: [pull_request]
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sonar-scanner
+`,
+			requiredContext: "sonar",
+			expectedResult:  gemara.Passed,
+		},
+	}
+
+	for _, test := range tests {
+		insights := detectSastToolInInsights([]si.SecurityTool{test.insightsTool})
+		workflow := detectSastInWorkflows(
+			[]data.WorkflowFile{{Name: "sast.yml", Path: ".github/workflows/sast.yml", Content: test.workflow}},
+			"main",
+		)
+		detection := sastDetection{
+			sources:        append(insights.sources, workflow.sources...),
+			coverageProven: workflow.coverageProven,
+		}
+		associateSastPolicies(detection.sources)
+
+		result, _, _ := evaluateSastEnforcement(detection, []string{test.requiredContext}, true)
+		assert.Equal(t, test.expectedResult, result, test.name)
+	}
+}
+
+func TestDocumentedPolicyMatchesReusableWorkflowCheck(t *testing.T) {
+	insights := detectSastToolInInsights([]si.SecurityTool{{
+		Name:        "CodeQL",
+		Type:        "SAST",
+		Rulesets:    []string{"default"},
+		Integration: si.SecurityToolIntegration{Ci: true},
+	}})
+	workflow := detectSastInWorkflows([]data.WorkflowFile{
+		{Name: "caller.yml", Path: ".github/workflows/caller.yml", Content: reusableCallerWorkflow},
+		{Name: "reusable-sast.yml", Path: ".github/workflows/reusable-sast.yml", Content: reusableSastWorkflow},
+	}, "main")
+	detection := sastDetection{
+		sources:        append(insights.sources, workflow.sources...),
+		coverageProven: workflow.coverageProven,
+	}
+	associateSastPolicies(detection.sources)
+
+	result, _, _ := evaluateSastEnforcement(detection, []string{"SAST gate / analyze"}, true)
+	assert.Equal(t, gemara.Passed, result)
 }
 
 func TestMatchesGitHubGlob(t *testing.T) {

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -14,10 +14,9 @@ func ptrTo[T any](v T) *T { return &v }
 
 func TestDetectSastToolInInsights(t *testing.T) {
 	tests := []struct {
-		name       string
-		tools      []si.SecurityTool
-		want       []string
-		wantPolicy bool
+		name  string
+		tools []si.SecurityTool
+		want  []sastSource
 	}{
 		{
 			name: "SAST tool integrated in CI is detected by name",
@@ -27,8 +26,16 @@ func TestDetectSastToolInInsights(t *testing.T) {
 				Rulesets:    []string{"default"},
 				Integration: si.SecurityToolIntegration{Ci: true},
 			}},
-			want:       []string{"CodeQL"},
-			wantPolicy: true,
+			want: []sastSource{{name: "CodeQL", policyDocumented: true}},
+		},
+		{
+			name: "SAST tool without rulesets carries no documented policy",
+			tools: []si.SecurityTool{{
+				Name:        "CodeQL",
+				Type:        "SAST",
+				Integration: si.SecurityToolIntegration{Ci: true},
+			}},
+			want: []sastSource{{name: "CodeQL", policyDocumented: false}},
 		},
 		{
 			name: "SAST tool without a name falls back to a generic label",
@@ -36,7 +43,7 @@ func TestDetectSastToolInInsights(t *testing.T) {
 				Type:        "SAST",
 				Integration: si.SecurityToolIntegration{Ci: true},
 			}},
-			want: []string{"SAST"},
+			want: []sastSource{{name: "SAST", policyDocumented: false}},
 		},
 		{
 			name: "SAST tool only run adhoc or at release is not CI evidence",
@@ -61,7 +68,6 @@ func TestDetectSastToolInInsights(t *testing.T) {
 	for _, test := range tests {
 		got := detectSastToolInInsights(test.tools)
 		assert.Equal(t, test.want, got.sources, test.name)
-		assert.Equal(t, test.wantPolicy, got.policyDocumented, test.name)
 	}
 }
 
@@ -281,12 +287,37 @@ func TestDetectSastInWorkflows(t *testing.T) {
 			assert.Empty(t, got.sources, test.name)
 			continue
 		}
+		var sourceNames []string
+		for _, source := range got.sources {
+			sourceNames = append(sourceNames, source.name)
+		}
 		for _, want := range test.wantContains {
-			assert.Contains(t, got.sources, want, test.name)
+			assert.Contains(t, sourceNames, want, test.name)
 		}
 		if test.name == "CodeQL action on pull_request is detected with job correlation names" {
-			assert.NotContains(t, got.sources, "CodeQL", "workflow name must not be used as status-check evidence")
+			assert.NotContains(t, sourceNames, "CodeQL", "workflow name must not be used as status-check evidence")
 		}
+	}
+}
+
+func TestMatchesGitHubGlob(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		pattern string
+		want    bool
+	}{
+		{name: "exact match", value: "main", pattern: "main", want: true},
+		{name: "single star stays within a path segment", value: "release-1", pattern: "release-*", want: true},
+		{name: "single star does not cross a slash", value: "feature/x", pattern: "feature*", want: false},
+		{name: "double star crosses slashes", value: "feature/x/y", pattern: "feature/**", want: true},
+		{name: "question mark is treated conservatively as no match", value: "release-x", pattern: "release-?", want: false},
+		{name: "plus is treated conservatively as no match", value: "release-x", pattern: "release-+", want: false},
+		{name: "character class is treated conservatively as no match", value: "release-1", pattern: "release-[0-9]", want: false},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.want, matchesGitHubGlob(test.value, test.pattern), test.name)
 	}
 }
 
@@ -294,62 +325,79 @@ func TestRequiredCheckMatchesSast(t *testing.T) {
 	tests := []struct {
 		name             string
 		requiredContexts []string
-		sastSources      []string
+		sastSources      []sastSource
 		want             bool
+		wantWithPolicy   bool
 	}{
 		{
 			name:             "check context carrying a known SAST identifier matches",
 			requiredContexts: []string{"CodeQL"},
-			sastSources:      []string{"codeql"},
+			sastSources:      []sastSource{{name: "codeql", policyDocumented: true}},
 			want:             true,
+			wantWithPolicy:   true,
+		},
+		{
+			name:             "matched source without documented policy is not policy-backed",
+			requiredContexts: []string{"CodeQL"},
+			sastSources:      []sastSource{{name: "codeql"}},
+			want:             true,
+			wantWithPolicy:   false,
+		},
+		{
+			name:             "policy from an unmatched tool does not make the match policy-backed",
+			requiredContexts: []string{"CodeQL"},
+			sastSources:      []sastSource{{name: "codeql"}, {name: "semgrep", policyDocumented: true}},
+			want:             true,
+			wantWithPolicy:   false,
 		},
 		{
 			name:             "check merely containing a known SAST identifier does not match",
 			requiredContexts: []string{"Build CodeQL pack"},
-			sastSources:      []string{"codeql"},
+			sastSources:      []sastSource{{name: "codeql"}},
 			want:             false,
 		},
 		{
 			name:             "check context matching a SAST job name matches",
 			requiredContexts: []string{"Security / Analyze"},
-			sastSources:      []string{"codeql", "Security / Analyze"},
+			sastSources:      []sastSource{{name: "codeql"}, {name: "Security / Analyze"}},
 			want:             true,
 		},
 		{
 			name:             "generic job component in another workflow does not match",
 			requiredContexts: []string{"Unit Tests / Analyze"},
-			sastSources:      []string{"codeql", "Security / Analyze"},
+			sastSources:      []sastSource{{name: "codeql"}, {name: "Security / Analyze"}},
 			want:             false,
 		},
 		{
 			name:             "substring of a SAST job name does not match",
 			requiredContexts: []string{"Analyze results"},
-			sastSources:      []string{"Static Analyze"},
+			sastSources:      []sastSource{{name: "Static Analyze"}},
 			want:             false,
 		},
 		{
 			name:             "unrelated required check does not match",
 			requiredContexts: []string{"build", "unit-tests"},
-			sastSources:      []string{"codeql", "Analyze"},
+			sastSources:      []sastSource{{name: "codeql"}, {name: "Analyze"}},
 			want:             false,
 		},
 		{
 			name:             "short generic source token does not produce a spurious match",
 			requiredContexts: []string{"lint"},
-			sastSources:      []string{"ci"},
+			sastSources:      []sastSource{{name: "ci"}},
 			want:             false,
 		},
 		{
 			name:             "no required contexts cannot match",
 			requiredContexts: nil,
-			sastSources:      []string{"codeql"},
+			sastSources:      []sastSource{{name: "codeql"}},
 			want:             false,
 		},
 	}
 
 	for _, test := range tests {
-		got := requiredCheckMatchesSast(test.requiredContexts, test.sastSources)
+		got, gotWithPolicy := requiredCheckMatchesSast(test.requiredContexts, test.sastSources)
 		assert.Equal(t, test.want, got, test.name)
+		assert.Equal(t, test.wantWithPolicy, gotWithPolicy, test.name)
 	}
 }
 
@@ -363,31 +411,37 @@ func TestEvaluateSastEnforcement(t *testing.T) {
 	}{
 		{
 			name:             "SAST in CI enforced by a matching required check passes",
-			detection:        sastDetection{sources: []string{"codeql", "Analyze"}, policyDocumented: true},
+			detection:        sastDetection{sources: []sastSource{{name: "codeql", policyDocumented: true}, {name: "Analyze", policyDocumented: true}}},
 			requiredContexts: []string{"Analyze"},
 			wantResult:       gemara.Passed,
 		},
 		{
 			name:             "enforced SAST without a documented policy needs review",
-			detection:        sastDetection{sources: []string{"codeql", "Analyze"}},
+			detection:        sastDetection{sources: []sastSource{{name: "codeql"}, {name: "Analyze"}}},
 			requiredContexts: []string{"Analyze"},
 			wantResult:       gemara.NeedsReview,
 		},
 		{
+			name:             "enforced tool without policy does not pass on an unmatched tool's policy",
+			detection:        sastDetection{sources: []sastSource{{name: "codeql"}, {name: "semgrep", policyDocumented: true}}},
+			requiredContexts: []string{"codeql"},
+			wantResult:       gemara.NeedsReview,
+		},
+		{
 			name:             "SAST in CI with required checks but no match needs review",
-			detection:        sastDetection{sources: []string{"codeql", "Analyze"}, policyDocumented: true},
+			detection:        sastDetection{sources: []sastSource{{name: "codeql", policyDocumented: true}, {name: "Analyze", policyDocumented: true}}},
 			requiredContexts: []string{"build"},
 			wantResult:       gemara.NeedsReview,
 		},
 		{
 			name:            "SAST in CI with admin-observable absence of required checks fails",
-			detection:       sastDetection{sources: []string{"codeql"}, policyDocumented: true},
+			detection:       sastDetection{sources: []sastSource{{name: "codeql", policyDocumented: true}}},
 			adminObservable: true,
 			wantResult:      gemara.Failed,
 		},
 		{
 			name:            "SAST in CI with unobservable branch protection needs review",
-			detection:       sastDetection{sources: []string{"codeql"}, policyDocumented: true},
+			detection:       sastDetection{sources: []sastSource{{name: "codeql", policyDocumented: true}}},
 			adminObservable: false,
 			wantResult:      gemara.NeedsReview,
 		},
@@ -403,13 +457,13 @@ func TestEvaluateSastEnforcement(t *testing.T) {
 		},
 		{
 			name:             "Security Insights evidence cannot pass when workflow coverage is uninspectable",
-			detection:        sastDetection{sources: []string{"codeql"}, policyDocumented: true, inspectionBlocked: true},
+			detection:        sastDetection{sources: []sastSource{{name: "codeql", policyDocumented: true}}, inspectionBlocked: true},
 			requiredContexts: []string{"codeql"},
 			wantResult:       gemara.NeedsReview,
 		},
 		{
 			name:             "independently proven workflow coverage can pass despite an unrelated uninspectable workflow",
-			detection:        sastDetection{sources: []string{"codeql"}, policyDocumented: true, inspectionBlocked: true, coverageProven: true},
+			detection:        sastDetection{sources: []sastSource{{name: "codeql", policyDocumented: true}}, inspectionBlocked: true, coverageProven: true},
 			requiredContexts: []string{"codeql"},
 			wantResult:       gemara.Passed,
 		},

--- a/evaluation_plans/osps/vuln_management/steps_test.go
+++ b/evaluation_plans/osps/vuln_management/steps_test.go
@@ -1,6 +1,7 @@
 package vuln_management
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
@@ -13,18 +14,21 @@ func ptrTo[T any](v T) *T { return &v }
 
 func TestDetectSastToolInInsights(t *testing.T) {
 	tests := []struct {
-		name  string
-		tools []si.SecurityTool
-		want  []string
+		name       string
+		tools      []si.SecurityTool
+		want       []string
+		wantPolicy bool
 	}{
 		{
 			name: "SAST tool integrated in CI is detected by name",
 			tools: []si.SecurityTool{{
 				Name:        "CodeQL",
 				Type:        "SAST",
+				Rulesets:    []string{"default"},
 				Integration: si.SecurityToolIntegration{Ci: true},
 			}},
-			want: []string{"CodeQL"},
+			want:       []string{"CodeQL"},
+			wantPolicy: true,
 		},
 		{
 			name: "SAST tool without a name falls back to a generic label",
@@ -56,7 +60,8 @@ func TestDetectSastToolInInsights(t *testing.T) {
 
 	for _, test := range tests {
 		got := detectSastToolInInsights(test.tools)
-		assert.Equal(t, test.want, got, test.name)
+		assert.Equal(t, test.want, got.sources, test.name)
+		assert.Equal(t, test.wantPolicy, got.policyDocumented, test.name)
 	}
 }
 
@@ -74,12 +79,49 @@ jobs:
 `
 
 const semgrepRunWorkflow = `name: Security
-on: [push]
+on: [pull_request]
 jobs:
   sast:
     runs-on: ubuntu-latest
     steps:
       - run: semgrep ci
+`
+
+const pathFilteredCodeqlWorkflow = `name: CodeQL
+on:
+  pull_request:
+    paths:
+      - src/**
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/codeql-action/analyze@v3
+`
+
+const filteredPullRequestWithPushWorkflow = `name: CodeQL
+on:
+  pull_request:
+    paths:
+      - src/**
+  push:
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/codeql-action/analyze@v3
+`
+
+const branchIgnoreCodeqlWorkflow = `name: CodeQL
+on:
+  pull_request:
+    branches-ignore:
+      - release/**
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/codeql-action/analyze@v3
 `
 
 const scheduledCodeqlWorkflow = `name: Scheduled CodeQL
@@ -102,21 +144,66 @@ jobs:
       - run: make build
 `
 
+const reusableCallerWorkflow = `name: Security
+on: [pull_request]
+jobs:
+  sast:
+    name: SAST gate
+    uses: ./.github/workflows/reusable-sast.yml
+`
+
+const reusableSastWorkflow = `name: Reusable security
+on: [workflow_call]
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/codeql-action/analyze@v3
+`
+
+const remoteReusableSastWorkflow = `name: Security
+on: [pull_request]
+jobs:
+  sast:
+    name: Code scan
+    uses: org/security/.github/workflows/codeql.yml@v1
+`
+
+const unknownRemoteReusableWorkflow = `name: Security
+on: [pull_request]
+jobs:
+  sast:
+    uses: org/security/.github/workflows/scan.yml@v1
+`
+
+const cyclicReusableWorkflow = `name: Cyclic
+on: [workflow_call]
+jobs:
+  recurse:
+    uses: ./.github/workflows/cyclic.yml
+`
+
 func TestDetectSastInWorkflows(t *testing.T) {
 	tests := []struct {
 		name         string
 		files        []data.WorkflowFile
 		wantContains []string
 		wantEmpty    bool
+		wantBlocked  bool
 	}{
 		{
 			name:         "CodeQL action on pull_request is detected with job correlation names",
 			files:        []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: codeqlWorkflow}},
-			wantContains: []string{"codeql", "CodeQL", "Analyze"},
+			wantContains: []string{"codeql", "CodeQL / Analyze"},
 		},
 		{
-			name:         "semgrep run command on push is detected",
+			name:         "semgrep run command on pull request is detected",
 			files:        []data.WorkflowFile{{Name: "sec.yml", Path: ".github/workflows/sec.yml", Content: semgrepRunWorkflow}},
+			wantContains: []string{"semgrep"},
+		},
+		{
+			name:         "SAST run on every pushed commit is detected",
+			files:        []data.WorkflowFile{{Name: "sec.yml", Path: ".github/workflows/sec.yml", Content: strings.Replace(semgrepRunWorkflow, "pull_request", "push", 1)}},
 			wantContains: []string{"semgrep"},
 		},
 		{
@@ -125,25 +212,80 @@ func TestDetectSastInWorkflows(t *testing.T) {
 			wantEmpty: true,
 		},
 		{
+			name:        "path-filtered SAST workflow cannot prove coverage of all changes",
+			files:       []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: pathFilteredCodeqlWorkflow}},
+			wantEmpty:   true,
+			wantBlocked: true,
+		},
+		{
+			name:         "unfiltered push covers changes despite a filtered pull request trigger",
+			files:        []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: filteredPullRequestWithPushWorkflow}},
+			wantContains: []string{"codeql", "CodeQL / analyze"},
+		},
+		{
+			name:         "branch ignore that does not exclude default branch still covers changes",
+			files:        []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Content: branchIgnoreCodeqlWorkflow}},
+			wantContains: []string{"codeql", "CodeQL / analyze"},
+		},
+		{
 			name:      "workflow without a SAST tool is not detected",
 			files:     []data.WorkflowFile{{Name: "build.yml", Path: ".github/workflows/build.yml", Content: nonSastWorkflow}},
 			wantEmpty: true,
 		},
 		{
-			name:      "truncated and non-workflow files are skipped",
-			files:     []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Truncated: true}, {Name: "README.md", Content: codeqlWorkflow}},
-			wantEmpty: true,
+			name:        "truncated workflow records incomplete inspection",
+			files:       []data.WorkflowFile{{Name: "codeql.yml", Path: ".github/workflows/codeql.yml", Truncated: true}, {Name: "README.md", Content: codeqlWorkflow}},
+			wantEmpty:   true,
+			wantBlocked: true,
+		},
+		{
+			name:        "unparseable workflow records incomplete inspection",
+			files:       []data.WorkflowFile{{Name: "broken.yml", Path: ".github/workflows/broken.yml", Content: "on: [pull_request]\njobs: ["}},
+			wantEmpty:   true,
+			wantBlocked: true,
+		},
+		{
+			name: "local reusable SAST workflow is resolved recursively",
+			files: []data.WorkflowFile{
+				{Name: "caller.yml", Path: ".github/workflows/caller.yml", Content: reusableCallerWorkflow},
+				{Name: "reusable-sast.yml", Path: ".github/workflows/reusable-sast.yml", Content: reusableSastWorkflow},
+			},
+			wantContains: []string{"codeql", "Security / SAST gate", "Security / SAST gate / analyze"},
+		},
+		{
+			name:         "recognizable remote reusable SAST workflow is detected",
+			files:        []data.WorkflowFile{{Name: "caller.yml", Path: ".github/workflows/caller.yml", Content: remoteReusableSastWorkflow}},
+			wantContains: []string{"codeql", "Security / Code scan"},
+		},
+		{
+			name:        "uninspectable remote reusable workflow records uncertainty",
+			files:       []data.WorkflowFile{{Name: "caller.yml", Path: ".github/workflows/caller.yml", Content: unknownRemoteReusableWorkflow}},
+			wantEmpty:   true,
+			wantBlocked: true,
+		},
+		{
+			name: "cyclic local reusable workflow records uncertainty",
+			files: []data.WorkflowFile{
+				{Name: "caller.yml", Path: ".github/workflows/caller.yml", Content: strings.Replace(reusableCallerWorkflow, "reusable-sast.yml", "cyclic.yml", 1)},
+				{Name: "cyclic.yml", Path: ".github/workflows/cyclic.yml", Content: cyclicReusableWorkflow},
+			},
+			wantEmpty:   true,
+			wantBlocked: true,
 		},
 	}
 
 	for _, test := range tests {
-		got := detectSastInWorkflows(test.files)
+		got := detectSastInWorkflows(test.files, "main")
+		assert.Equal(t, test.wantBlocked, got.inspectionBlocked, test.name)
 		if test.wantEmpty {
-			assert.Empty(t, got, test.name)
+			assert.Empty(t, got.sources, test.name)
 			continue
 		}
 		for _, want := range test.wantContains {
-			assert.Contains(t, got, want, test.name)
+			assert.Contains(t, got.sources, want, test.name)
+		}
+		if test.name == "CodeQL action on pull_request is detected with job correlation names" {
+			assert.NotContains(t, got.sources, "CodeQL", "workflow name must not be used as status-check evidence")
 		}
 	}
 }
@@ -158,14 +300,32 @@ func TestRequiredCheckMatchesSast(t *testing.T) {
 		{
 			name:             "check context carrying a known SAST identifier matches",
 			requiredContexts: []string{"CodeQL"},
-			sastSources:      []string{"some-other-source"},
+			sastSources:      []string{"codeql"},
 			want:             true,
 		},
 		{
+			name:             "check merely containing a known SAST identifier does not match",
+			requiredContexts: []string{"Build CodeQL pack"},
+			sastSources:      []string{"codeql"},
+			want:             false,
+		},
+		{
 			name:             "check context matching a SAST job name matches",
-			requiredContexts: []string{"Analyze"},
-			sastSources:      []string{"codeql", "Analyze"},
+			requiredContexts: []string{"Security / Analyze"},
+			sastSources:      []string{"codeql", "Security / Analyze"},
 			want:             true,
+		},
+		{
+			name:             "generic job component in another workflow does not match",
+			requiredContexts: []string{"Unit Tests / Analyze"},
+			sastSources:      []string{"codeql", "Security / Analyze"},
+			want:             false,
+		},
+		{
+			name:             "substring of a SAST job name does not match",
+			requiredContexts: []string{"Analyze results"},
+			sastSources:      []string{"Static Analyze"},
+			want:             false,
 		},
 		{
 			name:             "unrelated required check does not match",
@@ -196,44 +356,67 @@ func TestRequiredCheckMatchesSast(t *testing.T) {
 func TestEvaluateSastEnforcement(t *testing.T) {
 	tests := []struct {
 		name             string
-		sastSources      []string
+		detection        sastDetection
 		requiredContexts []string
 		adminObservable  bool
 		wantResult       gemara.Result
 	}{
 		{
 			name:             "SAST in CI enforced by a matching required check passes",
-			sastSources:      []string{"codeql", "Analyze"},
+			detection:        sastDetection{sources: []string{"codeql", "Analyze"}, policyDocumented: true},
 			requiredContexts: []string{"Analyze"},
 			wantResult:       gemara.Passed,
 		},
 		{
+			name:             "enforced SAST without a documented policy needs review",
+			detection:        sastDetection{sources: []string{"codeql", "Analyze"}},
+			requiredContexts: []string{"Analyze"},
+			wantResult:       gemara.NeedsReview,
+		},
+		{
 			name:             "SAST in CI with required checks but no match needs review",
-			sastSources:      []string{"codeql", "Analyze"},
+			detection:        sastDetection{sources: []string{"codeql", "Analyze"}, policyDocumented: true},
 			requiredContexts: []string{"build"},
 			wantResult:       gemara.NeedsReview,
 		},
 		{
 			name:            "SAST in CI with admin-observable absence of required checks fails",
-			sastSources:     []string{"codeql"},
+			detection:       sastDetection{sources: []string{"codeql"}, policyDocumented: true},
 			adminObservable: true,
 			wantResult:      gemara.Failed,
 		},
 		{
 			name:            "SAST in CI with unobservable branch protection needs review",
-			sastSources:     []string{"codeql"},
+			detection:       sastDetection{sources: []string{"codeql"}, policyDocumented: true},
 			adminObservable: false,
 			wantResult:      gemara.NeedsReview,
 		},
 		{
-			name:        "no SAST in CI fails",
-			sastSources: nil,
-			wantResult:  gemara.Failed,
+			name:       "no SAST in CI fails",
+			detection:  sastDetection{},
+			wantResult: gemara.Failed,
+		},
+		{
+			name:       "no SAST evidence with incomplete inspection needs review",
+			detection:  sastDetection{inspectionBlocked: true},
+			wantResult: gemara.NeedsReview,
+		},
+		{
+			name:             "Security Insights evidence cannot pass when workflow coverage is uninspectable",
+			detection:        sastDetection{sources: []string{"codeql"}, policyDocumented: true, inspectionBlocked: true},
+			requiredContexts: []string{"codeql"},
+			wantResult:       gemara.NeedsReview,
+		},
+		{
+			name:             "independently proven workflow coverage can pass despite an unrelated uninspectable workflow",
+			detection:        sastDetection{sources: []string{"codeql"}, policyDocumented: true, inspectionBlocked: true, coverageProven: true},
+			requiredContexts: []string{"codeql"},
+			wantResult:       gemara.Passed,
 		},
 	}
 
 	for _, test := range tests {
-		result, message, _ := evaluateSastEnforcement(test.sastSources, test.requiredContexts, test.adminObservable)
+		result, message, _ := evaluateSastEnforcement(test.detection, test.requiredContexts, test.adminObservable)
 		assert.Equal(t, test.wantResult, result, test.name)
 		assert.NotEmpty(t, message, test.name)
 	}


### PR DESCRIPTION
## Summary

Implement OSPS-VM-06.02 by verifying that every code change is evaluated by a documented SAST policy and that the corresponding check is required on the default branch.

- detect SAST CI integrations declared in Security Insights
- inspect pull request and push workflows, including local reusable workflows
- correlate documented policy evidence with required GitHub Actions check contexts for the same SAST tool
- conservatively return `NeedsReview` when workflow coverage or branch protection cannot be proven
- prevent unrelated tools, ambiguous check names, or unsupported branch globs from producing false passes

## Validation

- `gofmt`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `golangci-lint run ./...` (0 issues)
- `go mod tidy` produces no changes

Closes #416
