### PR TITLE
feat(OSPS-VM-05): evaluate SCA policy, pre-release scanning, and enforcement

### DIFF
--- a/data/documentation.go
+++ b/data/documentation.go
@@ -1,0 +1,149 @@
+package data
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// DocumentationFile is a decoded text document from an established repository
+// documentation location.
+type DocumentationFile struct {
+	Path    string
+	Content string
+}
+
+var documentationDirectories = map[string]bool{
+	".github":       true,
+	"doc":           true,
+	"docs":          true,
+	"documentation": true,
+}
+
+var documentationExtensions = map[string]bool{
+	".adoc":     true,
+	".markdown": true,
+	".md":       true,
+	".rst":      true,
+	".txt":      true,
+}
+
+// GetDocumentationFiles reads text documentation from the repository root and
+// the conventional .github, doc, docs, and documentation directories. It
+// returns successfully decoded files even when another document could not be
+// retrieved; callers can use that evidence while treating the returned error as
+// an incomplete inspection.
+func (r *RestData) GetDocumentationFiles() ([]DocumentationFile, error) {
+	if r == nil || !r.contentsObserved {
+		return nil, errors.New("repository contents were not observed")
+	}
+
+	var (
+		files        []DocumentationFile
+		readErrs     []error
+		limitReached bool
+		inspected    int
+	)
+	const maxDocumentationFiles = 100
+	readEntries := func(entries []*github.RepositoryContent) {
+		for _, entry := range entries {
+			if entry == nil || entry.GetType() != "file" || !isDocumentationPath(entry.GetPath()) {
+				continue
+			}
+			if inspected >= maxDocumentationFiles {
+				if !limitReached {
+					readErrs = append(readErrs, fmt.Errorf("documentation inspection limit of %d files reached", maxDocumentationFiles))
+					limitReached = true
+				}
+				return
+			}
+			inspected++
+			content, err := r.decodeDocumentationEntry(entry)
+			if err != nil {
+				readErrs = append(readErrs, fmt.Errorf("%s: %w", entry.GetPath(), err))
+				continue
+			}
+			files = append(files, DocumentationFile{Path: entry.GetPath(), Content: content})
+		}
+	}
+
+	readEntries(r.contents.Content)
+	for _, rootEntry := range r.contents.Content {
+		if limitReached {
+			break
+		}
+		if rootEntry == nil || rootEntry.GetType() != "dir" ||
+			!documentationDirectories[strings.ToLower(rootEntry.GetName())] {
+			continue
+		}
+		r.collectDocumentationDirectory(rootEntry.GetPath(), 0, readEntries, &readErrs)
+	}
+
+	// Tests and other deterministic callers may seed conventional directory
+	// listings directly without duplicating directory entries in the root list.
+	for dir := range documentationDirectories {
+		if limitReached {
+			break
+		}
+		if _, ok := r.contents.SubContent[dir]; !ok || hasRootDirectory(r.contents.Content, dir) {
+			continue
+		}
+		r.collectDocumentationDirectory(dir, 0, readEntries, &readErrs)
+	}
+
+	return files, errors.Join(readErrs...)
+}
+
+func (r *RestData) collectDocumentationDirectory(
+	dir string,
+	depth int,
+	readEntries func([]*github.RepositoryContent),
+	readErrs *[]error,
+) {
+	const maxDocumentationDepth = 4
+	if depth >= maxDocumentationDepth {
+		*readErrs = append(*readErrs, fmt.Errorf("%s: documentation directory exceeds inspection depth", dir))
+		return
+	}
+	listing, err := r.getSubdirContents(dir)
+	if err != nil {
+		*readErrs = append(*readErrs, fmt.Errorf("%s: %w", dir, err))
+		return
+	}
+	readEntries(listing.Content)
+	if strings.EqualFold(path.Clean(dir), ".github") {
+		return
+	}
+	for _, entry := range listing.Content {
+		if entry != nil && entry.GetType() == "dir" {
+			r.collectDocumentationDirectory(entry.GetPath(), depth+1, readEntries, readErrs)
+		}
+	}
+}
+
+func (r *RestData) decodeDocumentationEntry(entry *github.RepositoryContent) (string, error) {
+	if entry.Content != nil {
+		return entry.GetContent()
+	}
+	fetched, err := r.GetFileContent(entry.GetPath())
+	if err != nil {
+		return "", err
+	}
+	return fetched.GetContent()
+}
+
+func isDocumentationPath(filePath string) bool {
+	return documentationExtensions[strings.ToLower(path.Ext(filePath))]
+}
+
+func hasRootDirectory(entries []*github.RepositoryContent, name string) bool {
+	for _, entry := range entries {
+		if entry != nil && entry.GetType() == "dir" && strings.EqualFold(entry.GetName(), name) {
+			return true
+		}
+	}
+	return false
+}

--- a/data/documentation_test.go
+++ b/data/documentation_test.go
@@ -1,0 +1,87 @@
+package data
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDocumentationFilesUsesObservedContents(t *testing.T) {
+	rest := NewRestDataWithContents(RepoContent{
+		Content: []*github.RepositoryContent{
+			{Type: github.Ptr("file"), Name: github.Ptr("README.md"), Path: github.Ptr("README.md"), Content: github.Ptr("root policy")},
+			{Type: github.Ptr("dir"), Name: github.Ptr("docs"), Path: github.Ptr("docs")},
+			{Type: github.Ptr("file"), Name: github.Ptr("main.go"), Path: github.Ptr("main.go"), Content: github.Ptr("package main")},
+		},
+		SubContent: map[string]RepoContent{
+			"docs": {
+				Content: []*github.RepositoryContent{
+					{Type: github.Ptr("file"), Name: github.Ptr("security.rst"), Path: github.Ptr("docs/security.rst"), Content: github.Ptr("docs policy")},
+				},
+			},
+		},
+	})
+
+	files, err := rest.GetDocumentationFiles()
+	require.NoError(t, err)
+	assert.Equal(t, []DocumentationFile{
+		{Path: "README.md", Content: "root policy"},
+		{Path: "docs/security.rst", Content: "docs policy"},
+	}, files)
+}
+
+func TestGetDocumentationFilesReturnsPartialEvidenceAndError(t *testing.T) {
+	rest := NewRestDataWithContents(RepoContent{
+		Content: []*github.RepositoryContent{
+			{Type: github.Ptr("file"), Name: github.Ptr("README.md"), Path: github.Ptr("README.md"), Content: github.Ptr("readable")},
+			{Type: github.Ptr("file"), Name: github.Ptr("SECURITY.md"), Path: github.Ptr("SECURITY.md"), Content: github.Ptr("large"), Encoding: github.Ptr("none")},
+		},
+	})
+
+	files, err := rest.GetDocumentationFiles()
+	require.Error(t, err)
+	assert.Equal(t, []DocumentationFile{{Path: "README.md", Content: "readable"}}, files)
+}
+
+func TestGetDocumentationFilesRequiresObservedRoot(t *testing.T) {
+	files, err := (&RestData{}).GetDocumentationFiles()
+	assert.Nil(t, files)
+	assert.Error(t, err)
+}
+
+func TestPayloadCachesDocumentationFiles(t *testing.T) {
+	payload := NewPayloadWithRepoContents(Payload{}, []*github.RepositoryContent{
+		{Type: github.Ptr("file"), Name: github.Ptr("README.md"), Path: github.Ptr("README.md"), Content: github.Ptr("first")},
+	}, nil)
+
+	files, err := payload.GetDocumentationFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	payload.contents.Content[0].Content = github.Ptr("changed after first read")
+	files, err = payload.GetDocumentationFiles()
+	require.NoError(t, err)
+	assert.Equal(t, "first", files[0].Content)
+}
+
+func TestGetDocumentationFilesBoundsInspection(t *testing.T) {
+	entries := make([]*github.RepositoryContent, 101)
+	for i := range entries {
+		name := fmt.Sprintf("doc-%03d.md", i)
+		entries[i] = &github.RepositoryContent{
+			Type:    github.Ptr("file"),
+			Name:    github.Ptr(name),
+			Path:    github.Ptr(name),
+			Content: github.Ptr("policy"),
+		}
+	}
+	rest := NewRestDataWithContents(RepoContent{Content: entries})
+
+	files, err := rest.GetDocumentationFiles()
+	require.Error(t, err)
+	assert.Len(t, files, 100)
+	assert.Contains(t, err.Error(), "inspection limit")
+}

--- a/data/payload.go
+++ b/data/payload.go
@@ -53,7 +53,10 @@ type BinaryAnalysis struct {
 type payloadCache struct {
 	workflows []WorkflowFile
 	// set once workflows have been fetched, so an empty result is not refetched
-	workflowsLoaded bool
+	workflowsLoaded     bool
+	documentation       []DocumentationFile
+	documentationErr    error
+	documentationLoaded bool
 }
 
 // AddEvidence, GetEvidence, and ClearEvidence implement gemara.HasEvidence.
@@ -231,6 +234,7 @@ func (p *Payload) GetWorkflowFiles() ([]WorkflowFile, error) {
 	if p.GraphqlRepoData == nil || p.Config == nil || p.cache == nil {
 		return nil, fmt.Errorf("payload missing required repository data")
 	}
+
 	if p.cache.workflowsLoaded {
 		return p.cache.workflows, nil
 	}
@@ -241,4 +245,24 @@ func (p *Payload) GetWorkflowFiles() ([]WorkflowFile, error) {
 	p.cache.workflows = files
 	p.cache.workflowsLoaded = true
 	return files, nil
+}
+
+// GetDocumentationFiles returns repository documentation once per payload.
+// VM-05 has three controls that inspect the same documents, so caching avoids
+// repeating a potentially large sequence of GitHub content requests. Unlike
+// GetWorkflowFiles, errors are cached deliberately: the walk is expensive and
+// returns whatever partial files it gathered alongside the error, so all three
+// controls observe the same partial evidence rather than re-running the walk.
+func (p *Payload) GetDocumentationFiles() ([]DocumentationFile, error) {
+	if p.RestData == nil || p.cache == nil {
+		return nil, fmt.Errorf("payload missing required repository data")
+	}
+	if p.cache.documentationLoaded {
+		return p.cache.documentation, p.cache.documentationErr
+	}
+	files, err := p.RestData.GetDocumentationFiles()
+	p.cache.documentation = files
+	p.cache.documentationErr = err
+	p.cache.documentationLoaded = true
+	return files, err
 }

--- a/data/repository_metadata.go
+++ b/data/repository_metadata.go
@@ -29,6 +29,13 @@ type GitHubRepositoryMetadata struct {
 	ghOrg              *github.Organization
 }
 
+// RequiredStatusCheck retains the optional GitHub App pin attached to a
+// ruleset check. A matching context produced by another app is not equivalent.
+type RequiredStatusCheck struct {
+	Context       string
+	IntegrationID *int64
+}
+
 func (r *GitHubRepositoryMetadata) IsActive() bool {
 	return !r.ghRepo.GetArchived() && !r.ghRepo.GetDisabled()
 }
@@ -88,6 +95,7 @@ func (r *GitHubRepositoryMetadata) RequiredStatusCheckContexts() []string {
 	if r.defaultBranchRules == nil {
 		return nil
 	}
+
 	var contexts []string
 	for _, rule := range r.defaultBranchRules.RequiredStatusChecks {
 		if rule == nil {
@@ -100,6 +108,28 @@ func (r *GitHubRepositoryMetadata) RequiredStatusCheckContexts() []string {
 		}
 	}
 	return contexts
+}
+
+// RequiredStatusChecks returns ruleset checks without discarding producer pins.
+func (r *GitHubRepositoryMetadata) RequiredStatusChecks() []RequiredStatusCheck {
+	if r.defaultBranchRules == nil {
+		return nil
+	}
+	var checks []RequiredStatusCheck
+	for _, rule := range r.defaultBranchRules.RequiredStatusChecks {
+		if rule == nil {
+			continue
+		}
+		for _, check := range rule.Parameters.RequiredStatusChecks {
+			if check != nil {
+				checks = append(checks, RequiredStatusCheck{
+					Context:       check.Context,
+					IntegrationID: check.IntegrationID,
+				})
+			}
+		}
+	}
+	return checks
 }
 
 // RulesetsObserved reports whether the ruleset lookup for the default branch

--- a/data/repository_metadata_test.go
+++ b/data/repository_metadata_test.go
@@ -99,6 +99,25 @@ func TestRequiredStatusCheckContexts(t *testing.T) {
 	}
 }
 
+func TestRequiredStatusChecksPreservesIntegrationID(t *testing.T) {
+	integrationID := int64(12345)
+	metadata := &GitHubRepositoryMetadata{defaultBranchRules: &github.BranchRules{
+		RequiredStatusChecks: []*github.RequiredStatusChecksBranchRule{{
+			Parameters: github.RequiredStatusChecksRuleParameters{
+				RequiredStatusChecks: []*github.RuleStatusCheck{{
+					Context:       "Dependency Audit",
+					IntegrationID: &integrationID,
+				}},
+			},
+		}},
+	}}
+
+	assert.Equal(t, []RequiredStatusCheck{{
+		Context:       "Dependency Audit",
+		IntegrationID: &integrationID,
+	}}, metadata.RequiredStatusChecks())
+}
+
 func TestRulesetsObserved(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -43,6 +43,7 @@ type RestData struct {
 	Releases                    []ReleaseData
 	ReleasesError               error `json:"-" yaml:"-"`
 	contents                    RepoContent
+	contentsObserved            bool
 	ghClient                    *github.Client `json:"-" yaml:"-"`
 	HttpClient                  HttpClient     `json:"-" yaml:"-"`
 }
@@ -435,6 +436,7 @@ func (r *RestData) getRepoContents() {
 		r.Config.Logger.Error(fmt.Sprintf("failed to retrieve top-level repo contents via GitHub API: %s", err.Error()))
 		return
 	}
+	r.contentsObserved = true
 	r.contents.Content = content
 	if len(r.contents.Content) == 0 {
 		r.Config.Logger.Error("no contents found at the top level of the repository")

--- a/data/rest_data_mock.go
+++ b/data/rest_data_mock.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/google/go-github/v74/github"
+	"github.com/privateerproj/privateer-sdk/config"
 )
 
 type ClientMock struct {
@@ -42,7 +43,7 @@ func (c *ClientMock) Do(req *http.Request) (*http.Response, error) {
 // cache instead of making an API call. Security Insights is initialized to its
 // empty-but-non-nil shape, matching the state Setup leaves it in.
 func NewRestDataWithContents(contents RepoContent) *RestData {
-	r := &RestData{contents: contents}
+	r := &RestData{contents: contents, contentsObserved: true}
 	r.ensureInsightsInitialized()
 	return r
 }
@@ -66,6 +67,32 @@ func NewPayloadWithHTTPMock(base Payload, body []byte, statusCode int, httpErr e
 	return base
 }
 
+// NewPayloadWithWorkflowCache builds a Payload whose workflow cache is
+// pre-seeded with the given files, so that other packages' tests can exercise
+// workflow-content checks (via GetWorkflowFiles) without a live GitHub client.
+// The cache is marked loaded so GetWorkflowFiles returns files as-is, even when
+// empty, without attempting a fetch.
+func NewPayloadWithWorkflowCache(base Payload, files []WorkflowFile) Payload {
+	if base.RestData == nil {
+		base.RestData = &RestData{}
+	}
+	// GetWorkflowFiles requires these to be non-nil before it will read the
+	// cache, so seed empty defaults when the caller left them unset.
+	if base.GraphqlRepoData == nil {
+		base.GraphqlRepoData = &GraphqlRepoData{}
+	}
+	if base.Config == nil {
+		base.Config = &config.Config{}
+	}
+	if base.cache == nil {
+		base.cache = &payloadCache{}
+	}
+	base.cache.workflows = files
+	base.cache.workflowsLoaded = true
+	base.ensureInsightsInitialized()
+	return base
+}
+
 // NewPayloadWithRepoContents builds a Payload whose RestData is backed by the
 // given root and subdirectory listings, so that other packages' tests can
 // exercise contents-based fallbacks (checkFile, FindFile, FindFileInDirs)
@@ -80,6 +107,10 @@ func NewPayloadWithRepoContents(base Payload, root []*github.RepositoryContent, 
 		sub[dir] = RepoContent{Content: entries}
 	}
 	base.contents = RepoContent{Content: root, SubContent: sub}
+	base.contentsObserved = true
+	if base.cache == nil {
+		base.cache = &payloadCache{}
+	}
 	base.ensureInsightsInitialized()
 	return base
 }

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -218,13 +218,16 @@ var (
 			vuln_management.HasVexDocument,
 		},
 		"OSPS-VM-05.01": {
-			reusable_steps.NotImplemented,
+			reusable_steps.IsActive,
+			vuln_management.HasSCARemediationThresholdPolicy,
 		},
 		"OSPS-VM-05.03": {
-			reusable_steps.NotImplemented,
+			reusable_steps.IsActive,
+			vuln_management.EnforcesSCAOnChanges,
 		},
 		"OSPS-VM-05.02": {
-			reusable_steps.NotImplemented,
+			reusable_steps.IsActive,
+			vuln_management.HasSCAReleasePolicy,
 		},
 		"OSPS-VM-06.01": {
 			reusable_steps.HasDependencyManagementPolicy,

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -1,6 +1,7 @@
 package vuln_management
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -758,4 +759,986 @@ func HasVexDocument(payload data.Payload) (result gemara.Result, message string,
 	}
 
 	return gemara.NeedsReview, "No VEX document was found in the repository; confirm manually whether non-affecting vulnerabilities are accounted for in a VEX document", gemara.Low
+}
+
+var (
+	scaAcronymPattern             = regexp.MustCompile(`(?:^|[^0-9a-z])sca(?:[^0-9a-z]|$)`)
+	policyNegationPattern         = regexp.MustCompile(`\b(?:do(?:es)? not|not required|need not|no requirement|optional|informational only)\b`)
+	policyObligationPattern       = regexp.MustCompile(`\b(?:must|shall|required|requires|will block|is blocked|are blocked)\b`)
+	vulnerabilityPattern          = regexp.MustCompile(`\bvulnerabilit(?:y|ies)\b`)
+	licensePattern                = regexp.MustCompile(`\blicen[cs](?:e|es|ing)\b`)
+	vulnerabilityThresholdPattern = regexp.MustCompile(`(?:\b(?:critical|high|medium|moderate|low)\b|\bcvss\b\s*(?:score\s*)?(?:>=|>|at least)\s*[0-9]+(?:\.[0-9]+)?|\bwithin\s+[0-9]+\s+(?:hour|day|week|month)s?\b)`)
+	licenseThresholdPattern       = regexp.MustCompile(`\b(?:denied|disallowed|forbidden|prohibited|incompatible|unapproved|allowlisted|approved)\b`)
+	remediationPattern            = regexp.MustCompile(`\b(?:address(?:ed)?|remediat(?:e|ed)|resolv(?:e|ed)|fix(?:ed)?|remove(?:d)?|replace(?:d)?|reject(?:ed)?|block(?:ed)?)\b`)
+	preReleasePattern             = regexp.MustCompile(`\b(?:before|prior to)\s+(?:any\s+|each\s+|a\s+)?(?:release|publication|publishing|deployment)\b`)
+	releaseBlockedPattern         = regexp.MustCompile(`\b(?:release|publication|publishing|deployment)\b.{0,80}\b(?:block(?:ed)?|prevent(?:ed)?|prohibit(?:ed)?|not permitted)\b|\bblock(?:ed)?\b.{0,80}\buntil\b.{0,80}\b(?:address(?:ed)?|remediat(?:ed)?|resolv(?:ed)?|fix(?:ed)?)\b`)
+	allChangesPattern             = regexp.MustCompile(`\b(?:all|every)\s+(?:code\s+)?changes?\b|\bpull requests?\b|\bbefore merg(?:e|ing)\b`)
+	knownVulnerabilityPattern     = regexp.MustCompile(`\bknown vulnerabilit(?:y|ies)\b`)
+	maliciousDependencyPattern    = regexp.MustCompile(`\bmalicious\b.{0,40}\b(?:dependencies|dependency|packages?|components?)\b|\b(?:dependencies|dependency|packages?|components?)\b.{0,40}\bmalicious\b`)
+	mergeBlockingPattern          = regexp.MustCompile(`\b(?:block|reject|prevent|prohibit)(?:s|ed|ing)?\b.{0,80}\b(?:merg(?:e|ing)|change|pull request|violation)\b|\b(?:merg(?:e|ing)|change|pull request|violation)\b.{0,80}\b(?:block|reject|prevent|prohibit)(?:s|ed|ing)?\b|\bmust pass\b`)
+	nonExploitablePattern         = regexp.MustCompile(`\b(?:non[- ]exploitable|not exploitable|not affected)\b`)
+	exceptionPattern              = regexp.MustCompile(`\b(?:declar(?:e|ed)|suppress(?:ed|ion)?|waiv(?:e|ed|er)|exception|justif(?:y|ied|ication))\b`)
+	scopeNegationPattern          = regexp.MustCompile(`\b(?:not all|not every|only some|only selected)\s+(?:code\s+)?changes?\b`)
+	negatedRemediationPattern     = regexp.MustCompile(`\bnot\s+(?:be\s+)?(?:address(?:ed)?|remediat(?:e|ed)?|resolv(?:e|ed)?|fix(?:ed)?|remov(?:e|ed)?|replac(?:e|ed)?|reject(?:ed)?|block(?:ed)?)\b`)
+	sentenceSplitPattern          = regexp.MustCompile(`[.!?;]+(?:\s+|$)`)
+	htmlCommentPattern            = regexp.MustCompile(`(?s)<!--.*?-->`)
+)
+
+var scaToolKeywords = []string{"software composition", "dependency scanning", "dependency analysis", "composition analysis"}
+
+type scaIdentifier struct {
+	needle                string
+	id                    string
+	coversVulnerabilities bool
+	coversMalicious       bool
+}
+
+// License-only products are deliberately absent. In particular, Licensee and
+// FOSSA evidence cannot establish evaluation for vulnerabilities or malicious
+// dependencies.
+var scaActionIdentifiers = []scaIdentifier{
+	{"actions/dependency-review-action", "dependency-review", true, true},
+	{"google/osv-scanner-action", "osv-scanner", true, false},
+	{"google/osv-scanner-action/osv-scanner-action", "osv-scanner", true, false},
+	{"aquasecurity/trivy-action", "trivy", true, false},
+	{"anchore/scan-action", "grype", true, false},
+	{"snyk/actions/node", "snyk", true, false},
+	{"snyk/actions/python", "snyk", true, false},
+	{"snyk/actions/golang", "snyk", true, false},
+	{"snyk/actions/docker", "snyk", true, false},
+	{"dependency-check/dependency-check-action", "dependency-check", true, false},
+}
+
+var scaCommandIdentifiers = []scaIdentifier{
+	{"osv-scanner", "osv-scanner", true, false},
+	{"trivy", "trivy", true, false},
+	{"grype", "grype", true, false},
+	{"snyk", "snyk", true, false},
+	{"dependency-check", "dependency-check", true, false},
+	{"pip-audit", "pip-audit", true, false},
+	{"govulncheck", "govulncheck", true, false},
+	{"nancy", "nancy", true, false},
+	{"cargo audit", "cargo-audit", true, false},
+	{"npm audit", "npm-audit", true, false},
+}
+
+type scaSource struct {
+	name                  string
+	toolID                string
+	workflowContext       bool
+	policyDocumented      bool
+	exceptionDocumented   bool
+	coversVulnerabilities bool
+	coversMalicious       bool
+}
+
+type scaDetection struct {
+	sources             []scaSource
+	inspectionBlocked   bool
+	coverageProven      bool
+	scannerSignal       bool
+	nonBlockingObserved bool
+}
+
+type scaRepositoryPolicy struct {
+	documented          bool
+	exceptionDocumented bool
+	path                string
+}
+
+func looksLikeSCA(value string) bool {
+	value = strings.ToLower(value)
+	if scaAcronymPattern.MatchString(value) {
+		return true
+	}
+	for _, keyword := range scaToolKeywords {
+		if strings.Contains(value, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+func isLicenseOnlyTool(value string) bool {
+	value = strings.ToLower(value)
+	return strings.Contains(value, "licensee") || strings.Contains(value, "fossa") ||
+		strings.Contains(value, "license-only") || strings.Contains(value, "license only")
+}
+
+func matchSCAAction(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if isLicenseOnlyTool(value) {
+		return ""
+	}
+	if at := strings.Index(value, "@"); at >= 0 {
+		value = value[:at]
+	}
+	for _, candidate := range scaActionIdentifiers {
+		if value == candidate.needle {
+			return candidate.id
+		}
+	}
+	return ""
+}
+
+func validSCACommand(candidate, command string) bool {
+	args := strings.TrimSpace(strings.TrimPrefix(command, candidate))
+	if strings.HasPrefix(args, "--version") || strings.HasPrefix(args, "-version") ||
+		strings.HasPrefix(args, "--help") || strings.HasPrefix(args, "-h") {
+		return false
+	}
+	switch candidate {
+	case "osv-scanner":
+		return strings.HasPrefix(args, "scan ") || args == "scan"
+	case "trivy":
+		for _, target := range []string{"fs", "repo", "image", "rootfs", "sbom"} {
+			if args == target || strings.HasPrefix(args, target+" ") {
+				return true
+			}
+		}
+		return false
+	case "snyk":
+		return args == "test" || strings.HasPrefix(args, "test ")
+	case "nancy":
+		return args == "sleuth" || strings.HasPrefix(args, "sleuth ")
+	case "govulncheck", "grype":
+		return args != "" && !strings.HasPrefix(args, "-")
+	default:
+		return true
+	}
+}
+
+func matchSCACommand(script string) string {
+	for _, segment := range commandSeparatorPattern.Split(script, -1) {
+		command := normalizeCommand(segment)
+		for _, candidate := range scaCommandIdentifiers {
+			if (command == candidate.needle || strings.HasPrefix(command, candidate.needle+" ")) &&
+				validSCACommand(candidate.needle, command) {
+				return candidate.id
+			}
+		}
+	}
+
+	return ""
+}
+
+func scaToolCapabilities(toolID string) (vulnerabilities bool, malicious bool) {
+	for _, candidate := range append(scaActionIdentifiers, scaCommandIdentifiers...) {
+		if candidate.id == toolID {
+			vulnerabilities = vulnerabilities || candidate.coversVulnerabilities
+			malicious = malicious || candidate.coversMalicious
+		}
+	}
+	return
+}
+
+func scaToolInInsights(payload data.Payload) *si.SecurityTool {
+	if payload.RestData == nil || payload.Insights.Repository == nil {
+		return nil
+	}
+	for i := range payload.Insights.Repository.SecurityPosture.Tools {
+		tool := &payload.Insights.Repository.SecurityPosture.Tools[i]
+		if !isLicenseOnlyTool(tool.Type+" "+tool.Name) && looksLikeSCA(tool.Type+" "+tool.Name) {
+			return tool
+		}
+	}
+	return nil
+}
+
+func canonicalSCAToolID(value string) string {
+	if id := matchSCAAction(value); id != "" {
+		return id
+	}
+	lower := strings.ToLower(strings.TrimSpace(value))
+	for _, candidate := range scaCommandIdentifiers {
+		if strings.Contains(lower, candidate.needle) {
+			return candidate.id
+		}
+	}
+	if looksLikeSCA(lower) {
+		return lower
+	}
+	return ""
+}
+
+func detectSCAToolsInInsights(tools []si.SecurityTool) scaDetection {
+	var detection scaDetection
+	for _, tool := range tools {
+		if !tool.Integration.Ci || isLicenseOnlyTool(tool.Type+" "+tool.Name) ||
+			!looksLikeSCA(tool.Type+" "+tool.Name) {
+			continue
+		}
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			name = "SCA"
+		}
+		detection.scannerSignal = true
+		toolID := canonicalSCAToolID(name)
+		coversVulnerabilities, coversMalicious := scaToolCapabilities(toolID)
+		detection.sources = append(detection.sources, scaSource{
+			name:                  name,
+			toolID:                toolID,
+			policyDocumented:      len(tool.Rulesets) > 0,
+			coversVulnerabilities: coversVulnerabilities,
+			coversMalicious:       coversMalicious,
+		})
+	}
+	return detection
+}
+
+func normalizeCondition(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if strings.HasPrefix(value, "${{") && strings.HasSuffix(value, "}}") {
+		value = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "${{"), "}}"))
+	}
+	return value
+}
+
+func conditionState(condition *actionlint.String) (enabled bool, uncertain bool) {
+	if condition == nil {
+		return true, false
+	}
+	switch normalizeCondition(condition.Value) {
+	case "true":
+		return true, false
+	case "false":
+		return false, false
+	default:
+		return false, true
+	}
+}
+
+func continueOnErrorState(value *actionlint.Bool) (suppressed bool, uncertain bool) {
+	if value == nil {
+		return false, false
+	}
+	if value.Expression != nil {
+		return false, true
+	}
+	return value.Value, false
+}
+
+func shellSuppressesFailure(script string) bool {
+	lowerScript := strings.ToLower(script)
+	if strings.Contains(lowerScript, "set +e") {
+		return true
+	}
+	for _, line := range strings.Split(script, "\n") {
+		if matchSCACommand(line) == "" {
+			continue
+		}
+		lower := strings.ToLower(strings.TrimSpace(line))
+		if strings.Contains(lower, "||") || strings.Contains(lower, "; exit 0") ||
+			strings.HasPrefix(lower, "if ") || strings.HasPrefix(lower, "! ") {
+			return true
+		}
+	}
+	return false
+}
+
+func stepSCAInvocation(step *actionlint.Step) (toolID string, shellSuppressed bool) {
+	if step == nil {
+		return "", false
+	}
+	switch exec := step.Exec.(type) {
+	case *actionlint.ExecAction:
+		if exec.Uses != nil {
+			return matchSCAAction(exec.Uses.Value), false
+		}
+	case *actionlint.ExecRun:
+		if exec.Run != nil {
+			return matchSCACommand(exec.Run.Value), shellSuppressesFailure(exec.Run.Value)
+		}
+	}
+	return "", false
+}
+
+func jobCheckContext(job *actionlint.Job) (string, bool) {
+	if job == nil {
+		return "", false
+	}
+	context := ""
+	if job.Name != nil {
+		context = strings.TrimSpace(job.Name.Value)
+	}
+	if context == "" && job.ID != nil {
+		context = strings.TrimSpace(job.ID.Value)
+	}
+	if context == "" || strings.Contains(context, "${{") {
+		return "", false
+	}
+	return context, true
+}
+
+func inspectDirectSCAJob(job *actionlint.Job) (toolIDs []string, blocked bool, nonBlocking bool, signal bool) {
+	for _, step := range job.Steps {
+		toolID, _ := stepSCAInvocation(step)
+		if toolID != "" {
+			signal = true
+			break
+		}
+	}
+	if !signal {
+		return nil, false, false, false
+	}
+	if len(job.Needs) > 0 {
+		return nil, true, false, true
+	}
+
+	enabled, uncertain := conditionState(job.If)
+	if uncertain {
+		return nil, true, false, true
+	}
+	if !enabled {
+		return nil, false, true, true
+	}
+	suppressed, uncertain := continueOnErrorState(job.ContinueOnError)
+	if uncertain {
+		return nil, true, false, true
+	}
+	if suppressed {
+		return nil, false, true, true
+	}
+
+	for _, step := range job.Steps {
+		toolID, shellSuppressed := stepSCAInvocation(step)
+		if toolID == "" {
+			continue
+		}
+		enabled, uncertain := conditionState(step.If)
+		if uncertain {
+			blocked = true
+			continue
+		}
+		if !enabled {
+			nonBlocking = true
+			continue
+		}
+		suppressed, uncertain := continueOnErrorState(step.ContinueOnError)
+		if uncertain {
+			blocked = true
+			continue
+		}
+		if suppressed || shellSuppressed {
+			nonBlocking = true
+			continue
+		}
+		toolIDs = append(toolIDs, toolID)
+	}
+	return
+}
+
+func detectSCAInWorkflows(files []data.WorkflowFile, defaultBranch string) scaDetection {
+	var detection scaDetection
+	parsed := make(map[string]*actionlint.Workflow)
+	for _, file := range files {
+		if !strings.HasSuffix(file.Name, ".yml") && !strings.HasSuffix(file.Name, ".yaml") {
+			continue
+		}
+		if file.Truncated {
+			detection.inspectionBlocked = true
+			continue
+		}
+		workflow, errs := actionlint.Parse([]byte(file.Content))
+		if workflow == nil {
+			detection.inspectionBlocked = true
+			continue
+		}
+		if len(errs) > 0 {
+			detection.inspectionBlocked = true
+		}
+		parsed[strings.TrimPrefix(file.Path, "./")] = workflow
+	}
+
+	var inspectJob func(*actionlint.Job, map[string]bool) ([]scaSource, bool, bool, bool)
+	inspectJob = func(job *actionlint.Job, visiting map[string]bool) (sources []scaSource, blocked bool, nonBlocking bool, signal bool) {
+		if job == nil {
+			return
+		}
+		if job.WorkflowCall == nil || job.WorkflowCall.Uses == nil {
+			toolIDs, directBlocked, directNonBlocking, directSignal := inspectDirectSCAJob(job)
+			blocked, nonBlocking, signal = directBlocked, directNonBlocking, directSignal
+			if len(toolIDs) == 0 {
+				return
+			}
+			context, known := jobCheckContext(job)
+			if !known {
+				return nil, true, nonBlocking, true
+			}
+			for _, toolID := range toolIDs {
+				coversVulnerabilities, coversMalicious := scaToolCapabilities(toolID)
+				sources = append(sources, scaSource{
+					name:                  context,
+					toolID:                toolID,
+					workflowContext:       true,
+					coversVulnerabilities: coversVulnerabilities,
+					coversMalicious:       coversMalicious,
+				})
+			}
+			return
+		}
+
+		uses := strings.TrimSpace(job.WorkflowCall.Uses.Value)
+		if len(job.Needs) > 0 {
+			return nil, true, false, true
+		}
+		if id := matchSCAAction(uses); id != "" {
+			enabled, conditionUncertain := conditionState(job.If)
+			suppressed, continueUncertain := continueOnErrorState(job.ContinueOnError)
+			if conditionUncertain || continueUncertain {
+				return nil, true, false, true
+			}
+			if !enabled || suppressed {
+				return nil, false, true, true
+			}
+			// A remote reusable workflow can identify the scanner but not the
+			// called job name that GitHub includes in the emitted check context.
+			return nil, true, false, true
+		}
+		if !strings.HasPrefix(uses, "./") {
+			return nil, false, false, false
+		}
+		calledPath := strings.TrimPrefix(uses, "./")
+		if visiting[calledPath] {
+			return nil, true, false, true
+		}
+		called, ok := parsed[calledPath]
+		if !ok {
+			return nil, true, false, true
+		}
+		callerContext, known := jobCheckContext(job)
+		if !known {
+			return nil, true, false, true
+		}
+		visiting[calledPath] = true
+		defer delete(visiting, calledPath)
+		for _, calledJob := range called.Jobs {
+			childSources, childBlocked, childNonBlocking, childSignal := inspectJob(calledJob, visiting)
+			blocked = blocked || childBlocked
+			nonBlocking = nonBlocking || childNonBlocking
+			signal = signal || childSignal
+			for _, source := range childSources {
+				source.name = callerContext + " / " + source.name
+				sources = append(sources, source)
+			}
+		}
+		if !signal {
+			return nil, blocked, nonBlocking, false
+		}
+		enabled, conditionUncertain := conditionState(job.If)
+		suppressed, continueUncertain := continueOnErrorState(job.ContinueOnError)
+		if conditionUncertain || continueUncertain {
+			return nil, true, nonBlocking, true
+		}
+		if !enabled || suppressed {
+			return nil, blocked, true, true
+		}
+		return
+	}
+
+	for filePath, workflow := range parsed {
+		covered, coverageUncertain := workflowCoversChanges(workflow, defaultBranch)
+		for _, job := range workflow.Jobs {
+			sources, blocked, nonBlocking, signal := inspectJob(job, map[string]bool{filePath: true})
+			if !signal {
+				continue
+			}
+			detection.scannerSignal = true
+			detection.nonBlockingObserved = detection.nonBlockingObserved || nonBlocking
+			if blocked || coverageUncertain {
+				detection.inspectionBlocked = true
+			}
+			if !covered {
+				continue
+			}
+			if len(sources) > 0 {
+				detection.coverageProven = true
+				detection.sources = append(detection.sources, sources...)
+			}
+		}
+	}
+	return detection
+}
+
+func associateSCAPolicies(sources []scaSource, repositoryPolicy scaRepositoryPolicy) {
+	documentedTools := make(map[string]bool)
+	for _, source := range sources {
+		if !source.workflowContext && source.toolID != "" && source.policyDocumented {
+			documentedTools[source.toolID] = true
+		}
+	}
+	for i := range sources {
+		if !sources[i].workflowContext {
+			continue
+		}
+		if repositoryPolicy.documented {
+			sources[i].policyDocumented = true
+			sources[i].exceptionDocumented = repositoryPolicy.exceptionDocumented
+			continue
+		}
+		if documentedTools[sources[i].toolID] {
+			sources[i].policyDocumented = true
+		}
+	}
+}
+
+type scaRequiredStatusCheck struct {
+	context       string
+	integrationID *int64
+}
+
+func requiredStatusChecks(payload data.Payload) []scaRequiredStatusCheck {
+	var checks []scaRequiredStatusCheck
+	if payload.RepositoryMetadata != nil {
+		if detailed, ok := payload.RepositoryMetadata.(interface {
+			RequiredStatusChecks() []data.RequiredStatusCheck
+		}); ok {
+			for _, check := range detailed.RequiredStatusChecks() {
+				checks = append(checks, scaRequiredStatusCheck{
+					context:       check.Context,
+					integrationID: check.IntegrationID,
+				})
+			}
+		} else {
+			for _, context := range payload.RepositoryMetadata.RequiredStatusCheckContexts() {
+				checks = append(checks, scaRequiredStatusCheck{context: context})
+			}
+		}
+	}
+	if payload.GraphqlRepoData != nil {
+		for _, context := range payload.Repository.DefaultBranchRef.BranchProtectionRule.RequiredStatusCheckContexts {
+			checks = append(checks, scaRequiredStatusCheck{context: context})
+		}
+	}
+	return checks
+}
+
+func requiredCheckMatchesSCA(required []scaRequiredStatusCheck, sources []scaSource) (
+	matched bool,
+	withPolicy bool,
+	withException bool,
+	withThreatCoverage bool,
+	producerUncertain bool,
+	context string,
+) {
+	for _, requiredCheck := range required {
+		normalizedRequired := strings.ToLower(strings.Join(strings.Fields(requiredCheck.context), " "))
+		if normalizedRequired == "" {
+			continue
+		}
+		for _, source := range sources {
+			if !source.workflowContext ||
+				normalizedRequired != strings.ToLower(strings.Join(strings.Fields(source.name), " ")) {
+				continue
+			}
+			if requiredCheck.integrationID != nil {
+				producerUncertain = true
+				continue
+			}
+			matched = true
+			context = requiredCheck.context
+			withPolicy = withPolicy || source.policyDocumented
+			withException = withException || (source.policyDocumented && source.exceptionDocumented)
+			withThreatCoverage = withThreatCoverage ||
+				(source.coversVulnerabilities && source.coversMalicious)
+		}
+	}
+	return
+}
+
+func hasSCAAction(workflow *actionlint.Workflow) bool {
+	if workflow == nil {
+		return false
+	}
+	for _, job := range workflow.Jobs {
+		if job == nil {
+			continue
+		}
+		if job.WorkflowCall != nil && job.WorkflowCall.Uses != nil {
+			enabled, uncertain := conditionState(job.If)
+			suppressed, continueUncertain := continueOnErrorState(job.ContinueOnError)
+			if enabled && !uncertain && !suppressed && !continueUncertain && matchSCAAction(job.WorkflowCall.Uses.Value) != "" {
+				return true
+			}
+		}
+		tools, _, _, _ := inspectDirectSCAJob(job)
+		if len(tools) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func isReleaseTriggered(workflow *actionlint.Workflow) bool {
+	for _, event := range workflow.On {
+		webhook, ok := event.(*actionlint.WebhookEvent)
+		if !ok {
+			continue
+		}
+		switch webhook.EventName() {
+		case "release":
+			return true
+		case "push":
+			if hasVersionTagFilter(webhook.Tags) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var versionTagPattern = regexp.MustCompile(`^(?:v?[0-9][0-9A-Za-z._*+?\[\]-]*|v\*[0-9A-Za-z._*+?\[\]-]*|\*(?:\.\*)+|v?\[[0-9A-Za-z._*+?\[\]-]*)$`)
+
+func hasVersionTagFilter(tags *actionlint.WebhookEventFilter) bool {
+	if tags.IsEmpty() {
+		return false
+	}
+	for _, value := range tags.Values {
+		if value != nil && versionTagPattern.MatchString(strings.ToLower(value.Value)) {
+			return true
+		}
+	}
+	return false
+}
+
+func releaseScaWorkflow(payload data.Payload) (path string, inspectionBlocked bool, err error) {
+	workflows, err := payload.GetWorkflowFiles()
+	if err != nil {
+		return "", false, err
+	}
+	for _, file := range workflows {
+		if !strings.HasSuffix(file.Name, ".yml") && !strings.HasSuffix(file.Name, ".yaml") {
+			continue
+		}
+		if file.Truncated {
+			inspectionBlocked = true
+			continue
+		}
+		workflow, errs := actionlint.Parse([]byte(file.Content))
+		if workflow == nil {
+			inspectionBlocked = true
+			continue
+		}
+		if len(errs) > 0 {
+			inspectionBlocked = true
+		}
+		if isReleaseTriggered(workflow) && hasSCAAction(workflow) {
+			return file.Path, inspectionBlocked, nil
+		}
+	}
+	return "", inspectionBlocked, nil
+}
+
+func repositoryDocumentation(payload data.Payload) ([]data.DocumentationFile, error) {
+	if payload.RestData == nil {
+		return nil, errors.New("repository documentation is unavailable")
+	}
+	files, err := payload.GetDocumentationFiles()
+	if payload.SecurityPolicy.Present && strings.TrimSpace(payload.SecurityPolicy.Content) != "" {
+		found := false
+		for _, file := range files {
+			if strings.EqualFold(file.Path, "SECURITY.md") || strings.HasSuffix(strings.ToLower(file.Path), "/security.md") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			files = append(files, data.DocumentationFile{Path: "SECURITY.md", Content: payload.SecurityPolicy.Content})
+		}
+	}
+	return files, err
+}
+
+func documentationSections(content string) []string {
+	content = htmlCommentPattern.ReplaceAllString(content, "")
+	var (
+		sections []string
+		current  []string
+		inFence  bool
+	)
+	flush := func() {
+		section := strings.ToLower(strings.Join(strings.Fields(strings.Join(current, "\n")), " "))
+		if strings.TrimSpace(section) != "" {
+			sections = append(sections, section)
+		}
+		current = nil
+	}
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || strings.HasPrefix(trimmed, ">") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			flush()
+		}
+		current = append(current, line)
+	}
+	flush()
+	return sections
+}
+
+func hasSCAContext(section string) bool {
+	return scaAcronymPattern.MatchString(section) ||
+		strings.Contains(section, "software composition analysis") ||
+		strings.Contains(section, "dependency scanning") ||
+		strings.Contains(section, "dependency review")
+}
+
+func policyStatements(section string) []string {
+	var statements []string
+	for _, statement := range sentenceSplitPattern.Split(section, -1) {
+		statement = strings.TrimSpace(statement)
+		if statement != "" {
+			statements = append(statements, statement)
+		}
+	}
+	return statements
+}
+
+func statementNegated(statement string) bool {
+	return policyNegationPattern.MatchString(statement) ||
+		scopeNegationPattern.MatchString(statement) ||
+		negatedRemediationPattern.MatchString(statement)
+}
+
+func hasSCARemediationThreshold(section string) bool {
+	if !hasSCAContext(section) {
+		return false
+	}
+	vulnerabilityThreshold, licenseThreshold := false, false
+	for _, statement := range policyStatements(section) {
+		if statementNegated(statement) || !policyObligationPattern.MatchString(statement) ||
+			!remediationPattern.MatchString(statement) {
+			continue
+		}
+		vulnerabilityThreshold = vulnerabilityThreshold ||
+			(vulnerabilityPattern.MatchString(statement) && vulnerabilityThresholdPattern.MatchString(statement))
+		licenseThreshold = licenseThreshold ||
+			(licensePattern.MatchString(statement) && licenseThresholdPattern.MatchString(statement))
+	}
+	return vulnerabilityThreshold && licenseThreshold
+}
+
+func hasSCAReleaseRequirement(section string) bool {
+	if !hasSCAContext(section) {
+		return false
+	}
+	for _, statement := range policyStatements(section) {
+		if !statementNegated(statement) && hasSCAContext(statement) &&
+			policyObligationPattern.MatchString(statement) &&
+			remediationPattern.MatchString(statement) &&
+			(preReleasePattern.MatchString(statement) || releaseBlockedPattern.MatchString(statement)) {
+			return true
+		}
+	}
+	return false
+}
+
+func scaEnforcementPolicy(section string) (documented bool, exceptionDocumented bool) {
+	if !hasSCAContext(section) {
+		return false, false
+	}
+	coverage, blocking := false, false
+	for _, statement := range policyStatements(section) {
+		if statementNegated(statement) {
+			continue
+		}
+		coverage = coverage || (hasSCAContext(statement) &&
+			knownVulnerabilityPattern.MatchString(statement) &&
+			maliciousDependencyPattern.MatchString(statement) &&
+			allChangesPattern.MatchString(statement) &&
+			policyObligationPattern.MatchString(statement))
+		blocking = blocking || (policyObligationPattern.MatchString(statement) &&
+			mergeBlockingPattern.MatchString(statement))
+		exceptionDocumented = exceptionDocumented ||
+			(nonExploitablePattern.MatchString(statement) && exceptionPattern.MatchString(statement))
+	}
+	return coverage && blocking, exceptionDocumented
+}
+
+// sectionContainsPolicyDisclaimer reports whether any statement in the section
+// negates or qualifies a policy (e.g. "optional", "not required", "not fixed",
+// "not all changes"). A matched obligation that shares a section with such a
+// disclaimer is treated as contradictory and downgraded to NeedsReview instead
+// of being trusted as a definitive Passed, since a nearby disclaimer can gut
+// the obligation.
+func sectionContainsPolicyDisclaimer(section string) bool {
+	for _, statement := range policyStatements(section) {
+		if statementNegated(statement) {
+			return true
+		}
+	}
+	return false
+}
+
+func findDocumentationPolicy(files []data.DocumentationFile, matcher func(string) bool) (path string, contradicted bool) {
+	for _, file := range files {
+		for _, section := range documentationSections(file.Content) {
+			if matcher(section) {
+				return file.Path, sectionContainsPolicyDisclaimer(section)
+			}
+		}
+	}
+	return "", false
+}
+
+func findSCARepositoryPolicy(files []data.DocumentationFile) scaRepositoryPolicy {
+	var policy scaRepositoryPolicy
+	for _, file := range files {
+		for _, section := range documentationSections(file.Content) {
+			documented, exceptionDocumented := scaEnforcementPolicy(section)
+			if !documented {
+				continue
+			}
+			policy.documented = true
+			policy.exceptionDocumented = policy.exceptionDocumented || exceptionDocumented
+			if policy.path == "" {
+				policy.path = file.Path
+			}
+		}
+	}
+	return policy
+}
+
+// HasSCARemediationThresholdPolicy evaluates OSPS-VM-05.01 using the text of
+// repository documentation. Security Insights pointers and dependency tooling
+// are signals only because neither exposes the required threshold language.
+func HasSCARemediationThresholdPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	files, docsErr := repositoryDocumentation(payload)
+	if path, contradicted := findDocumentationPolicy(files, hasSCARemediationThreshold); path != "" {
+		if contradicted {
+			return gemara.NeedsReview, "Repository documentation references SCA remediation thresholds, but the same section contains contradictory or optional language; confirm the policy manually (" + path + ")", gemara.Medium
+		}
+		return gemara.Passed, "Repository documentation defines remediation thresholds for vulnerable dependencies and unacceptable licenses (" + path + ")", gemara.High
+	}
+
+	hasDepPolicy := payload.RestData != nil && payload.Insights.Repository != nil &&
+		payload.Insights.Repository.Documentation != nil &&
+		payload.Insights.Repository.Documentation.DependencyManagementPolicy != nil
+	if docsErr != nil || (payload.RestData != nil && payload.InsightsError) {
+		return gemara.NeedsReview, "Repository documentation or Security Insights could not be completely inspected; confirm an SCA remediation threshold covering vulnerabilities and licenses", gemara.Low
+	}
+	if hasDepPolicy {
+		return gemara.NeedsReview, "A dependency-management policy is declared in Security Insights, but its contents do not machine-verifiably define remediation thresholds for vulnerabilities and licenses", gemara.Medium
+	}
+	if payload.RestData != nil {
+		if configPath := payload.DependencyToolingConfig(); configPath != "" {
+			return gemara.NeedsReview, "Dependency tooling was found (" + configPath + "), but no substantive SCA remediation threshold was found in repository documentation", gemara.Medium
+		}
+	}
+	return gemara.Failed, "Repository documentation was completely inspected and no SCA remediation threshold covering vulnerabilities and licenses was found", gemara.Medium
+}
+
+// HasSCAReleasePolicy evaluates OSPS-VM-05.02 using explicit repository policy
+// language. Tool and workflow integrations remain NeedsReview signals because
+// they do not themselves state that violations must be resolved before release.
+func HasSCAReleasePolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	files, docsErr := repositoryDocumentation(payload)
+	if path, contradicted := findDocumentationPolicy(files, hasSCAReleaseRequirement); path != "" {
+		if contradicted {
+			return gemara.NeedsReview, "Repository documentation references addressing SCA violations before release, but the same section contains contradictory or optional language; confirm the policy manually (" + path + ")", gemara.Medium
+		}
+		return gemara.Passed, "Repository documentation requires SCA violations to be addressed before release (" + path + ")", gemara.High
+	}
+
+	hasDepPolicy := payload.RestData != nil && payload.Insights.Repository != nil &&
+		payload.Insights.Repository.Documentation != nil &&
+		payload.Insights.Repository.Documentation.DependencyManagementPolicy != nil
+	hasReleaseProcess := payload.RestData != nil && payload.Insights.Project != nil &&
+		payload.Insights.Project.Documentation != nil &&
+		payload.Insights.Project.Documentation.ReleaseProcess != nil
+	tool := scaToolInInsights(payload)
+	workflowPath, workflowBlocked, workflowErr := releaseScaWorkflow(payload)
+	if docsErr != nil || workflowErr != nil || workflowBlocked ||
+		(payload.RestData != nil && payload.InsightsError) {
+		return gemara.NeedsReview, "Repository documentation, Security Insights, or release workflows could not be completely inspected; confirm SCA violations must be addressed before release", gemara.Low
+	}
+	if hasDepPolicy || hasReleaseProcess || (tool != nil && tool.Integration.Release) || workflowPath != "" {
+		return gemara.NeedsReview, "Release or SCA process signals were found, but repository documentation does not machine-verifiably require SCA violations to be addressed before release", gemara.Medium
+	}
+	return gemara.Failed, "Repository documentation and release workflows were completely inspected and no policy requiring SCA violations to be addressed before release was found", gemara.Medium
+}
+
+// EnforcesSCAOnChanges evaluates OSPS-VM-05.03 end to end: a vulnerability or
+// malicious-dependency scanner must actively cover changes, its actual workflow
+// check context must exactly match a required check, and a documented policy
+// (including the non-exploitable-finding exception) must govern that gate.
+func EnforcesSCAOnChanges(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	var detection scaDetection
+	if payload.RestData != nil && payload.Insights.Repository != nil {
+		insights := detectSCAToolsInInsights(payload.Insights.Repository.SecurityPosture.Tools)
+		detection.sources = append(detection.sources, insights.sources...)
+		detection.scannerSignal = insights.scannerSignal
+	}
+
+	workflows, workflowErr := payload.GetWorkflowFiles()
+	if workflowErr != nil {
+		detection.inspectionBlocked = true
+	} else {
+		defaultBranch := ""
+		if payload.GraphqlRepoData != nil {
+			defaultBranch = payload.Repository.DefaultBranchRef.Name
+		}
+		workflowDetection := detectSCAInWorkflows(workflows, defaultBranch)
+		detection.sources = append(detection.sources, workflowDetection.sources...)
+		detection.inspectionBlocked = detection.inspectionBlocked || workflowDetection.inspectionBlocked
+		detection.coverageProven = workflowDetection.coverageProven
+		detection.scannerSignal = detection.scannerSignal || workflowDetection.scannerSignal
+		detection.nonBlockingObserved = workflowDetection.nonBlockingObserved
+	}
+
+	files, docsErr := repositoryDocumentation(payload)
+	repositoryPolicy := findSCARepositoryPolicy(files)
+	if docsErr != nil || (payload.RestData != nil && payload.InsightsError) {
+		detection.inspectionBlocked = true
+	}
+	associateSCAPolicies(detection.sources, repositoryPolicy)
+
+	required := requiredStatusChecks(payload)
+	matched, withPolicy, withException, withThreatCoverage, producerUncertain, context :=
+		requiredCheckMatchesSCA(required, detection.sources)
+	if matched {
+		if !withThreatCoverage {
+			return gemara.NeedsReview, "An all-change SCA workflow is required as " + context + ", but the detected scanner was not verified to cover both known vulnerabilities and malicious dependencies", gemara.Medium
+		}
+		if !withPolicy {
+			return gemara.NeedsReview, "An all-change SCA workflow is exactly required as " + context + ", but no documented SCA ruleset or repository policy was verified", gemara.Medium
+		}
+		if !withException {
+			return gemara.NeedsReview, "An all-change SCA workflow and documented policy are enforced by " + context + ", but the policy exception for declared non-exploitable findings could not be mechanically verified", gemara.Medium
+		}
+		return gemara.Passed, "An active SCA workflow covers all changes, exactly matches required check " + context + ", and enforces a documented policy including declared non-exploitable findings", gemara.High
+	}
+	if producerUncertain {
+		return gemara.NeedsReview, "An SCA workflow context matches a required ruleset check, but that check is pinned to a GitHub App whose identity could not be correlated to the workflow producer", gemara.Medium
+	}
+
+	if detection.inspectionBlocked && !detection.coverageProven {
+		return gemara.NeedsReview, "Workflow, documentation, or Security Insights inspection was incomplete, so end-to-end SCA enforcement could not be determined", gemara.Low
+	}
+	if detection.nonBlockingObserved {
+		return gemara.NeedsReview, "An SCA scanner is present but is disabled or allowed to succeed after scanner failure; confirm violations actually block changes", gemara.Medium
+	}
+	if detection.coverageProven {
+		if len(required) > 0 {
+			return gemara.NeedsReview, "An active SCA workflow covers changes, but none of its emitted job contexts exactly matches a required status check", gemara.Medium
+		}
+		if payload.RepositoryMetadata != nil && payload.RepositoryMetadata.ViewerCanAdminister() {
+			return gemara.Failed, "An active SCA workflow covers changes but its emitted job context is not required on the default branch", gemara.High
+		}
+		return gemara.NeedsReview, "An active SCA workflow covers changes, but default-branch required checks are not observable with the current token", gemara.Low
+	}
+	if detection.scannerSignal {
+		return gemara.NeedsReview, "SCA tooling was observed, but all-change coverage, active failure behavior, and exact required-check enforcement were not all verified", gemara.Medium
+	}
+	if payload.RestData != nil {
+		if configPath := payload.DependencyToolingConfig(); configPath != "" {
+			return gemara.NeedsReview, "Dependency tooling was found (" + configPath + "), but it does not prove merge-blocking SCA evaluation of every change", gemara.Low
+		}
+	}
+	return gemara.Failed, "Complete workflow and policy inspection found no vulnerability or malicious-dependency scanner enforcing all changes", gemara.Medium
 }

--- a/evaluation_plans/osps/vuln_management/vm_05_test.go
+++ b/evaluation_plans/osps/vuln_management/vm_05_test.go
@@ -1,0 +1,672 @@
+package vuln_management
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/google/go-github/v74/github"
+	"github.com/ossf/si-tooling/v2/si"
+	"github.com/rhysd/actionlint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ossf/pvtr-github-repo-scanner/data"
+)
+
+type fakeRequiredChecksMetadata struct {
+	data.RepositoryMetadata
+	requiredChecks []string
+	admin          bool
+}
+
+func (f *fakeRequiredChecksMetadata) RequiredStatusCheckContexts() []string {
+	return f.requiredChecks
+}
+
+func (f *fakeRequiredChecksMetadata) ViewerCanAdminister() bool { return f.admin }
+
+type fakePinnedRequiredCheckMetadata struct {
+	*fakeRequiredChecksMetadata
+	checks []data.RequiredStatusCheck
+}
+
+func (f *fakePinnedRequiredCheckMetadata) RequiredStatusChecks() []data.RequiredStatusCheck {
+	return f.checks
+}
+
+func yml(name, content string) data.WorkflowFile {
+	return data.WorkflowFile{Name: name, Path: ".github/workflows/" + name, Content: content}
+}
+
+func repositoryFile(name, filePath, content string) *github.RepositoryContent {
+	return &github.RepositoryContent{
+		Type:    github.Ptr("file"),
+		Name:    github.Ptr(name),
+		Path:    github.Ptr(filePath),
+		Content: github.Ptr(content),
+	}
+}
+
+func documentationPayload(filePath, content string) data.Payload {
+	name := filePath
+	if slash := strings.LastIndex(filePath, "/"); slash >= 0 {
+		name = filePath[slash+1:]
+	}
+	if slash := strings.Index(filePath, "/"); slash >= 0 {
+		dir := filePath[:slash]
+		return data.NewPayloadWithRepoContents(
+			data.Payload{},
+			[]*github.RepositoryContent{{
+				Type: github.Ptr("dir"),
+				Name: github.Ptr(dir),
+				Path: github.Ptr(dir),
+			}},
+			map[string][]*github.RepositoryContent{
+				dir: {repositoryFile(name, filePath, content)},
+			},
+		)
+	}
+	return data.NewPayloadWithRepoContents(
+		data.Payload{},
+		[]*github.RepositoryContent{repositoryFile(name, filePath, content)},
+		map[string][]*github.RepositoryContent{},
+	)
+}
+
+func observedPayload() data.Payload {
+	return data.NewPayloadWithRepoContents(
+		data.Payload{},
+		[]*github.RepositoryContent{},
+		map[string][]*github.RepositoryContent{},
+	)
+}
+
+func withWorkflows(payload data.Payload, files ...data.WorkflowFile) data.Payload {
+	payload = data.NewPayloadWithWorkflowCache(payload, files)
+	payload.Repository.DefaultBranchRef.Name = "main"
+	return payload
+}
+
+const (
+	remediationPolicy = `# Software composition analysis remediation
+
+Software composition analysis findings must be remediated. Critical and high
+dependency vulnerabilities must be fixed within 14 days. Dependencies using
+denied or incompatible licenses must be removed or replaced.
+`
+	releasePolicy = `# Release policy
+
+All software composition analysis violations must be resolved before any release.
+`
+	enforcementPolicy = `# SCA merge policy
+
+All changes must be evaluated by software composition analysis for known
+vulnerabilities and malicious dependencies. Violations must block merging.
+Findings may be suppressed only when declared non-exploitable with justification.
+`
+	enforcementPolicyWithoutException = `# SCA merge policy
+
+All changes must be evaluated by software composition analysis for known
+vulnerabilities and malicious dependencies. Violations must block merging.
+`
+	activeSCAWorkflow = `name: Security
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+`
+)
+
+func TestHasSCARemediationThresholdPolicyReadsRepositoryDocumentation(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+		want    gemara.Result
+	}{
+		{"README policy passes", "README.md", remediationPolicy, gemara.Passed},
+		{"SECURITY policy passes", "SECURITY.md", remediationPolicy, gemara.Passed},
+		{"docs policy passes", "docs/dependencies.md", remediationPolicy, gemara.Passed},
+		{
+			"keywords without thresholds do not pass",
+			"README.md",
+			"# Dependencies\n\nSCA reports vulnerabilities and license information for maintainers to review.\n",
+			gemara.Failed,
+		},
+		{
+			"vulnerability threshold without license threshold does not pass",
+			"SECURITY.md",
+			"# SCA\n\nSCA vulnerabilities must be fixed within 7 days. Licenses are listed in reports.\n",
+			gemara.Failed,
+		},
+		{
+			"unrelated license sentence does not complete vulnerability threshold",
+			"SECURITY.md",
+			"# SCA\n\nSCA must address high vulnerabilities. Approved licenses are listed in reports.\n",
+			gemara.Failed,
+		},
+		{
+			"terms in different sections do not coalesce",
+			"README.md",
+			"# Vulnerabilities\n\nSCA critical vulnerabilities must be fixed within 7 days.\n\n# License\n\nDenied licenses must be removed.\n",
+			gemara.Failed,
+		},
+		{
+			"negated policy does not pass",
+			"README.md",
+			"# SCA\n\nSCA vulnerabilities and denied licenses are informational only and do not require remediation within 30 days.\n",
+			gemara.Failed,
+		},
+		{
+			"example in code fence does not pass",
+			"README.md",
+			"# Example\n\n```\nSCA critical vulnerabilities must be fixed within 7 days and denied licenses must be removed.\n```\n",
+			gemara.Failed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message, _ := HasSCARemediationThresholdPolicy(documentationPayload(test.path, test.content))
+			assert.Equal(t, test.want, result, message)
+		})
+	}
+}
+
+func TestHasSCAReleasePolicyReadsRepositoryDocumentation(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    gemara.Result
+	}{
+		{"explicit policy passes", releasePolicy, gemara.Passed},
+		{
+			"release and SCA keywords alone do not pass",
+			"# Releases\n\nWe publish releases monthly and run SCA in CI.\n",
+			gemara.Failed,
+		},
+		{
+			"optional remediation does not pass",
+			"# Release policy\n\nSCA findings are optional and may be addressed before release.\n",
+			gemara.Failed,
+		},
+		{
+			"requirements in separate sections do not coalesce",
+			"# SCA\n\nSCA violations must be resolved.\n\n# Release\n\nReleases are published weekly.\n",
+			gemara.Failed,
+		},
+		{
+			"scan before release is not an address policy",
+			"# Release\n\nSCA must run before release, and findings are informational only.\n",
+			gemara.Failed,
+		},
+		{
+			"timing and remediation in separate statements do not coalesce",
+			"# Release\n\nSCA must run before release. Findings are addressed monthly.\n",
+			gemara.Failed,
+		},
+		{
+			"semicolon disclaimer keeps obligation qualified",
+			"# Release\n\nSCA findings must be fixed before release; this is currently optional.\n",
+			gemara.NeedsReview,
+		},
+		{
+			"not-fixed negation does not pass",
+			"# Release\n\nSCA findings must be ignored, not fixed before release.\n",
+			gemara.Failed,
+		},
+		{
+			"next-sentence disclaimer downgrades to review",
+			"# Release\n\nSCA findings must be fixed before release. This requirement is optional.\n",
+			gemara.NeedsReview,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message, _ := HasSCAReleasePolicy(withWorkflows(
+				documentationPayload("docs/release.md", test.content),
+			))
+			assert.Equal(t, test.want, result, message)
+		})
+	}
+}
+
+func TestDocumentationSignalsAndFailuresNeedReview(t *testing.T) {
+	depPolicy := &si.Repository{
+		Documentation: &si.RepositoryDocumentation{
+			DependencyManagementPolicy: github.Ptr(si.URL("https://example.com/policy")),
+		},
+	}
+	payload := observedPayload()
+	payload.Insights.Repository = depPolicy
+	payload.Insights.Project = &si.Project{}
+
+	result, message, _ := HasSCARemediationThresholdPolicy(payload)
+	assert.Equal(t, gemara.NeedsReview, result, message)
+
+	result, message, _ = HasSCAReleasePolicy(withWorkflows(payload))
+	assert.Equal(t, gemara.NeedsReview, result, message)
+
+	unreadable := data.NewPayloadWithRepoContents(
+		data.Payload{},
+		[]*github.RepositoryContent{{
+			Type:     github.Ptr("file"),
+			Name:     github.Ptr("README.md"),
+			Path:     github.Ptr("README.md"),
+			Encoding: github.Ptr("none"),
+			Content:  github.Ptr("too large"),
+		}},
+		nil,
+	)
+	result, message, _ = HasSCARemediationThresholdPolicy(unreadable)
+	assert.Equal(t, gemara.NeedsReview, result, message)
+
+	result, message, _ = HasSCAReleasePolicy(withWorkflows(unreadable))
+	assert.Equal(t, gemara.NeedsReview, result, message)
+}
+
+func TestEnforcesSCAOnChangesRequiresEndToEndEvidence(t *testing.T) {
+	passPayload := func(workflow string, required string, policy string) data.Payload {
+		payload := withWorkflows(documentationPayload("SECURITY.md", policy), yml("sca.yml", workflow))
+		payload.RepositoryMetadata = &fakeRequiredChecksMetadata{requiredChecks: []string{required}}
+		return payload
+	}
+
+	tests := []struct {
+		name    string
+		payload data.Payload
+		want    gemara.Result
+	}{
+		{
+			name:    "exact emitted job context and verified policy pass",
+			payload: passPayload(activeSCAWorkflow, "Dependency Audit", enforcementPolicy),
+			want:    gemara.Passed,
+		},
+		{
+			name:    "case and whitespace normalization remains exact",
+			payload: passPayload(activeSCAWorkflow, "  dependency   AUDIT ", enforcementPolicy),
+			want:    gemara.Passed,
+		},
+		{
+			name:    "stale generic SCA context cannot match actual job",
+			payload: passPayload(activeSCAWorkflow, "dependency-review", enforcementPolicy),
+			want:    gemara.NeedsReview,
+		},
+		{
+			name:    "unrelated SCA-looking required context cannot match",
+			payload: passPayload(activeSCAWorkflow, "SCA / stale-job", enforcementPolicy),
+			want:    gemara.NeedsReview,
+		},
+		{
+			name:    "documented policy without exception is capped",
+			payload: passPayload(activeSCAWorkflow, "Dependency Audit", enforcementPolicyWithoutException),
+			want:    gemara.NeedsReview,
+		},
+		{
+			name: "if false scanner cannot pass",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"      - uses: actions/dependency-review-action@v4",
+				"      - if: false\n        uses: actions/dependency-review-action@v4",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "if false scanning job cannot pass",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"    name: Dependency Audit",
+				"    name: Dependency Audit\n    if: false",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "continue on error scanner cannot pass",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"      - uses: actions/dependency-review-action@v4",
+				"      - continue-on-error: true\n        uses: actions/dependency-review-action@v4",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "continue on error scanning job cannot pass",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"    name: Dependency Audit",
+				"    name: Dependency Audit\n    continue-on-error: true",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "shell suppression cannot pass",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"      - uses: actions/dependency-review-action@v4",
+				"      - run: osv-scanner scan . || true",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "trailing true suppression cannot pass",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"      - uses: actions/dependency-review-action@v4",
+				"      - run: osv-scanner scan .; true",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "exit zero suppression cannot pass",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"      - uses: actions/dependency-review-action@v4",
+				"      - run: osv-scanner scan . || exit 0",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "conditional expression is uncertain",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"      - uses: actions/dependency-review-action@v4",
+				"      - if: ${{ github.event.pull_request.draft == false }}\n        uses: actions/dependency-review-action@v4",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "scanner job with prerequisites is uncertain",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"    name: Dependency Audit",
+				"    name: Dependency Audit\n    needs: precheck",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "vulnerability-only scanner cannot prove malicious dependency coverage",
+			payload: passPayload(strings.Replace(
+				activeSCAWorkflow,
+				"      - uses: actions/dependency-review-action@v4",
+				"      - run: govulncheck ./...",
+				1,
+			), "Dependency Audit", enforcementPolicy),
+			want: gemara.NeedsReview,
+		},
+		{
+			name: "negated all-change policy cannot pass",
+			payload: passPayload(
+				activeSCAWorkflow,
+				"Dependency Audit",
+				strings.Replace(enforcementPolicy, "All changes must", "Not all changes must", 1),
+			),
+			want: gemara.NeedsReview,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, message, _ := EnforcesSCAOnChanges(test.payload)
+			assert.Equal(t, test.want, result, message)
+		})
+	}
+}
+
+func TestEnforcesSCAOnChangesDoesNotTrustPinnedProducerByContextAlone(t *testing.T) {
+	payload := withWorkflows(documentationPayload("SECURITY.md", enforcementPolicy), yml("sca.yml", activeSCAWorkflow))
+	integrationID := int64(12345)
+	payload.RepositoryMetadata = &fakePinnedRequiredCheckMetadata{
+		fakeRequiredChecksMetadata: &fakeRequiredChecksMetadata{},
+		checks: []data.RequiredStatusCheck{{
+			Context:       "Dependency Audit",
+			IntegrationID: &integrationID,
+		}},
+	}
+
+	result, message, _ := EnforcesSCAOnChanges(payload)
+	assert.Equal(t, gemara.NeedsReview, result, message)
+}
+
+func TestDetectSCAInWorkflowsRejectsSuppressionAndSetupOnly(t *testing.T) {
+	tests := []struct {
+		name            string
+		command         string
+		wantSignal      bool
+		wantNonBlocking bool
+	}{
+		{"or echo suppression", "osv-scanner scan . || echo ignored", true, true},
+		{"set plus e suppression", "set +e\nosv-scanner scan .", true, true},
+		{"version query is not scan", "osv-scanner --version", false, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workflow := strings.Replace(activeSCAWorkflow,
+				"      - uses: actions/dependency-review-action@v4",
+				"      - run: |\n          "+strings.ReplaceAll(test.command, "\n", "\n          "),
+				1,
+			)
+			detection := detectSCAInWorkflows([]data.WorkflowFile{yml("sca.yml", workflow)}, "main")
+			assert.Equal(t, test.wantSignal, detection.scannerSignal)
+			assert.Equal(t, test.wantNonBlocking, detection.nonBlockingObserved)
+			assert.False(t, detection.coverageProven)
+		})
+	}
+
+	setupOnly := strings.Replace(activeSCAWorkflow,
+		"uses: actions/dependency-review-action@v4",
+		"uses: snyk/actions/setup@v1",
+		1,
+	)
+	detection := detectSCAInWorkflows([]data.WorkflowFile{yml("sca.yml", setupOnly)}, "main")
+	assert.False(t, detection.scannerSignal)
+}
+
+func TestMatchSCAActionRecognizesCommonForms(t *testing.T) {
+	matches := []string{
+		"google/osv-scanner-action@v1",
+		"google/osv-scanner-action/osv-scanner-action@v1.9.0",
+		"snyk/actions/docker@master",
+		"anchore/scan-action@v3",
+		"actions/dependency-review-action@v4",
+	}
+	for _, ref := range matches {
+		t.Run(ref, func(t *testing.T) {
+			assert.NotEmpty(t, matchSCAAction(ref), "expected %q to be recognized as an SCA action", ref)
+		})
+	}
+
+	nonMatches := []string{
+		"actions/checkout@v4",
+		"https://github.com/google/osv-scanner-action",
+		"licensee/licensee@v9",
+	}
+	for _, ref := range nonMatches {
+		t.Run("no_match_"+ref, func(t *testing.T) {
+			assert.Empty(t, matchSCAAction(ref), "expected %q not to be recognized as an SCA action", ref)
+		})
+	}
+}
+
+func TestVerifiedRepositoryEvidenceSurvivesInsightsFailure(t *testing.T) {
+	thresholdPayload := documentationPayload("README.md", remediationPolicy)
+	thresholdPayload.InsightsError = true
+	result, message, _ := HasSCARemediationThresholdPolicy(thresholdPayload)
+	assert.Equal(t, gemara.Passed, result, message)
+
+	releasePayload := documentationPayload("SECURITY.md", releasePolicy)
+	releasePayload.InsightsError = true
+	result, message, _ = HasSCAReleasePolicy(releasePayload)
+	assert.Equal(t, gemara.Passed, result, message)
+
+	enforcementPayload := withWorkflows(
+		documentationPayload("SECURITY.md", enforcementPolicy),
+		yml("sca.yml", activeSCAWorkflow),
+	)
+	enforcementPayload.InsightsError = true
+	enforcementPayload.RepositoryMetadata = &fakeRequiredChecksMetadata{
+		requiredChecks: []string{"Dependency Audit"},
+	}
+	result, message, _ = EnforcesSCAOnChanges(enforcementPayload)
+	assert.Equal(t, gemara.Passed, result, message)
+}
+
+func TestLicenseOnlyWorkflowCannotSatisfyVM0503(t *testing.T) {
+	for _, invocation := range []string{
+		"uses: licensee/licensee-action@v2",
+		"uses: fossas/fossa-action@v1",
+	} {
+		t.Run(invocation, func(t *testing.T) {
+			workflow := strings.Replace(
+				activeSCAWorkflow,
+				"uses: actions/dependency-review-action@v4",
+				invocation,
+				1,
+			)
+			payload := withWorkflows(documentationPayload("SECURITY.md", enforcementPolicy), yml("license.yml", workflow))
+			payload.RepositoryMetadata = &fakeRequiredChecksMetadata{requiredChecks: []string{"Dependency Audit"}}
+
+			result, message, _ := EnforcesSCAOnChanges(payload)
+			assert.NotEqual(t, gemara.Passed, result, message)
+		})
+	}
+}
+
+func TestSecurityInsightsRulesetIsNotEnoughWithoutExceptionEvidence(t *testing.T) {
+	payload := withWorkflows(observedPayload(), yml("sca.yml", activeSCAWorkflow))
+	payload.Insights.Repository.SecurityPosture.Tools = []si.SecurityTool{{
+		Name:        "dependency-review",
+		Type:        "SCA",
+		Rulesets:    []string{"default"},
+		Integration: si.SecurityToolIntegration{Ci: true},
+	}}
+	payload.RepositoryMetadata = &fakeRequiredChecksMetadata{requiredChecks: []string{"Dependency Audit"}}
+
+	result, message, _ := EnforcesSCAOnChanges(payload)
+	assert.Equal(t, gemara.NeedsReview, result, message)
+}
+
+func TestLocalReusableWorkflowContextIsCorrelatedExactly(t *testing.T) {
+	caller := `on:
+  pull_request:
+    branches: [main]
+jobs:
+  sca:
+    name: SCA Gate
+    uses: ./.github/workflows/reusable.yml
+`
+	called := `on:
+  workflow_call:
+jobs:
+  audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/dependency-review-action@v4
+`
+	payload := withWorkflows(
+		documentationPayload("SECURITY.md", enforcementPolicy),
+		yml("caller.yml", caller),
+		yml("reusable.yml", called),
+	)
+	payload.RepositoryMetadata = &fakeRequiredChecksMetadata{
+		requiredChecks: []string{"SCA Gate / Dependency Audit"},
+	}
+
+	result, message, _ := EnforcesSCAOnChanges(payload)
+	assert.Equal(t, gemara.Passed, result, message)
+}
+
+func TestMalformedOrIncompleteEvidenceNeedsReview(t *testing.T) {
+	malformedSI := withWorkflows(observedPayload())
+	malformedSI.InsightsError = true
+	result, message, _ := HasSCARemediationThresholdPolicy(malformedSI)
+	assert.Equal(t, gemara.NeedsReview, result, message)
+	result, message, _ = HasSCAReleasePolicy(malformedSI)
+	assert.Equal(t, gemara.NeedsReview, result, message)
+	result, message, _ = EnforcesSCAOnChanges(malformedSI)
+	assert.Equal(t, gemara.NeedsReview, result, message)
+
+	truncated := withWorkflows(observedPayload(), data.WorkflowFile{
+		Name: "sca.yml", Path: ".github/workflows/sca.yml", Truncated: true,
+	})
+	result, message, _ = EnforcesSCAOnChanges(truncated)
+	assert.Equal(t, gemara.NeedsReview, result, message)
+
+	garbled := withWorkflows(observedPayload(), yml("sca.yml", ":\n\t- invalid: [yaml"))
+	result, message, _ = EnforcesSCAOnChanges(garbled)
+	assert.Equal(t, gemara.NeedsReview, result, message)
+}
+
+func TestVM05PublicEntryPointsHandleSparsePayloads(t *testing.T) {
+	entryPoints := []struct {
+		name string
+		run  func(data.Payload) (gemara.Result, string, gemara.ConfidenceLevel)
+	}{
+		{"VM-05.01", HasSCARemediationThresholdPolicy},
+		{"VM-05.02", HasSCAReleasePolicy},
+		{"VM-05.03", EnforcesSCAOnChanges},
+	}
+	for _, entryPoint := range entryPoints {
+		t.Run(entryPoint.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				result, _, _ := entryPoint.run(data.Payload{})
+				assert.Equal(t, gemara.NeedsReview, result)
+			})
+		})
+	}
+}
+
+func TestHasSCAActionProtectsAgainstMentionsAndLicenseTools(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"action", strings.Replace(activeSCAWorkflow, "branches: [main]", "branches: [main]", 1), true},
+		{"CLI", strings.Replace(activeSCAWorkflow, "uses: actions/dependency-review-action@v4", "run: osv-scanner scan .", 1), true},
+		{"echo", strings.Replace(activeSCAWorkflow, "uses: actions/dependency-review-action@v4", "run: echo trivy", 1), false},
+		{"comment", strings.Replace(activeSCAWorkflow, "- uses: actions/dependency-review-action@v4", "- run: make build # trivy", 1), false},
+		{"licensee", strings.Replace(activeSCAWorkflow, "uses: actions/dependency-review-action@v4", "uses: licensee/licensee-action@v2", 1), false},
+		{"fossa", strings.Replace(activeSCAWorkflow, "uses: actions/dependency-review-action@v4", "uses: fossas/fossa-action@v1", 1), false},
+		{"suppressed", strings.Replace(activeSCAWorkflow, "uses: actions/dependency-review-action@v4", "run: trivy fs . || true", 1), false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workflow, errs := actionlint.Parse([]byte(test.content))
+			require.NotNil(t, workflow)
+			require.Empty(t, errs)
+			assert.Equal(t, test.want, hasSCAAction(workflow))
+		})
+	}
+}
+
+func TestHasVersionTagFilter(t *testing.T) {
+	versionLike := []string{"v*", "v*.*.*", "v1.*", "*.*.*", "1.2.3", "v2", "v*-rc*"}
+	notVersionLike := []string{"dev*", "nightly", "latest", "release-*", "*"}
+	for _, tag := range versionLike {
+		assert.True(t, hasVersionTagFilter(filterWith(tag)), tag)
+	}
+	for _, tag := range notVersionLike {
+		assert.False(t, hasVersionTagFilter(filterWith(tag)), tag)
+	}
+}
+
+func filterWith(value string) *actionlint.WebhookEventFilter {
+	return &actionlint.WebhookEventFilter{Values: []*actionlint.String{{Value: value}}}
+}


### PR DESCRIPTION
Closes #35

Implements the three OSPS-VM-05 sub-controls, which were previously wired to `NotImplemented` stubs:

| Control | Requirement |
| --- | --- |
| VM-05.01 | A documented threshold for remediating SCA findings (vulnerabilities and licenses) |
| VM-05.02 | A documented policy for addressing SCA violations prior to release |
| VM-05.03 | Every change automatically evaluated, with violations blocked |

## Approach

No Security Insights field records an SCA remediation threshold or a pre-release SCA policy, so these cannot be read directly. Each control evaluates layered evidence — Security Insights first, then GitHub-observable signals: release and pull-request workflows parsed with `actionlint`, required status checks from rulesets and classic branch protection, and dependency-update tooling config. As a result the checks still produce a meaningful verdict on repositories with no `security-insights.yml`, rather than depending on that file alone.

## Result semantics

The main risk in a compliance scanner is claiming a control is met on evidence that doesn't show it, so results are deliberately conservative:

- **Passed** only where evidence is verifiable end to end. For VM-05.03 this requires the SCA scan to be correlated with a required status check, so that *"a scan runs"* is never reported as *"violations block merges"*.
- **NeedsReview** where a signal exists but its content can't be inspected (e.g. a policy document is linked but not readable), and where evidence couldn't be retrieved at all. A workflow-read failure is never reported as a violation — `Failed` asserts something we observed, and we observed nothing for a file we never read. This matches the convention and rationale already documented in `build_release` and `access_control`.
- **Failed** only on an observed absence, consistent with `docs.HasDependencyManagementPolicy` on the same signal.
- **NotApplicable** for inactive repositories, via the existing `IsActive` step.

## Detection notes

Each of these covers a case that produced a wrong verdict during development, and is now pinned by a regression test:

- The `SCA` acronym is matched on **word boundaries**. As a substring it also matches `scan`, `scanner` and `secret-scanning` — and since `secret-scanning` is a real Security Insights tool type in this codebase, substring matching returned `Passed` at `High` confidence for repositories whose only evidence was a secret scanner plus a required check named `secret-scan`.
- Workflow triggers and steps are read from the parsed **actionlint AST** rather than raw file text, so a tool named in a comment or echoed in a script isn't mistaken for a scan. Both `uses:` actions and `run:` CLI invocations count, since most recognized scanners are CLIs.
- Workflows that actionlint reports **non-fatally** (unknown key, missing `runs-on`) are still inspected; it returns a usable tree alongside those findings, and discarding them understated coverage.
- Release detection requires the `release` event or a push filtered to **version-like tags**, so routine tag pushes such as `dev*` or `nightly` aren't read as releases.

## Behavioral impact

Three controls that previously always returned `NotImplemented` now return real verdicts, so evaluation output for these IDs changes for every scanned repository. No existing control logic was modified.

## Testing

Adds `data.NewPayloadWithWorkflowCache` so workflow-content checks can be exercised without a live GitHub client. Tests cover each control's result paths, plus the detection helpers (`hasVersionTagFilter`, `hasSCAAction`, `looksLikeSCA`, `parseWorkflow`) directly — at the step level a helper regression is indistinguishable from any other no-signal path, which is how an earlier tag-matching regression went unnoticed.

Each regression test was verified to fail against the previous behavior, so the assertions discriminate rather than passing vacuously.

`go build`, `go vet`, `go test ./...`, `golangci-lint` (0 issues), and `make -B build` all pass.