### PR TITLE
feat(OSPS-SA-03): implement security assessment and threat modeling checks

### DIFF
--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -192,10 +192,10 @@ var (
 			sec_assessment.HasExternalInterfaceDocumentation,
 		},
 		"OSPS-SA-03.01": {
-			reusable_steps.NotImplemented,
+			sec_assessment.HasSecurityAssessment,
 		},
 		"OSPS-SA-03.02": {
-			reusable_steps.NotImplemented,
+			sec_assessment.HasThreatModelAnalysis,
 		},
 		"OSPS-VM-01.01": {
 			reusable_steps.IsActive,

--- a/evaluation_plans/osps/sec_assessment/steps.go
+++ b/evaluation_plans/osps/sec_assessment/steps.go
@@ -1,11 +1,13 @@
 package sec_assessment
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
 	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
+	"github.com/ossf/si-tooling/v2/si"
 )
 
 // DesignDocFiles are common file names for design/architecture documentation
@@ -164,4 +166,189 @@ func HasExternalInterfaceDocumentation(payload data.Payload) (result gemara.Resu
 	// No interface-doc file, API-doc directory, or Security Insights guide was
 	// found for a released project, so the MUST requirement is unmet.
 	return gemara.Failed, "No documentation file, API-documentation directory, or Security Insights guide describing the external software interfaces of released assets was found", gemara.Medium
+}
+
+// threatModelingIndicators are lowercase phrases that signal a security
+// assessment covered threat modeling or attack surface analysis rather than a
+// generic review. They are matched against the assessment name and comment.
+var threatModelingIndicators = []string{
+	"threat model",
+	"threat-model",
+	"threatmodel",
+	"attack surface",
+	"attack-surface",
+	"stride",
+	"pasta",
+	"dread",
+	"attack tree",
+}
+
+// assessmentDenials are lowercase phrases that indicate a comment is declaring
+// the *absence* of an assessment rather than one that was performed. Comment is
+// a required Security Insights field, and real-world files populate it to state
+// the opposite ("No self assessment completed", "has not yet been completed"),
+// so a bare comment carrying one of these must not be credited as a declaration.
+// Each phrase is intentionally specific: broad fragments like "has not" or "not
+// yet" would also match genuine declarations (e.g. "assessment completed; scope
+// has not changed since"), flipping a real assessment to a wrong verdict.
+var assessmentDenials = []string{
+	"no self assessment",
+	"no self-assessment",
+	"no third party assessment",
+	"no third-party assessment",
+	"no assessment",
+	"no formal",
+	"not been completed",
+	"not yet been completed",
+	"not been performed",
+	"not been conducted",
+	"not completed",
+	"not performed",
+	"not conducted",
+	"never been",
+	"never performed",
+	"never conducted",
+}
+
+// commentDeniesAssessment reports whether a comment explicitly states that no
+// assessment was performed, so such a comment is not mistaken for a declaration.
+func commentDeniesAssessment(comment string) bool {
+	lower := strings.ToLower(comment)
+	for _, denial := range assessmentDenials {
+		if strings.Contains(lower, denial) {
+			return true
+		}
+	}
+	return false
+}
+
+// assessmentDeclared reports whether a Security Insights assessment declares an
+// assessment that was actually performed. A populated Name or Evidence is a
+// structured signal of a real artifact and is always credited. A bare Comment is
+// credited only when it does not explicitly deny that an assessment was done,
+// because Comment is required and is routinely used to record its absence.
+func assessmentDeclared(assessment si.Assessment) bool {
+	if assessment.Name != nil && strings.TrimSpace(*assessment.Name) != "" {
+		return true
+	}
+	if assessment.Evidence != nil && strings.TrimSpace(string(*assessment.Evidence)) != "" {
+		return true
+	}
+	comment := strings.TrimSpace(assessment.Comment)
+	if comment == "" {
+		return false
+	}
+	return !commentDeniesAssessment(comment)
+}
+
+// mentionsThreatModeling reports whether an assessment's name, comment, or
+// evidence references threat modeling or attack surface analysis.
+func mentionsThreatModeling(assessment si.Assessment) bool {
+	text := strings.ToLower(assessment.Comment)
+	if assessment.Name != nil {
+		text += " " + strings.ToLower(*assessment.Name)
+	}
+	if assessment.Evidence != nil {
+		text += " " + strings.ToLower(string(*assessment.Evidence))
+	}
+	for _, indicator := range threatModelingIndicators {
+		if strings.Contains(text, indicator) {
+			return true
+		}
+	}
+	return false
+}
+
+// securityAssessments returns the repository's declared security assessments,
+// tolerating a nil Insights.Repository (possible when RestData is present but no
+// Security Insights file was parsed) so callers can branch on an empty result
+// rather than panicking.
+func securityAssessments(payload data.Payload) si.SecurityPosture {
+	if payload.Insights.Repository == nil {
+		return si.SecurityPosture{}
+	}
+	return payload.Insights.Repository.SecurityPosture
+}
+
+// HasSecurityAssessment implements OSPS-SA-03.01: when the project has made a
+// release, it MUST perform a security assessment to understand the most likely
+// and impactful potential security problems in the software.
+func HasSecurityAssessment(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	released, observable := reusable_steps.HasPublishedRelease(payload)
+	if !observable {
+		return gemara.NeedsReview, "Release data is unavailable; manually review whether a security assessment was performed", gemara.Low
+	}
+	if !released {
+		return gemara.NotApplicable, "No published releases found; the security-assessment requirement does not apply", gemara.High
+	}
+
+	// An unparseable Security Insights file is inconclusive, not a failure: strict
+	// YAML loading means one unrelated typo can make the whole file unreadable.
+	if payload.InsightsError {
+		return gemara.NeedsReview, "Security Insights file could not be parsed; manually review whether a security assessment was performed", gemara.Low
+	}
+
+	assessments := securityAssessments(payload).Assessments
+	if assessmentDeclared(assessments.Self) {
+		// A declaration proves only that an artifact exists, not that it identifies
+		// the most likely and impactful security problems.
+		return gemara.NeedsReview, "Security Insights declares a self security assessment, but its coverage and sufficiency require manual or AI-assisted review", gemara.Low
+	}
+	populatedThirdParty := 0
+	for _, assessment := range assessments.ThirdPartyAssessment {
+		if assessmentDeclared(assessment) {
+			populatedThirdParty++
+		}
+	}
+	if populatedThirdParty > 0 {
+		// Third-party provenance does not establish that the assessment covers the
+		// risks required by this control.
+		return gemara.NeedsReview, fmt.Sprintf("Security Insights declares %d third-party security assessment(s), but their coverage and sufficiency require manual or AI-assisted review", populatedThirdParty), gemara.Low
+	}
+
+	return gemara.Failed, "Project has published releases but no security assessment was found in Security Insights", gemara.Medium
+}
+
+// HasThreatModelAnalysis implements OSPS-SA-03.02: when the project has made a
+// release, it MUST perform threat modeling and attack surface analysis to
+// understand and protect against attacks on critical code paths, functions,
+// and interactions within the system.
+func HasThreatModelAnalysis(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	released, observable := reusable_steps.HasPublishedRelease(payload)
+	if !observable {
+		return gemara.NeedsReview, "Release data is unavailable; manually review whether threat modeling and attack surface analysis were performed", gemara.Low
+	}
+	if !released {
+		return gemara.NotApplicable, "No published releases found; the threat-modeling requirement does not apply", gemara.High
+	}
+
+	// An unparseable Security Insights file is inconclusive, not a failure: strict
+	// YAML loading means one unrelated typo can make the whole file unreadable.
+	if payload.InsightsError {
+		return gemara.NeedsReview, "Security Insights file could not be parsed; manually review whether threat modeling and attack surface analysis were performed", gemara.Low
+	}
+
+	assessments := securityAssessments(payload).Assessments
+	candidates := append([]si.Assessment{assessments.Self}, assessments.ThirdPartyAssessment...)
+
+	hasAssessment := false
+	for _, assessment := range candidates {
+		if !assessmentDeclared(assessment) {
+			continue
+		}
+		hasAssessment = true
+		if mentionsThreatModeling(assessment) {
+			// Matching terminology proves an artifact is declared, but not that it
+			// sufficiently covers critical paths, interactions, threats, and mitigations.
+			return gemara.NeedsReview, "Security Insights declares threat modeling or attack surface analysis, but its coverage and sufficiency require manual or AI-assisted review", gemara.Low
+		}
+	}
+
+	if hasAssessment {
+		// Security Insights has no dedicated threat-model field, so an assessment
+		// without recognized terminology may still contain the required analysis.
+		return gemara.NeedsReview, "A security assessment is declared but does not mention threat modeling or attack surface analysis - manual review needed", gemara.Low
+	}
+
+	return gemara.Failed, "Project has published releases but no threat modeling or attack surface analysis was found in Security Insights", gemara.Medium
 }

--- a/evaluation_plans/osps/sec_assessment/steps_test.go
+++ b/evaluation_plans/osps/sec_assessment/steps_test.go
@@ -454,3 +454,342 @@ func Test_HasExternalInterfaceDocumentation(t *testing.T) {
 		})
 	}
 }
+
+// restDataWithReleaseAndAssessments builds RestData describing a project that has
+// (or has not) published a release, with an optional self assessment and any
+// number of third-party assessments.
+func restDataWithReleaseAndAssessments(published bool, self si.Assessment, thirdParty ...si.Assessment) *data.RestData {
+	rd := &data.RestData{
+		Insights: si.SecurityInsights{
+			Repository: &si.Repository{},
+		},
+	}
+	rd.Insights.Repository.SecurityPosture.Assessments.Self = self
+	rd.Insights.Repository.SecurityPosture.Assessments.ThirdPartyAssessment = thirdParty
+	if published {
+		rd.Releases = []data.ReleaseData{{TagName: "v1.0.0", Draft: false}}
+	}
+	return rd
+}
+
+func Test_HasSecurityAssessment(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    data.Payload
+		wantResult gemara.Result
+		wantMsg    string
+	}{
+		{
+			name:       "no rest data - needs review",
+			payload:    data.Payload{RestData: nil},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Release data is unavailable; manually review whether a security assessment was performed",
+		},
+		{
+			name: "release retrieval error - needs review",
+			payload: data.Payload{
+				RestData: &data.RestData{ReleasesError: fmt.Errorf("API unavailable")},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Release data is unavailable; manually review whether a security assessment was performed",
+		},
+		{
+			name: "no published releases - not applicable",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(false, si.Assessment{}),
+			},
+			wantResult: gemara.NotApplicable,
+			wantMsg:    "No published releases found; the security-assessment requirement does not apply",
+		},
+		{
+			name: "only draft release - not applicable",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					Insights: si.SecurityInsights{Repository: &si.Repository{}},
+					Releases: []data.ReleaseData{{TagName: "v1.0.0", Draft: true}},
+				},
+			},
+			wantResult: gemara.NotApplicable,
+			wantMsg:    "No published releases found; the security-assessment requirement does not apply",
+		},
+		{
+			name: "released with self assessment comment - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Comment: "Reviewed the codebase"}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights declares a self security assessment, but its coverage and sufficiency require manual or AI-assisted review",
+		},
+		{
+			name: "released with self assessment evidence only - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Evidence: ptrTo(si.URL("https://example.com/report"))}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights declares a self security assessment, but its coverage and sufficiency require manual or AI-assisted review",
+		},
+		{
+			name: "released with third-party assessment - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{}, si.Assessment{Comment: "External audit"}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights declares 1 third-party security assessment(s), but their coverage and sufficiency require manual or AI-assisted review",
+		},
+		{
+			name: "released with multiple populated and empty third-party assessments - needs review with populated count",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(
+					true,
+					si.Assessment{},
+					si.Assessment{Comment: "External audit"},
+					si.Assessment{},
+					si.Assessment{Name: ptrTo("Independent review")},
+				),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights declares 2 third-party security assessment(s), but their coverage and sufficiency require manual or AI-assisted review",
+		},
+		{
+			name: "released with empty third-party assessment - failed",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{}, si.Assessment{}),
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no security assessment was found in Security Insights",
+		},
+		{
+			name: "released with whitespace-only assessment fields - failed",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{
+					Comment:  " \t ",
+					Name:     ptrTo(" "),
+					Evidence: ptrTo(si.URL(" \n")),
+				}),
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no security assessment was found in Security Insights",
+		},
+		{
+			name: "released with negated self assessment comment - failed",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Comment: "A formal self-assessment has not yet been completed for this project."}),
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no security assessment was found in Security Insights",
+		},
+		{
+			name: "released with 'No self assessment completed' comment - failed",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Comment: "No self assessment completed"}),
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no security assessment was found in Security Insights",
+		},
+		{
+			name: "negated comment but populated name still declares - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{
+					Name:    ptrTo("2024 self assessment"),
+					Comment: "No further review has not been completed",
+				}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights declares a self security assessment, but its coverage and sufficiency require manual or AI-assisted review",
+		},
+		{
+			name: "genuine declaration with incidental 'has not' is credited - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{
+					Comment: "Self assessment completed in 2024; scope has not changed since.",
+				}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights declares a self security assessment, but its coverage and sufficiency require manual or AI-assisted review",
+		},
+		{
+			name: "unparseable security insights - needs review",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					InsightsError: true,
+					Releases:      []data.ReleaseData{{TagName: "v1.0.0", Draft: false}},
+				},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights file could not be parsed; manually review whether a security assessment was performed",
+		},
+		{
+			name: "released with no assessment - failed",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{}),
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no security assessment was found in Security Insights",
+		},
+		{
+			name: "released with nil insights repository - failed",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					Releases: []data.ReleaseData{{TagName: "v1.0.0", Draft: false}},
+				},
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no security assessment was found in Security Insights",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, gotMsg, _ := HasSecurityAssessment(tt.payload)
+			if gotResult != tt.wantResult {
+				t.Errorf("HasSecurityAssessment() result = %v, want %v", gotResult, tt.wantResult)
+			}
+			if gotMsg != tt.wantMsg {
+				t.Errorf("HasSecurityAssessment() message = %q, want %q", gotMsg, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func Test_HasThreatModelAnalysis(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    data.Payload
+		wantResult gemara.Result
+		wantMsg    string
+	}{
+		{
+			name:       "no rest data - needs review",
+			payload:    data.Payload{RestData: nil},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Release data is unavailable; manually review whether threat modeling and attack surface analysis were performed",
+		},
+		{
+			name: "release retrieval error - needs review",
+			payload: data.Payload{
+				RestData: &data.RestData{ReleasesError: fmt.Errorf("API unavailable")},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Release data is unavailable; manually review whether threat modeling and attack surface analysis were performed",
+		},
+		{
+			name: "no published releases - not applicable",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(false, si.Assessment{}),
+			},
+			wantResult: gemara.NotApplicable,
+			wantMsg:    "No published releases found; the threat-modeling requirement does not apply",
+		},
+		{
+			name: "only draft release - not applicable",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					Insights: si.SecurityInsights{Repository: &si.Repository{}},
+					Releases: []data.ReleaseData{{TagName: "v1.0.0", Draft: true}},
+				},
+			},
+			wantResult: gemara.NotApplicable,
+			wantMsg:    "No published releases found; the threat-modeling requirement does not apply",
+		},
+		{
+			name: "self assessment mentions threat modeling - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Comment: "Performed threat modeling using STRIDE"}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights declares threat modeling or attack surface analysis, but its coverage and sufficiency require manual or AI-assisted review",
+		},
+		{
+			name: "case-insensitive third-party assessment mentions attack surface - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{}, si.Assessment{Name: ptrTo("ATTACK SURFACE analysis")}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights declares threat modeling or attack surface analysis, but its coverage and sufficiency require manual or AI-assisted review",
+		},
+		{
+			name: "threat modeling term only in evidence - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{
+					Comment:  "Security review performed",
+					Evidence: ptrTo(si.URL("https://example.com/threat-model.md")),
+				}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights declares threat modeling or attack surface analysis, but its coverage and sufficiency require manual or AI-assisted review",
+		},
+		{
+			name: "assessment present but no threat modeling terms - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Comment: "General security review"}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "A security assessment is declared but does not mention threat modeling or attack surface analysis - manual review needed",
+		},
+		{
+			name: "negated self assessment comment - failed",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Comment: "A formal self-assessment has not yet been completed for this project."}),
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no threat modeling or attack surface analysis was found in Security Insights",
+		},
+		{
+			name: "unparseable security insights - needs review",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					InsightsError: true,
+					Releases:      []data.ReleaseData{{TagName: "v1.0.0", Draft: false}},
+				},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Security Insights file could not be parsed; manually review whether threat modeling and attack surface analysis were performed",
+		},
+		{
+			name: "empty third-party assessment - failed",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{}, si.Assessment{}),
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no threat modeling or attack surface analysis was found in Security Insights",
+		},
+		{
+			name: "whitespace-only assessment - failed",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Comment: " \t ", Name: ptrTo(" ")}),
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no threat modeling or attack surface analysis was found in Security Insights",
+		},
+		{
+			name: "released with no assessment - failed",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{}),
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no threat modeling or attack surface analysis was found in Security Insights",
+		},
+		{
+			name: "released with nil insights repository - failed",
+			payload: data.Payload{
+				RestData: &data.RestData{
+					Releases: []data.ReleaseData{{TagName: "v1.0.0", Draft: false}},
+				},
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Project has published releases but no threat modeling or attack surface analysis was found in Security Insights",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, gotMsg, _ := HasThreatModelAnalysis(tt.payload)
+			if gotResult != tt.wantResult {
+				t.Errorf("HasThreatModelAnalysis() result = %v, want %v", gotResult, tt.wantResult)
+			}
+			if gotMsg != tt.wantMsg {
+				t.Errorf("HasThreatModelAnalysis() message = %q, want %q", gotMsg, tt.wantMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements OSPS-SA-03, replacing the `NotImplemented` placeholders for both assessment requirements:

- **OSPS-SA-03.01** (`HasSecurityAssessment`): when the project has made a release, it MUST perform a security assessment to understand the most likely and impactful potential security problems.
- **OSPS-SA-03.02** (`HasThreatModelAnalysis`): when the project has made a release, it MUST perform threat modeling and attack surface analysis.

## Approach

Both checks derive evidence from Security Insights `repository.security.assessments` (self and third-party):

- **Release-gated**: both requirements apply only "when the project has made a release". No published (non-draft) release → `NotApplicable`; unreadable release data → `NeedsReview`.
- **SA-03.02** additionally scans the assessment name/comment for threat-modeling / attack-surface terminology (threat model, attack surface, STRIDE, PASTA, DREAD, attack tree).
- Access to `Insights.Repository` is nil-safe, matching the existing `vuln_management` guard pattern.

## Why `NeedsReview` instead of `Passed` when an assessment is found

Detecting an assessment tells us only that **an artifact exists or is declared** — it does **not** verify that the artifact is correct, current, or sufficient. The scanner cannot, without inspecting the contents, confirm that:

- **SA-03.01**: the assessment actually identifies the *most likely and impactful* security problems for this software.
- **SA-03.02**: the threat model / attack-surface analysis genuinely covers the *critical code paths, functions, and interactions*, and enumerates threats with mitigations.

A keyword match (e.g. finding "STRIDE" or "threat model") or a populated Security Insights field is trivially satisfiable and could be a stub, an outdated document, or a checkbox entry. Auto-passing on that basis would let projects clear a MUST requirement without any substantive analysis, giving downstream consumers false assurance. Conversely, failing a project that *has* done the work but expressed it in unrecognized terms would be wrong.

`NeedsReview` is the correct verdict because sufficiency is a **judgment about document contents** that today requires a human (or a future AI-assisted evaluator). We therefore return:

- `NeedsReview` when an assessment is found → a reviewer confirms coverage before it counts as a pass.
- `Failed` when the project has released but no assessment evidence exists at all.

This mirrors how other non-deterministic content checks already behave in this repo (e.g. `TestExecutionDocumentation` / QA-06.02 and `DocumentsTestMaintenancePolicy` / QA-06.03 defer to manual review rather than auto-passing), and it deliberately leaves a clean seam to plug in AI-assisted content evaluation later, at which point qualifying artifacts could be promoted to `Passed`.

## Result matrix

| Condition | 03.01 | 03.02 |
|---|---|---|
| No published release | NotApplicable | NotApplicable |
| Release data unreadable | NeedsReview | NeedsReview |
| Assessment declared / found | NeedsReview | NeedsReview |
| Released, no assessment | Failed | Failed |

## Testing

- Table-driven tests for both steps with exact result + message assertions across every branch (release gating, draft-only releases, self/third-party assessments, empty/whitespace-only assessments, case-insensitive keyword matching, nil `Insights.Repository`).
- Package coverage: 100% of statements.
- `go test ./...`, `go vet`, and `golangci-lint` all pass.

Closes #31