### PR TITLE
feat(OSPS-SA-02): implement external interface documentation check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Many of the assessments depend upon the presence of a [Security Insights](https:
 
 ## Work in Progress
 
-Currently 41 control requirements across OSPS Baselines levels 1-3 are covered, with 11 not yet implemented. [Maturity Level 1](https://baseline.openssf.org/versions/2025-02-25.html#level-1) requirements are the most rigorously tested and are recommended for use. The results of these layer 1 assessments are integrated into [LFX Insights](https://insights.linuxfoundation.org/project/k8s/repository/kubernetes-kubernetes/security), powering the [Security & Best Practices results](https://insights.linuxfoundation.org/docs/metrics/security/).
+Currently 42 control requirements across OSPS Baselines levels 1-3 are covered, with 10 not yet implemented. [Maturity Level 1](https://baseline.openssf.org/versions/2025-02-25.html#level-1) requirements are the most rigorously tested and are recommended for use. The results of these layer 1 assessments are integrated into [LFX Insights](https://insights.linuxfoundation.org/project/k8s/repository/kubernetes-kubernetes/security), powering the [Security & Best Practices results](https://insights.linuxfoundation.org/docs/metrics/security/).
 
 ![alt text](kubernetes_insights_baseline.png)
 

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -189,7 +189,7 @@ var (
 			sec_assessment.HasDesignDocumentation,
 		},
 		"OSPS-SA-02.01": {
-			reusable_steps.NotImplemented,
+			sec_assessment.HasExternalInterfaceDocumentation,
 		},
 		"OSPS-SA-03.01": {
 			reusable_steps.NotImplemented,

--- a/evaluation_plans/osps/sec_assessment/steps.go
+++ b/evaluation_plans/osps/sec_assessment/steps.go
@@ -65,3 +65,105 @@ func HasDesignDocumentation(payload data.Payload) (result gemara.Result, message
 
 	return gemara.Failed, "Design documentation demonstrating all actions and actors was NOT found", confidence
 }
+
+// InterfaceDocFiles are common file names for external interface / API documentation.
+var InterfaceDocFiles = []string{
+	"api.md",
+	"api.rst",
+	"api.txt",
+	"apidocs.md",
+	"api-reference.md",
+	"api-reference.rst",
+	"openapi.yaml",
+	"openapi.yml",
+	"openapi.json",
+	"swagger.yaml",
+	"swagger.yml",
+	"swagger.json",
+}
+
+// InterfaceDocDirectories are common directory names that typically contain
+// external interface / API documentation.
+var InterfaceDocDirectories = []string{
+	"api",
+	"apis",
+	"apidocs",
+	"api-docs",
+	"reference",
+	"references",
+	"docs",
+	"doc",
+}
+
+// hasPublishedRelease reports whether the project has published at least one
+// non-draft release. observable is false when release data could not be seen,
+// so callers can degrade to manual review instead of a definitive result.
+func hasPublishedRelease(payload data.Payload) (released bool, observable bool) {
+	// Missing REST data or a fetch error means release state is unknown.
+	if payload.RestData == nil || payload.ReleasesError != nil {
+		return false, false
+	}
+	for _, release := range payload.Releases {
+		if !release.Draft {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+// HasExternalInterfaceDocumentation assesses OSPS-SA-02.01: when the project has
+// made a release, its documentation must describe all external software
+// interfaces (APIs) of the released assets.
+func HasExternalInterfaceDocumentation(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	// The requirement only applies once a release exists.
+	released, observable := hasPublishedRelease(payload)
+	if !observable {
+		return gemara.NeedsReview, "Release data is unavailable; manually review whether the documentation describes all external software interfaces", gemara.Low
+	}
+	if !released {
+		return gemara.NotApplicable, "No published releases found; the external interface documentation requirement does not apply", gemara.High
+	}
+
+	var foundDirectories []string
+
+	if payload.GraphqlRepoData != nil {
+		for _, entry := range payload.Repository.Object.Tree.Entries {
+			if entry.Type == "blob" {
+				for _, docFile := range InterfaceDocFiles {
+					if strings.EqualFold(entry.Name, docFile) {
+						// A matching file proves interface docs exist, but not that
+						// they cover every external interface of the released assets.
+						return gemara.NeedsReview, "External interface documentation found (" + entry.Name + "), but coverage of all external interfaces requires manual review", gemara.Low
+					}
+				}
+			}
+
+			if entry.Type == "tree" {
+				for _, docDir := range InterfaceDocDirectories {
+					if strings.EqualFold(entry.Name, docDir) {
+						foundDirectories = append(foundDirectories, entry.Name)
+					}
+				}
+			}
+		}
+	}
+
+	// A directory that typically holds API docs is a weaker signal that still
+	// cannot be confirmed to document every interface.
+	if len(foundDirectories) > 0 {
+		return gemara.NeedsReview, "No external interface documentation file found in root, but found directories that may contain API documentation: " + strings.Join(foundDirectories, ", ") + " - manual review needed to confirm all external interfaces are documented", gemara.Low
+	}
+
+	// Fallback: a detailed or quickstart guide in Security Insights may describe
+	// the interfaces, but this cannot be verified automatically.
+	if payload.RestData != nil && payload.Insights.Project != nil && payload.Insights.Project.Documentation != nil {
+		if payload.Insights.Project.Documentation.DetailedGuide != nil {
+			return gemara.NeedsReview, "No external interface documentation file found, but detailed guide specified in Security Insights - manual review needed to confirm all external interfaces are documented", gemara.Low
+		}
+		if payload.Insights.Project.Documentation.QuickstartGuide != nil {
+			return gemara.NeedsReview, "No external interface documentation file found, but quickstart guide specified in Security Insights - manual review needed to confirm all external interfaces are documented", gemara.Low
+		}
+	}
+
+	return gemara.Failed, "Documentation describing the external software interfaces of released assets was NOT found", confidence
+}

--- a/evaluation_plans/osps/sec_assessment/steps.go
+++ b/evaluation_plans/osps/sec_assessment/steps.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/ossf/pvtr-github-repo-scanner/data"
+	"github.com/ossf/pvtr-github-repo-scanner/evaluation_plans/reusable_steps"
 )
 
 // DesignDocFiles are common file names for design/architecture documentation
@@ -71,6 +72,9 @@ var InterfaceDocFiles = []string{
 	"api.md",
 	"api.rst",
 	"api.txt",
+	"api.yaml",
+	"api.yml",
+	"api.json",
 	"apidocs.md",
 	"api-reference.md",
 	"api-reference.rst",
@@ -89,26 +93,17 @@ var InterfaceDocDirectories = []string{
 	"apis",
 	"apidocs",
 	"api-docs",
+	"documentation",
 	"reference",
 	"references",
 	"docs",
 	"doc",
-}
-
-// hasPublishedRelease reports whether the project has published at least one
-// non-draft release. observable is false when release data could not be seen,
-// so callers can degrade to manual review instead of a definitive result.
-func hasPublishedRelease(payload data.Payload) (released bool, observable bool) {
-	// Missing REST data or a fetch error means release state is unknown.
-	if payload.RestData == nil || payload.ReleasesError != nil {
-		return false, false
-	}
-	for _, release := range payload.Releases {
-		if !release.Draft {
-			return true, true
-		}
-	}
-	return false, true
+	"spec",
+	"specs",
+	"openapi",
+	"swagger",
+	"schema",
+	"proto",
 }
 
 // HasExternalInterfaceDocumentation assesses OSPS-SA-02.01: when the project has
@@ -116,7 +111,7 @@ func hasPublishedRelease(payload data.Payload) (released bool, observable bool) 
 // interfaces (APIs) of the released assets.
 func HasExternalInterfaceDocumentation(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// The requirement only applies once a release exists.
-	released, observable := hasPublishedRelease(payload)
+	released, observable := reusable_steps.HasPublishedRelease(payload)
 	if !observable {
 		return gemara.NeedsReview, "Release data is unavailable; manually review whether the documentation describes all external software interfaces", gemara.Low
 	}
@@ -131,8 +126,9 @@ func HasExternalInterfaceDocumentation(payload data.Payload) (result gemara.Resu
 			if entry.Type == "blob" {
 				for _, docFile := range InterfaceDocFiles {
 					if strings.EqualFold(entry.Name, docFile) {
-						// A matching file proves interface docs exist, but not that
-						// they cover every external interface of the released assets.
+						// A matching root filename indicates interface docs likely
+						// exist, but does not prove they cover every external
+						// interface of the released assets.
 						return gemara.NeedsReview, "External interface documentation found (" + entry.Name + "), but coverage of all external interfaces requires manual review", gemara.Low
 					}
 				}
@@ -158,12 +154,14 @@ func HasExternalInterfaceDocumentation(payload data.Payload) (result gemara.Resu
 	// the interfaces, but this cannot be verified automatically.
 	if payload.RestData != nil && payload.Insights.Project != nil && payload.Insights.Project.Documentation != nil {
 		if payload.Insights.Project.Documentation.DetailedGuide != nil {
-			return gemara.NeedsReview, "No external interface documentation file found, but detailed guide specified in Security Insights - manual review needed to confirm all external interfaces are documented", gemara.Low
+			return gemara.NeedsReview, "No external interface documentation file or directory found, but detailed guide specified in Security Insights - manual review needed to confirm all external interfaces are documented", gemara.Low
 		}
 		if payload.Insights.Project.Documentation.QuickstartGuide != nil {
-			return gemara.NeedsReview, "No external interface documentation file found, but quickstart guide specified in Security Insights - manual review needed to confirm all external interfaces are documented", gemara.Low
+			return gemara.NeedsReview, "No external interface documentation file or directory found, but quickstart guide specified in Security Insights - manual review needed to confirm all external interfaces are documented", gemara.Low
 		}
 	}
 
-	return gemara.Failed, "Documentation describing the external software interfaces of released assets was NOT found", confidence
+	// No interface-doc file, API-doc directory, or Security Insights guide was
+	// found for a released project, so the MUST requirement is unmet.
+	return gemara.Failed, "No documentation file, API-documentation directory, or Security Insights guide describing the external software interfaces of released assets was found", gemara.Medium
 }

--- a/evaluation_plans/osps/sec_assessment/steps_test.go
+++ b/evaluation_plans/osps/sec_assessment/steps_test.go
@@ -1,6 +1,7 @@
 package sec_assessment
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -214,4 +215,200 @@ func buildGraphqlDataWithEntries(entries []fileEntry) *data.GraphqlRepoData {
 	}
 
 	return graphqlData
+}
+
+func Test_HasExternalInterfaceDocumentation(t *testing.T) {
+	oneRelease := []data.ReleaseData{{TagName: "v1.0.0"}}
+
+	tests := []struct {
+		name       string
+		payload    data.Payload
+		wantResult gemara.Result
+		wantMsg    string
+	}{
+		{
+			name:       "no rest data - needs review",
+			payload:    data.Payload{RestData: nil},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Release data is unavailable; manually review whether the documentation describes all external software interfaces",
+		},
+		{
+			name: "release retrieval error - needs review",
+			payload: data.Payload{
+				RestData: &data.RestData{ReleasesError: fmt.Errorf("API unavailable")},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "Release data is unavailable; manually review whether the documentation describes all external software interfaces",
+		},
+		{
+			name: "no published releases returns not applicable",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithFiles([]string{"api.md"}),
+				RestData:        &data.RestData{},
+			},
+			wantResult: gemara.NotApplicable,
+			wantMsg:    "No published releases found; the external interface documentation requirement does not apply",
+		},
+		{
+			name: "only draft release returns not applicable",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithFiles([]string{"api.md"}),
+				RestData:        &data.RestData{Releases: []data.ReleaseData{{TagName: "v1.0.0", Draft: true}}},
+			},
+			wantResult: gemara.NotApplicable,
+			wantMsg:    "No published releases found; the external interface documentation requirement does not apply",
+		},
+		{
+			name: "api doc file found - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithFiles([]string{"README.md", "api.md"}),
+				RestData:        &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "External interface documentation found (api.md), but coverage of all external interfaces requires manual review",
+		},
+		{
+			name: "openapi spec file found (case insensitive) - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithFiles([]string{"OpenAPI.yaml"}),
+				RestData:        &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "External interface documentation found (OpenAPI.yaml), but coverage of all external interfaces requires manual review",
+		},
+		{
+			name: "api directory found - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithEntries([]fileEntry{
+					{Name: "api", Type: "tree"},
+					{Name: "README.md", Type: "blob"},
+				}),
+				RestData: &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "No external interface documentation file found in root, but found directories that may contain API documentation: api - manual review needed to confirm all external interfaces are documented",
+		},
+		{
+			name: "docs directory found - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithEntries([]fileEntry{
+					{Name: "docs", Type: "tree"},
+					{Name: "README.md", Type: "blob"},
+				}),
+				RestData: &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "No external interface documentation file found in root, but found directories that may contain API documentation: docs - manual review needed to confirm all external interfaces are documented",
+		},
+		{
+			name: "multiple api directories found - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithEntries([]fileEntry{
+					{Name: "api", Type: "tree"},
+					{Name: "docs", Type: "tree"},
+					{Name: "README.md", Type: "blob"},
+				}),
+				RestData: &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "No external interface documentation file found in root, but found directories that may contain API documentation: api, docs - manual review needed to confirm all external interfaces are documented",
+		},
+		{
+			name: "api file takes precedence over api directory - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithEntries([]fileEntry{
+					{Name: "docs", Type: "tree"},
+					{Name: "openapi.json", Type: "blob"},
+				}),
+				RestData: &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "External interface documentation found (openapi.json), but coverage of all external interfaces requires manual review",
+		},
+		{
+			name: "no doc file but DetailedGuide exists - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithFiles([]string{"README.md"}),
+				RestData: &data.RestData{
+					Releases: oneRelease,
+					Insights: si.SecurityInsights{
+						Project: &si.Project{
+							Documentation: &si.ProjectDocumentation{
+								DetailedGuide: ptrTo(si.URL("https://example.com/docs")),
+							},
+						},
+					},
+				},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "No external interface documentation file found, but detailed guide specified in Security Insights - manual review needed to confirm all external interfaces are documented",
+		},
+		{
+			name: "no doc file but QuickstartGuide exists - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithFiles([]string{"README.md"}),
+				RestData: &data.RestData{
+					Releases: oneRelease,
+					Insights: si.SecurityInsights{
+						Project: &si.Project{
+							Documentation: &si.ProjectDocumentation{
+								QuickstartGuide: ptrTo(si.URL("https://example.com/quickstart")),
+							},
+						},
+					},
+				},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "No external interface documentation file found, but quickstart guide specified in Security Insights - manual review needed to confirm all external interfaces are documented",
+		},
+		{
+			name: "release exists but no interface documentation - failed",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithFiles([]string{"README.md"}),
+				RestData: &data.RestData{
+					Releases: oneRelease,
+					Insights: si.SecurityInsights{
+						Project: &si.Project{
+							Documentation: &si.ProjectDocumentation{},
+						},
+					},
+				},
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Documentation describing the external software interfaces of released assets was NOT found",
+		},
+		{
+			name: "release exists but no graphql tree data - failed",
+			payload: data.Payload{
+				GraphqlRepoData: nil,
+				RestData:        &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Documentation describing the external software interfaces of released assets was NOT found",
+		},
+		{
+			name: "directory named like api file should not match as needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithEntries([]fileEntry{
+					{Name: "api.md", Type: "tree"}, // directory, not a file
+					{Name: "README.md", Type: "blob"},
+				}),
+				RestData: &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.Failed,
+			wantMsg:    "Documentation describing the external software interfaces of released assets was NOT found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, gotMsg, _ := HasExternalInterfaceDocumentation(tt.payload)
+			if gotResult != tt.wantResult {
+				t.Errorf("HasExternalInterfaceDocumentation() result = %v, want %v", gotResult, tt.wantResult)
+			}
+			if tt.wantMsg != "" && gotMsg != tt.wantMsg {
+				t.Errorf("HasExternalInterfaceDocumentation() message = %q, want %q", gotMsg, tt.wantMsg)
+			}
+		})
+	}
 }

--- a/evaluation_plans/osps/sec_assessment/steps_test.go
+++ b/evaluation_plans/osps/sec_assessment/steps_test.go
@@ -225,6 +225,8 @@ func Test_HasExternalInterfaceDocumentation(t *testing.T) {
 		payload    data.Payload
 		wantResult gemara.Result
 		wantMsg    string
+		wantConf   gemara.ConfidenceLevel
+		checkConf  bool
 	}{
 		{
 			name:       "no rest data - needs review",
@@ -341,7 +343,7 @@ func Test_HasExternalInterfaceDocumentation(t *testing.T) {
 				},
 			},
 			wantResult: gemara.NeedsReview,
-			wantMsg:    "No external interface documentation file found, but detailed guide specified in Security Insights - manual review needed to confirm all external interfaces are documented",
+			wantMsg:    "No external interface documentation file or directory found, but detailed guide specified in Security Insights - manual review needed to confirm all external interfaces are documented",
 		},
 		{
 			name: "no doc file but QuickstartGuide exists - needs review",
@@ -359,7 +361,7 @@ func Test_HasExternalInterfaceDocumentation(t *testing.T) {
 				},
 			},
 			wantResult: gemara.NeedsReview,
-			wantMsg:    "No external interface documentation file found, but quickstart guide specified in Security Insights - manual review needed to confirm all external interfaces are documented",
+			wantMsg:    "No external interface documentation file or directory found, but quickstart guide specified in Security Insights - manual review needed to confirm all external interfaces are documented",
 		},
 		{
 			name: "release exists but no interface documentation - failed",
@@ -375,7 +377,9 @@ func Test_HasExternalInterfaceDocumentation(t *testing.T) {
 				},
 			},
 			wantResult: gemara.Failed,
-			wantMsg:    "Documentation describing the external software interfaces of released assets was NOT found",
+			wantMsg:    "No documentation file, API-documentation directory, or Security Insights guide describing the external software interfaces of released assets was found",
+			wantConf:   gemara.Medium,
+			checkConf:  true,
 		},
 		{
 			name: "release exists but no graphql tree data - failed",
@@ -384,7 +388,42 @@ func Test_HasExternalInterfaceDocumentation(t *testing.T) {
 				RestData:        &data.RestData{Releases: oneRelease},
 			},
 			wantResult: gemara.Failed,
-			wantMsg:    "Documentation describing the external software interfaces of released assets was NOT found",
+			wantMsg:    "No documentation file, API-documentation directory, or Security Insights guide describing the external software interfaces of released assets was found",
+			wantConf:   gemara.Medium,
+			checkConf:  true,
+		},
+		{
+			name: "api.yaml spec file found - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithFiles([]string{"api.yaml"}),
+				RestData:        &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "External interface documentation found (api.yaml), but coverage of all external interfaces requires manual review",
+		},
+		{
+			name: "documentation directory found - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithEntries([]fileEntry{
+					{Name: "documentation", Type: "tree"},
+					{Name: "README.md", Type: "blob"},
+				}),
+				RestData: &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "No external interface documentation file found in root, but found directories that may contain API documentation: documentation - manual review needed to confirm all external interfaces are documented",
+		},
+		{
+			name: "proto directory found - needs review",
+			payload: data.Payload{
+				GraphqlRepoData: buildGraphqlDataWithEntries([]fileEntry{
+					{Name: "proto", Type: "tree"},
+					{Name: "README.md", Type: "blob"},
+				}),
+				RestData: &data.RestData{Releases: oneRelease},
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "No external interface documentation file found in root, but found directories that may contain API documentation: proto - manual review needed to confirm all external interfaces are documented",
 		},
 		{
 			name: "directory named like api file should not match as needs review",
@@ -396,18 +435,21 @@ func Test_HasExternalInterfaceDocumentation(t *testing.T) {
 				RestData: &data.RestData{Releases: oneRelease},
 			},
 			wantResult: gemara.Failed,
-			wantMsg:    "Documentation describing the external software interfaces of released assets was NOT found",
+			wantMsg:    "No documentation file, API-documentation directory, or Security Insights guide describing the external software interfaces of released assets was found",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotResult, gotMsg, _ := HasExternalInterfaceDocumentation(tt.payload)
+			gotResult, gotMsg, gotConf := HasExternalInterfaceDocumentation(tt.payload)
 			if gotResult != tt.wantResult {
 				t.Errorf("HasExternalInterfaceDocumentation() result = %v, want %v", gotResult, tt.wantResult)
 			}
 			if tt.wantMsg != "" && gotMsg != tt.wantMsg {
 				t.Errorf("HasExternalInterfaceDocumentation() message = %q, want %q", gotMsg, tt.wantMsg)
+			}
+			if tt.checkConf && gotConf != tt.wantConf {
+				t.Errorf("HasExternalInterfaceDocumentation() confidence = %v, want %v", gotConf, tt.wantConf)
 			}
 		})
 	}

--- a/evaluation_plans/reusable_steps/steps.go
+++ b/evaluation_plans/reusable_steps/steps.go
@@ -69,6 +69,22 @@ func IsCodeRepo(payload data.Payload) (result gemara.Result, message string, con
 	return gemara.Passed, "Repository contains code", confidence
 }
 
+// HasPublishedRelease reports whether the project has published at least one
+// non-draft release. observable is false when release data could not be seen,
+// so callers can degrade to manual review instead of a definitive result.
+func HasPublishedRelease(payload data.Payload) (released bool, observable bool) {
+	// Missing REST data or a fetch error means release state is unknown.
+	if payload.RestData == nil || payload.ReleasesError != nil {
+		return false, false
+	}
+	for _, release := range payload.Releases {
+		if !release.Draft {
+			return true, true
+		}
+	}
+	return false, true
+}
+
 // AIFallback logs why an AI-assisted assessment was abandoned and returns
 // NeedsReview with the supplied fallback message. Use this when an AI-assisted
 // step cannot complete (e.g. client construction failure, missing evidence,

--- a/evaluation_plans/reusable_steps/steps_test.go
+++ b/evaluation_plans/reusable_steps/steps_test.go
@@ -1,6 +1,7 @@
 package reusable_steps
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
@@ -213,5 +214,53 @@ func TestIsActive(t *testing.T) {
 		result, message, _ := IsActive(tt.payload)
 		assert.Equal(t, tt.expectedResult, result, tt.assertionMessage)
 		assert.Equal(t, tt.expectedMessage, message, tt.assertionMessage)
+	}
+}
+
+func Test_HasPublishedRelease(t *testing.T) {
+	tests := []struct {
+		name           string
+		payload        data.Payload
+		wantReleased   bool
+		wantObservable bool
+	}{
+		{
+			name:           "nil rest data is unobservable",
+			payload:        data.Payload{RestData: nil},
+			wantReleased:   false,
+			wantObservable: false,
+		},
+		{
+			name:           "releases error is unobservable",
+			payload:        data.Payload{RestData: &data.RestData{ReleasesError: fmt.Errorf("boom")}},
+			wantReleased:   false,
+			wantObservable: false,
+		},
+		{
+			name:           "no releases is observable but unreleased",
+			payload:        data.Payload{RestData: &data.RestData{}},
+			wantReleased:   false,
+			wantObservable: true,
+		},
+		{
+			name:           "only draft releases is observable but unreleased",
+			payload:        data.Payload{RestData: &data.RestData{Releases: []data.ReleaseData{{TagName: "v1.0.0", Draft: true}}}},
+			wantReleased:   false,
+			wantObservable: true,
+		},
+		{
+			name:           "a published release is observable and released",
+			payload:        data.Payload{RestData: &data.RestData{Releases: []data.ReleaseData{{TagName: "v1.0.0", Draft: false}}}},
+			wantReleased:   true,
+			wantObservable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotReleased, gotObservable := HasPublishedRelease(tt.payload)
+			assert.Equal(t, tt.wantReleased, gotReleased, "released")
+			assert.Equal(t, tt.wantObservable, gotObservable, "observable")
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Implements **OSPS-SA-02.01** (closes #30): when the project has made a release, the project documentation MUST include descriptions of all external software interfaces of the released software assets.

Previously `OSPS-SA-02.01` was wired to `reusable_steps.NotImplemented`.

## Approach

Follows the OSPS-SA-03 convention from #426: because automation cannot confirm that documentation covers *all* external interfaces, any positive signal returns **NeedsReview** rather than **Passed**.

New step `sec_assessment.HasExternalInterfaceDocumentation`:
- **NeedsReview** when release data is unobservable (nil `RestData` / releases error)
- **NotApplicable** when there is no published (non-draft) release — the requirement is release-gated
- **NeedsReview** when a positive signal is found:
  - a root API/spec file — exact, case-insensitive names (no globbing): `api.md/rst/txt/yaml/yml/json`, `apidocs.md`, `api-reference.md/rst`, `openapi.yaml/yml/json`, `swagger.yaml/yml/json`
  - a directory that commonly holds API docs (`api`, `apis`, `apidocs`, `api-docs`, `documentation`, `reference`, `references`, `docs`, `doc`, `spec`, `specs`, `openapi`, `swagger`, `schema`, `proto`)
  - a `DetailedGuide` / `QuickstartGuide` declared in Security Insights
- **Failed** (`gemara.Medium`) when a release exists but no such evidence is found

Release gating uses the shared `reusable_steps.HasPublishedRelease` helper (extracted so it is reused rather than duplicated against #426).

## Review feedback addressed

- **Extracted `hasPublishedRelease` → `reusable_steps.HasPublishedRelease`** to remove the byte-identical duplication with the still-open #426 that would otherwise cause a `redeclared in this block` compile error for whichever PR merged second. #426 can consolidate onto the shared helper.
- **Fixed the leaked `Undetermined` confidence** on the terminal `Failed` branch — it now returns an explicit `gemara.Medium` (asserted in tests).
- **Widened the file/dir lists** (`api.yaml/yml/json`; `documentation`, `spec`, `specs`, `openapi`, `swagger`, `schema`, `proto` directories) to avoid false `Failed` results on common legitimate layouts, while keeping a reachable `Failed` consistent with the repo's DO-* / SA-01 "missing required docs → Failed" convention.
- **Clarified messages** to say "file or directory" where both scans came up empty.

## Testing

- `make build`, `go vet`, and `go test ./evaluation_plans/...` all pass
- **100%** statement coverage on `HasExternalInterfaceDocumentation` and `reusable_steps.HasPublishedRelease`

## Docs

- README control counts updated (41 → 42 covered, 11 → 10 not implemented)

No catalog YAML changes needed — `OSPS-SA-02.01` is already defined in the active catalogs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>