### PR TITLE
fix(OSPS-AC-04.01): query documented Actions permissions endpoint

### DIFF
--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -524,7 +524,7 @@ func (r *RestData) getReleases() error {
 }
 
 func (r *RestData) getWorkflowPermissions() error {
-	endpoint := fmt.Sprintf("%s/repos/%s/%s/actions", APIBase, r.owner, r.repo)
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/actions/permissions", APIBase, r.owner, r.repo)
 	responseData, err := r.MakeApiCall(endpoint, true)
 	if err != nil {
 		return err

--- a/data/rest-data_test.go
+++ b/data/rest-data_test.go
@@ -525,3 +525,57 @@ func TestGetReleasesResetsPartialListOnLaterPageError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to decode releases page 2")
 	assert.Nil(t, rest.Releases, "partial results from earlier pages must be discarded on error")
 }
+
+func TestGetWorkflowPermissionsUsesDocumentedEndpoints(t *testing.T) {
+	oldAPIBase := APIBase
+	defer func() { APIBase = oldAPIBase }()
+
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/test-owner/test-repo/actions/permissions":
+			_, _ = w.Write([]byte(`{"enabled": true, "allowed_actions": "all"}`))
+		case "/repos/test-owner/test-repo/actions/permissions/workflow":
+			_, _ = w.Write([]byte(`{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": false}`))
+		default:
+			http.Error(w, `{"message": "Not Found"}`, http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	APIBase = server.URL
+
+	rest := &RestData{
+		owner:      "test-owner",
+		repo:       "test-repo",
+		HttpClient: server.Client(),
+	}
+	require.NoError(t, rest.getWorkflowPermissions())
+	assert.Equal(t, []string{
+		"/repos/test-owner/test-repo/actions/permissions",
+		"/repos/test-owner/test-repo/actions/permissions/workflow",
+	}, requestedPaths)
+	assert.True(t, rest.WorkflowsEnabled)
+	assert.Equal(t, "read", rest.WorkflowPermissions.DefaultPermissions)
+	assert.True(t, rest.WorkflowPermissionsObserved)
+}
+
+func TestGetWorkflowPermissionsInaccessibleLeavesUnobserved(t *testing.T) {
+	oldAPIBase := APIBase
+	defer func() { APIBase = oldAPIBase }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message": "Resource not accessible by integration"}`, http.StatusForbidden)
+	}))
+	defer server.Close()
+	APIBase = server.URL
+
+	rest := &RestData{
+		owner:      "test-owner",
+		repo:       "test-repo",
+		HttpClient: server.Client(),
+	}
+	require.Error(t, rest.getWorkflowPermissions())
+	assert.False(t, rest.WorkflowPermissionsObserved, "insufficient token permissions must leave the observed flag false so the workflow-file heuristic applies")
+}


### PR DESCRIPTION
Fixes #442

## What/Why

`getWorkflowPermissions` called `GET /repos/{owner}/{repo}/actions`, which is not a documented GitHub REST route and returns 404 for every repository, so the Actions enabled/disabled signal never loaded and the follow-up `/actions/permissions/workflow` call never ran. This points the first call at the documented `/actions/permissions` route, restoring the API path for tokens with administration read access.

## Proof it works

- New `TestGetWorkflowPermissionsUsesDocumentedEndpoints` failed with `unexpected response: 404 Not Found` against the old endpoint and passes after the fix; it asserts both documented routes are hit and `WorkflowsEnabled`, `WorkflowPermissions`, and `WorkflowPermissionsObserved` populate.
- New `TestGetWorkflowPermissionsInaccessibleLeavesUnobserved` asserts a 403 leaves `WorkflowPermissionsObserved` false so AC-04.01 keeps using the workflow-file heuristic from #390.
- Full `go test ./...` green.
- Endpoint shape verified live: `gh api repos/{owner}/{repo}/actions/permissions` returns `{"enabled": true, "allowed_actions": "all", ...}` while `/actions` returns 404.

## Risk + AI role

Low. One endpoint string plus two regression tests. Fix and tests were AI-assisted and human-reviewed.

## Review focus

The non-admin fallback path: a 403 on the permissions endpoint must leave `WorkflowPermissionsObserved` false. Also worth confirming no other consumer expected `WorkflowsEnabled` to stay false-by-default now that the API path actually works for admin tokens.