### PR TITLE
fix(OSPS-SA-03.02): match threat-modeling acronyms as whole words

### DIFF
--- a/evaluation_plans/osps/sec_assessment/steps.go
+++ b/evaluation_plans/osps/sec_assessment/steps.go
@@ -2,6 +2,7 @@ package sec_assessment
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
@@ -170,18 +171,22 @@ func HasExternalInterfaceDocumentation(payload data.Payload) (result gemara.Resu
 
 // threatModelingIndicators are lowercase phrases that signal a security
 // assessment covered threat modeling or attack surface analysis rather than a
-// generic review. They are matched against the assessment name and comment.
+// generic review. They are matched against the assessment name and comment as
+// substrings so compound usages ("threat modeling", "attack surfaces") still
+// count.
 var threatModelingIndicators = []string{
 	"threat model",
 	"threat-model",
 	"threatmodel",
 	"attack surface",
 	"attack-surface",
-	"stride",
-	"pasta",
-	"dread",
 	"attack tree",
 }
+
+// threatModelingAcronyms matches methodology acronyms as whole words so
+// incidental substrings like "restrided", "antipasta", or "dreadful" are not
+// counted as threat-modeling mentions.
+var threatModelingAcronyms = regexp.MustCompile(`\b(stride|pasta|dread)\b`)
 
 // assessmentDenials are lowercase phrases that indicate a comment is declaring
 // the *absence* of an assessment rather than one that was performed. Comment is
@@ -256,7 +261,7 @@ func mentionsThreatModeling(assessment si.Assessment) bool {
 			return true
 		}
 	}
-	return false
+	return threatModelingAcronyms.MatchString(text)
 }
 
 // securityAssessments returns the repository's declared security assessments,

--- a/evaluation_plans/osps/sec_assessment/steps_test.go
+++ b/evaluation_plans/osps/sec_assessment/steps_test.go
@@ -727,6 +727,14 @@ func Test_HasThreatModelAnalysis(t *testing.T) {
 			wantMsg:    "A security assessment is declared but does not mention threat modeling or attack surface analysis - manual review needed",
 		},
 		{
+			name: "incidental acronym substrings do not count as threat modeling terms - needs review",
+			payload: data.Payload{
+				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Comment: "The dreadful backlog was restrided over antipasta"}),
+			},
+			wantResult: gemara.NeedsReview,
+			wantMsg:    "A security assessment is declared but does not mention threat modeling or attack surface analysis - manual review needed",
+		},
+		{
 			name: "negated self assessment comment - failed",
 			payload: data.Payload{
 				RestData: restDataWithReleaseAndAssessments(true, si.Assessment{Comment: "A formal self-assessment has not yet been completed for this project."}),
@@ -789,6 +797,31 @@ func Test_HasThreatModelAnalysis(t *testing.T) {
 			}
 			if gotMsg != tt.wantMsg {
 				t.Errorf("HasThreatModelAnalysis() message = %q, want %q", gotMsg, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func Test_mentionsThreatModeling(t *testing.T) {
+	tests := []struct {
+		name       string
+		assessment si.Assessment
+		want       bool
+	}{
+		{name: "phrase indicator", assessment: si.Assessment{Comment: "We performed threat modeling on the API"}, want: true},
+		{name: "acronym as whole word", assessment: si.Assessment{Comment: "Analyzed with STRIDE"}, want: true},
+		{name: "acronym with hyphen suffix", assessment: si.Assessment{Comment: "STRIDE-based review of trust boundaries"}, want: true},
+		{name: "acronym with punctuation", assessment: si.Assessment{Comment: "Methodologies used: PASTA, DREAD."}, want: true},
+		{name: "dreadful is not DREAD", assessment: si.Assessment{Comment: "The dreadful state of the docs was reviewed"}, want: false},
+		{name: "antipasta is not PASTA", assessment: si.Assessment{Comment: "Team lunch featured antipasta"}, want: false},
+		{name: "restrided is not STRIDE", assessment: si.Assessment{Comment: "We restrided the migration plan"}, want: false},
+		{name: "no indicators", assessment: si.Assessment{Comment: "General security review"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mentionsThreatModeling(tt.assessment); got != tt.want {
+				t.Errorf("mentionsThreatModeling(%q) = %v, want = %v", tt.assessment.Comment, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #429

## What/Why

`mentionsThreatModeling` matched its full indicator list with `strings.Contains`, so incidental substrings like `dreadful`, `antipasta`, or `restrided` were counted as threat-modeling mentions and selected the "declares threat modeling" message. This moves the three methodology acronyms (`stride`, `pasta`, `dread`) to a word-boundary regex while keeping substring matching for the phrase indicators, so compound usages like "threat modeling" and "attack surfaces" still count (the risk called out in the issue).

## Proof it works

- New `Test_mentionsThreatModeling` covers whole-word, hyphen-suffix (`STRIDE-based`), and punctuation-adjacent (`PASTA, DREAD.`) acronym matches plus the three incidental substrings; those three failed against the old matcher and pass after the fix.
- A new `Test_HasThreatModelAnalysis` case proves message selection no longer credits incidental substrings.
- Full `go test ./...` green.

As the issue notes, impact is message-only: both branches return `NeedsReview` at `Low` confidence, so no verdicts change.

## Risk + AI role

Low. Message-only impact by design. Fix and tests were AI-assisted and human-reviewed.

## Review focus

The phrase/acronym split: phrase indicators intentionally stay substring-matched so compounds keep matching. Confirm no other short indicators belong in the word-boundary set.