### PR TITLE
feat(OSPS-GV-04.01): require review before escalated permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Many of the assessments depend upon the presence of a [Security Insights](https:
 
 ## Work in Progress
 
-Currently 42 control requirements across OSPS Baselines levels 1-3 are covered, with 10 not yet implemented. [Maturity Level 1](https://baseline.openssf.org/versions/2025-02-25.html#level-1) requirements are the most rigorously tested and are recommended for use. The results of these layer 1 assessments are integrated into [LFX Insights](https://insights.linuxfoundation.org/project/k8s/repository/kubernetes-kubernetes/security), powering the [Security & Best Practices results](https://insights.linuxfoundation.org/docs/metrics/security/).
+Currently 43 control requirements across OSPS Baselines levels 1-3 are covered, with 9 not yet implemented. [Maturity Level 1](https://baseline.openssf.org/versions/2025-02-25.html#level-1) requirements are the most rigorously tested and are recommended for use. The results of these layer 1 assessments are integrated into [LFX Insights](https://insights.linuxfoundation.org/project/k8s/repository/kubernetes-kubernetes/security), powering the [Security & Best Practices results](https://insights.linuxfoundation.org/docs/metrics/security/).
 
 ![alt text](kubernetes_insights_baseline.png)
 

--- a/evaluation_plans/evaluation-plans.go
+++ b/evaluation_plans/evaluation-plans.go
@@ -124,7 +124,7 @@ var (
 			governance.HasContributionReviewPolicy,
 		},
 		"OSPS-GV-04.01": {
-			reusable_steps.NotImplemented,
+			governance.HasEscalatedPermissionsReviewPolicy,
 		},
 		"OSPS-LE-01.01": {
 			reusable_steps.GithubTermsOfService,

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -1,6 +1,7 @@
 package governance
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
@@ -145,4 +146,138 @@ func HasContributionReviewPolicy(payload data.Payload) (result gemara.Result, me
 	}
 
 	return gemara.Failed, "No contributor guide documenting requirements for acceptable contributions found in Security Insights data or repository files", gemara.Medium
+}
+
+// Vocabulary for OSPS-GV-04.01. All patterns are word-boundary anchored so
+// unrelated words cannot match as substrings.
+var (
+	// escalationVocabPattern recognizes text about collaborator roles and the
+	// permissions those roles carry.
+	escalationVocabPattern = regexp.MustCompile(`(?i)\b(?:maintainer|committer|collaborator|commit access|write access|push access|merge rights|admin(?:istrator)?\s+(?:role|rights|access)|elevated\s+(?:permissions?|privileges?|access)|escalated\s+permissions?|owner\s+role)\b`)
+
+	// reviewVocabPattern recognizes text about a person being reviewed,
+	// approved, nominated, or vetted.
+	reviewVocabPattern = regexp.MustCompile(`(?i)\b(?:review(?:ed)?|approv(?:e|ed|al)|nominat(?:e|ed|ion)|vote(?:d)?|consensus|sponsor(?:ed)?|vett(?:ed|ing))\b`)
+
+	// escalationObligationPattern recognizes language that makes the review a
+	// requirement rather than a description.
+	escalationObligationPattern = regexp.MustCompile(`(?i)\b(?:must|shall|required?|requires|only\s+(?:after|by|through|via)|needs?\s+to\s+be\s+approved)\b`)
+
+	// escalationNegationPattern recognizes language that disclaims or weakens
+	// the requirement within the same section, so contradictory prose is not
+	// credited as a definitive policy (the lesson from the VM-05 prose checks).
+	escalationNegationPattern = regexp.MustCompile(`(?i)\b(?:not\s+required|no\s+(?:formal\s+)?review|optional|informal(?:ly)?|do(?:es)?\s+not\s+require|without\s+(?:a\s+)?review)\b`)
+
+	// fencedCodeBlockPattern strips fenced code blocks before prose analysis so
+	// example snippets cannot satisfy or negate the policy vocabulary.
+	fencedCodeBlockPattern = regexp.MustCompile("(?s)```.*?```")
+)
+
+// escalationPolicySections splits a documentation file into markdown-heading
+// sections with fenced code blocks removed, so vocabulary co-occurrence is
+// judged within one topical section rather than across an entire file.
+func escalationPolicySections(content string) []string {
+	cleaned := fencedCodeBlockPattern.ReplaceAllString(content, "")
+	var sections []string
+	var current []string
+	flush := func() {
+		if len(current) > 0 {
+			sections = append(sections, strings.Join(current, "\n"))
+			current = nil
+		}
+	}
+	for _, line := range strings.Split(cleaned, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			flush()
+		}
+		current = append(current, line)
+	}
+	flush()
+	return sections
+}
+
+// classifyEscalationSection reports whether a section mentions collaborator
+// escalation together with review (mention), and whether it additionally states
+// the review as an uncontradicted requirement (policy).
+func classifyEscalationSection(section string) (mention bool, policy bool) {
+	if !escalationVocabPattern.MatchString(section) || !reviewVocabPattern.MatchString(section) {
+		return false, false
+	}
+	if !escalationObligationPattern.MatchString(section) {
+		return true, false
+	}
+	if escalationNegationPattern.MatchString(section) {
+		return true, false
+	}
+	return true, true
+}
+
+// HasEscalatedPermissionsReviewPolicy implements OSPS-GV-04.01: while active,
+// the project documentation MUST have a policy that code collaborators are
+// reviewed prior to granting escalated permissions to sensitive resources.
+//
+// This is distinct from GV-03.02 (requirements for acceptable contributions):
+// the subject here is the person receiving elevated access, not the change
+// being merged. Security Insights has no escalation-policy field, so evidence
+// is layered: repository documentation prose is scanned for a section that
+// pairs escalation vocabulary with review vocabulary; an uncontradicted
+// requirement Passes at Medium (heuristic prose match), a weaker pairing or a
+// declared Security Insights governance URL or a governance file needs human
+// review, and an observed absence of every signal Fails, mirroring GV-03.02's
+// terminal. Unreadable documentation is never reported as a violation.
+func HasEscalatedPermissionsReviewPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
+	if !payload.IsCodeRepo {
+		return gemara.NotApplicable, "Repository contains no code - skipping escalated-permissions policy check", gemara.High
+	}
+
+	files, docsErr := payload.GetDocumentationFiles()
+	policyFile := ""
+	mentionFile := ""
+	for _, file := range files {
+		for _, section := range escalationPolicySections(file.Content) {
+			mention, policy := classifyEscalationSection(section)
+			if policy && policyFile == "" {
+				policyFile = file.Path
+			}
+			if mention && mentionFile == "" {
+				mentionFile = file.Path
+			}
+		}
+	}
+
+	if policyFile != "" {
+		return gemara.Passed, "Documentation requires code collaborators to be reviewed before receiving escalated permissions (" + policyFile + ")", gemara.Medium
+	}
+	if mentionFile != "" {
+		return gemara.NeedsReview, "Documentation discusses collaborator roles and review (" + mentionFile + ") but does not state an uncontradicted requirement that collaborators are reviewed before escalated permissions are granted; manual review required", gemara.Medium
+	}
+	if payload.RestData != nil && payload.Insights.Repository != nil &&
+		payload.Insights.Repository.Documentation != nil &&
+		payload.Insights.Repository.Documentation.Governance != nil {
+		return gemara.NeedsReview, "Governance documentation is declared in Security Insights; confirm it requires review of code collaborators before escalated permissions are granted", gemara.Medium
+	}
+	if file := governanceFilePresent(files); file != "" {
+		return gemara.NeedsReview, "A governance document (" + file + ") is present but no escalation-review policy language was recognized; manual review required", gemara.Low
+	}
+	if docsErr != nil {
+		return gemara.NeedsReview, "Repository documentation could not be fully read; manually review whether a collaborator escalation-review policy is documented", gemara.Low
+	}
+
+	return gemara.Failed, "No policy requiring review of code collaborators before granting escalated permissions was found in repository documentation or Security Insights data", gemara.Medium
+}
+
+// governanceFilePresent returns the path of a conventional governance or
+// maintainers document among the fetched documentation files, or "".
+func governanceFilePresent(files []data.DocumentationFile) string {
+	for _, file := range files {
+		base := strings.ToLower(file.Path)
+		if slash := strings.LastIndex(base, "/"); slash >= 0 {
+			base = base[slash+1:]
+		}
+		switch base {
+		case "governance.md", "governance", "maintainers.md", "maintainers":
+			return file.Path
+		}
+	}
+	return ""
 }

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -148,31 +148,136 @@ func HasContributionReviewPolicy(payload data.Payload) (result gemara.Result, me
 	return gemara.Failed, "No contributor guide documenting requirements for acceptable contributions found in Security Insights data or repository files", gemara.Medium
 }
 
-// Vocabulary for detecting an escalated-permissions review policy. All
-// patterns are word-boundary anchored so unrelated words cannot match as
-// substrings.
+// fencedCodeBlockPattern strips fenced code blocks before prose analysis so
+// example snippets cannot satisfy or negate the policy vocabulary.
+var fencedCodeBlockPattern = regexp.MustCompile("(?s)```.*?```")
+
+// escalationTokens lowercases prose and strips punctuation. No stemming is
+// attempted: vocabulary entries are written as stems and compared by prefix,
+// which handles inflection by construction rather than by guessing suffixes.
+func escalationTokens(text string) []string {
+	fields := strings.Fields(text)
+	tokens := make([]string, 0, len(fields))
+	for _, field := range fields {
+		token := strings.ToLower(strings.Trim(field, ".,;:!?()[]{}\"'`"))
+		if token != "" {
+			tokens = append(tokens, token)
+		}
+	}
+	return tokens
+}
+
+// escalationTokenMatches compares one prose token against one vocabulary token.
+// A vocabulary entry of four or more characters is treated as a stem, so
+// "approv" covers approve/approved/approval/approves/approving and "maintainer"
+// covers the plural, without enumerating forms. Short entries such as "to" must
+// match exactly, so they cannot match inside unrelated words.
+func escalationTokenMatches(token, vocabToken string) bool {
+	if len(vocabToken) >= 4 {
+		return strings.HasPrefix(token, vocabToken)
+	}
+	return token == vocabToken
+}
+
+// escalationVocabulary is a set of phrases, each one or more consecutive
+// normalized tokens. Extending a vocabulary means adding a string.
+type escalationVocabulary struct {
+	name    string
+	phrases [][]string
+}
+
+func newEscalationVocabulary(name string, entries ...string) escalationVocabulary {
+	vocabulary := escalationVocabulary{name: name}
+	for _, entry := range entries {
+		vocabulary.phrases = append(vocabulary.phrases, escalationTokens(entry))
+	}
+	return vocabulary
+}
+
+// find returns the index of the earliest matching phrase, or -1. It returns a
+// position rather than a bool because the control requires review *prior to*
+// escalation, and an ordering relation cannot be expressed with a bool.
+func (v escalationVocabulary) find(tokens []string) int {
+	earliest := -1
+	for _, phrase := range v.phrases {
+		if len(phrase) == 0 {
+			continue
+		}
+		for i := 0; i+len(phrase) <= len(tokens); i++ {
+			matched := true
+			for j, want := range phrase {
+				if !escalationTokenMatches(tokens[i+j], want) {
+					matched = false
+					break
+				}
+			}
+			if matched && (earliest == -1 || i < earliest) {
+				earliest = i
+			}
+		}
+	}
+	return earliest
+}
+
+func (v escalationVocabulary) has(tokens []string) bool { return v.find(tokens) >= 0 }
+
+// Vocabulary for the escalated-permissions review policy. Note the distinction
+// a single pattern cannot draw: a role noun ("maintainer") is not itself
+// evidence of escalation, while an access object ("write access") or a granting
+// verb applied to a role is. That separation is what keeps prose about
+// reviewing *changes* from being read as a policy about vetting *people*.
 var (
-	// escalationVocabPattern recognizes text about collaborator roles and the
-	// permissions those roles carry.
-	escalationVocabPattern = regexp.MustCompile(`(?i)\b(?:maintainer|committer|collaborator|commit access|write access|push access|merge rights|admin(?:istrator)?\s+(?:role|rights|access)|elevated\s+(?:permissions?|privileges?|access)|escalated\s+permissions?|owner\s+role)\b`)
+	escalationAccessVocab = newEscalationVocabulary("access",
+		"write access", "commit access", "push access", "merge right",
+		"elevated permission", "elevated privilege", "elevated access",
+		"escalated permission", "admin access", "admin right",
+		"owner role", "maintainer role", "committer role", "triage right",
+	)
 
-	// reviewVocabPattern recognizes text about a person being reviewed,
-	// approved, nominated, or vetted.
-	reviewVocabPattern = regexp.MustCompile(`(?i)\b(?:review(?:ed)?|approv(?:e|ed|al)|nominat(?:e|ed|ion)|vote(?:d)?|consensus|sponsor(?:ed)?|vett(?:ed|ing))\b`)
+	escalationGrantVocab = newEscalationVocabulary("grant",
+		"grant", "receiv", "promot", "added as", "becom", "onboard",
+		"elevated to",
+	)
 
-	// escalationObligationPattern recognizes language that makes the review a
-	// requirement rather than a description.
-	escalationObligationPattern = regexp.MustCompile(`(?i)\b(?:must|shall|required?|requires|only\s+(?:after|by|through|via)|needs?\s+to\s+be\s+approved)\b`)
+	escalationRoleVocab = newEscalationVocabulary("role",
+		"maintainer", "committer", "collaborator", "approver", "owner",
+	)
 
-	// escalationNegationPattern recognizes language that disclaims or weakens
-	// the requirement within the same section, so contradictory prose is not
-	// credited as a definitive policy (the lesson from the SCA policy prose
-	// checks in vuln_management).
-	escalationNegationPattern = regexp.MustCompile(`(?i)\b(?:not\s+required|no\s+(?:formal\s+)?review|optional|informal(?:ly)?|do(?:es)?\s+not\s+require|without\s+(?:a\s+)?review)\b`)
+	escalationReviewVocab = newEscalationVocabulary("review",
+		"review", "approv", "nominat", "vote", "consensus", "vett",
+		"sponsor", "endors",
+	)
 
-	// fencedCodeBlockPattern strips fenced code blocks before prose analysis so
-	// example snippets cannot satisfy or negate the policy vocabulary.
-	fencedCodeBlockPattern = regexp.MustCompile("(?s)```.*?```")
+	escalationObligationVocab = newEscalationVocabulary("obligation",
+		"must", "shall", "requir", "only after", "only by", "only through",
+		"only via", "need to be approv", "may not", "cannot",
+	)
+
+	// An explicit ordering cue is itself a statement of required sequence, so
+	// it also satisfies the obligation gate for declaratively-phrased policies
+	// that carry no modal verb.
+	escalationOrderingVocab = newEscalationVocabulary("ordering",
+		"before", "prior to", "only after", "until", "preced",
+	)
+
+	// Language that disclaims or weakens the requirement, so contradictory
+	// prose is not credited as a definitive policy (the lesson from the SCA
+	// policy prose checks in vuln_management). Evaluated per sentence rather
+	// than per section, so an unrelated "optional" elsewhere cannot suppress a
+	// real policy.
+	escalationNegationVocab = newEscalationVocabulary("negation",
+		"not requir", "no formal review", "no review", "optional",
+		"informal", "does not requir", "do not requir", "without review",
+		"without a review", "at their discretion",
+	)
+
+	// A heading such as "Becoming a Maintainer" establishes that the whole
+	// section concerns conferring a role, which lets sentences inside it omit
+	// the access object without losing the subject.
+	escalationHeadingVocab = newEscalationVocabulary("heading",
+		"becom", "adding", "onboard", "promotion", "nominat", "joining",
+		"new maintainer", "new committer",
+	)
 )
 
 // escalationPolicySections splits a documentation file into markdown-heading
@@ -198,20 +303,79 @@ func escalationPolicySections(content string) []string {
 	return sections
 }
 
+// escalationSentences splits a section into sentences. Judging co-occurrence
+// per sentence rather than per section is what ties the review verb to the
+// escalation it governs.
+func escalationSentences(section string) []string {
+	var sentences []string
+	var current strings.Builder
+	flush := func() {
+		if sentence := strings.TrimSpace(current.String()); sentence != "" {
+			sentences = append(sentences, sentence)
+		}
+		current.Reset()
+	}
+	for _, r := range section {
+		current.WriteRune(r)
+		if r == '.' || r == ';' || r == '!' || r == '\n' {
+			flush()
+		}
+	}
+	flush()
+	return sentences
+}
+
 // classifyEscalationSection reports whether a section mentions collaborator
 // escalation together with review (mention), and whether it additionally states
 // the review as an uncontradicted requirement (policy).
+//
+// A section carries its own heading as its first line, so heading context is
+// available without changing the caller.
 func classifyEscalationSection(section string) (mention bool, policy bool) {
-	if !escalationVocabPattern.MatchString(section) || !reviewVocabPattern.MatchString(section) {
-		return false, false
+	heading, _, _ := strings.Cut(section, "\n")
+	headingTokens := escalationTokens(heading)
+	headingConfersRole := escalationHeadingVocab.has(headingTokens) &&
+		escalationRoleVocab.has(headingTokens)
+
+	for _, sentence := range escalationSentences(section) {
+		tokens := escalationTokens(sentence)
+
+		reviewAt := escalationReviewVocab.find(tokens)
+		if reviewAt < 0 {
+			continue
+		}
+
+		// The escalation subject must be an access object, or a granting verb
+		// applied to a role -- not a bare role noun. This is what stops
+		// "requires approval from a maintainer", which is about reviewing a
+		// change, from counting as evidence about granting access to a person.
+		escalationAt := escalationAccessVocab.find(tokens)
+		if escalationAt < 0 && escalationGrantVocab.has(tokens) && escalationRoleVocab.has(tokens) {
+			escalationAt = escalationGrantVocab.find(tokens)
+		}
+		if escalationAt < 0 && !headingConfersRole {
+			continue
+		}
+
+		mention = true
+
+		explicitOrder := escalationOrderingVocab.has(tokens)
+		if !escalationObligationVocab.has(tokens) && !explicitOrder {
+			continue
+		}
+		if escalationNegationVocab.has(tokens) {
+			continue
+		}
+		// Reviewed prior to granting: an explicit cue is strongest, otherwise
+		// the review term appearing ahead of the escalation term is weaker
+		// positional evidence of the same ordering.
+		if !explicitOrder && escalationAt >= 0 && reviewAt > escalationAt {
+			continue
+		}
+		policy = true
 	}
-	if !escalationObligationPattern.MatchString(section) {
-		return true, false
-	}
-	if escalationNegationPattern.MatchString(section) {
-		return true, false
-	}
-	return true, true
+
+	return mention, policy
 }
 
 // HasEscalatedPermissionsReviewPolicy checks that the project documentation
@@ -261,8 +425,8 @@ func HasEscalatedPermissionsReviewPolicy(payload data.Payload) (result gemara.Re
 	if file := governanceFilePresent(files); file != "" {
 		return gemara.NeedsReview, "A governance document (" + file + ") is present but no escalation-review policy language was recognized; manual review required", gemara.Low
 	}
-	if docsErr != nil {
-		return gemara.NeedsReview, "Repository documentation could not be fully read; manually review whether a collaborator escalation-review policy is documented", gemara.Low
+	if docsErr != nil || (payload.RestData != nil && payload.InsightsError) {
+		return gemara.NeedsReview, "Repository documentation or Security Insights could not be completely inspected; manually review whether a collaborator escalation-review policy is documented", gemara.Low
 	}
 
 	return gemara.Failed, "No policy requiring review of code collaborators before granting escalated permissions was found in repository documentation or Security Insights data", gemara.Medium

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -1,7 +1,6 @@
 package governance
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/gemaraproj/go-gemara"
@@ -148,10 +147,6 @@ func HasContributionReviewPolicy(payload data.Payload) (result gemara.Result, me
 	return gemara.Failed, "No contributor guide documenting requirements for acceptable contributions found in Security Insights data or repository files", gemara.Medium
 }
 
-// fencedCodeBlockPattern strips fenced code blocks before prose analysis so
-// example snippets cannot satisfy or negate the policy vocabulary.
-var fencedCodeBlockPattern = regexp.MustCompile("(?s)```.*?```")
-
 // escalationTokens lowercases prose and strips punctuation. No stemming is
 // attempted: vocabulary entries are written as stems and compared by prefix,
 // which handles inflection by construction rather than by guessing suffixes.
@@ -284,17 +279,38 @@ var (
 // sections with fenced code blocks removed, so vocabulary co-occurrence is
 // judged within one topical section rather than across an entire file.
 func escalationPolicySections(content string) []string {
-	cleaned := fencedCodeBlockPattern.ReplaceAllString(content, "")
-	var sections []string
-	var current []string
+	var (
+		sections []string
+		current  []string
+		inFence  bool
+	)
 	flush := func() {
 		if len(current) > 0 {
 			sections = append(sections, strings.Join(current, "\n"))
 			current = nil
 		}
 	}
-	for _, line := range strings.Split(cleaned, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Tracking fence state as we scan, rather than matching balanced pairs,
+		// means an unterminated fence swallows the rest of the file instead of
+		// leaving its contents to be read as prose. It also covers ~~~ fences.
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		// Blockquotes are skipped, matching the vuln_management scanner: the
+		// common governance blockquote quotes the requirement being satisfied,
+		// which contains exactly the vocabulary that would earn an unearned
+		// Pass. A policy stated only inside a callout degrades to the
+		// governance-file NeedsReview branch rather than being credited.
+		if strings.HasPrefix(trimmed, ">") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
 			flush()
 		}
 		current = append(current, line)

--- a/evaluation_plans/osps/governance/steps.go
+++ b/evaluation_plans/osps/governance/steps.go
@@ -148,8 +148,9 @@ func HasContributionReviewPolicy(payload data.Payload) (result gemara.Result, me
 	return gemara.Failed, "No contributor guide documenting requirements for acceptable contributions found in Security Insights data or repository files", gemara.Medium
 }
 
-// Vocabulary for OSPS-GV-04.01. All patterns are word-boundary anchored so
-// unrelated words cannot match as substrings.
+// Vocabulary for detecting an escalated-permissions review policy. All
+// patterns are word-boundary anchored so unrelated words cannot match as
+// substrings.
 var (
 	// escalationVocabPattern recognizes text about collaborator roles and the
 	// permissions those roles carry.
@@ -165,7 +166,8 @@ var (
 
 	// escalationNegationPattern recognizes language that disclaims or weakens
 	// the requirement within the same section, so contradictory prose is not
-	// credited as a definitive policy (the lesson from the VM-05 prose checks).
+	// credited as a definitive policy (the lesson from the SCA policy prose
+	// checks in vuln_management).
 	escalationNegationPattern = regexp.MustCompile(`(?i)\b(?:not\s+required|no\s+(?:formal\s+)?review|optional|informal(?:ly)?|do(?:es)?\s+not\s+require|without\s+(?:a\s+)?review)\b`)
 
 	// fencedCodeBlockPattern strips fenced code blocks before prose analysis so
@@ -212,19 +214,19 @@ func classifyEscalationSection(section string) (mention bool, policy bool) {
 	return true, true
 }
 
-// HasEscalatedPermissionsReviewPolicy implements OSPS-GV-04.01: while active,
-// the project documentation MUST have a policy that code collaborators are
-// reviewed prior to granting escalated permissions to sensitive resources.
+// HasEscalatedPermissionsReviewPolicy checks that the project documentation
+// has a policy that code collaborators are reviewed prior to granting
+// escalated permissions to sensitive resources.
 //
-// This is distinct from GV-03.02 (requirements for acceptable contributions):
-// the subject here is the person receiving elevated access, not the change
-// being merged. Security Insights has no escalation-policy field, so evidence
+// This is distinct from HasContributionReviewPolicy (requirements for
+// acceptable contributions): the subject here is the person receiving elevated
+// access, not the change being merged. Security Insights has no escalation-policy field, so evidence
 // is layered: repository documentation prose is scanned for a section that
 // pairs escalation vocabulary with review vocabulary; an uncontradicted
 // requirement Passes at Medium (heuristic prose match), a weaker pairing or a
 // declared Security Insights governance URL or a governance file needs human
-// review, and an observed absence of every signal Fails, mirroring GV-03.02's
-// terminal. Unreadable documentation is never reported as a violation.
+// review, and an observed absence of every signal Fails, mirroring
+// HasContributionReviewPolicy's terminal. Unreadable documentation is never reported as a violation.
 func HasEscalatedPermissionsReviewPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if !payload.IsCodeRepo {
 		return gemara.NotApplicable, "Repository contains no code - skipping escalated-permissions policy check", gemara.High

--- a/evaluation_plans/osps/governance/steps_test.go
+++ b/evaluation_plans/osps/governance/steps_test.go
@@ -355,3 +355,143 @@ func TestHasRolesAndResponsibilities(t *testing.T) {
 		})
 	}
 }
+
+// escalationDocsPayload builds a code-repo payload whose root contains a single
+// documentation file with the given content.
+func escalationDocsPayload(fileName, content string) data.Payload {
+	return data.NewPayloadWithRepoContents(
+		data.Payload{IsCodeRepo: true},
+		[]*github.RepositoryContent{{
+			Type:    github.Ptr("file"),
+			Name:    github.Ptr(fileName),
+			Path:    github.Ptr(fileName),
+			Content: github.Ptr(content),
+		}},
+		map[string][]*github.RepositoryContent{},
+	)
+}
+
+func TestHasEscalatedPermissionsReviewPolicy(t *testing.T) {
+	const clearPolicy = "# Becoming a maintainer\n\nNew maintainers must be approved by two existing maintainers before receiving write access.\n"
+	const negatedPolicy = "# Becoming a maintainer\n\nMaintainers must have write access, though a formal review is optional for long-time contributors.\n"
+	const mentionOnly = "# Roles\n\nNew maintainers typically get write access after a review by the core team.\n"
+	const splitSections = "# Roles\n\nMaintainers hold write access.\n\n# Reviews\n\nAll pull requests must be reviewed and approved.\n"
+	const fencedOnly = "# Setup\n\n```\nNew maintainers must be approved before receiving write access.\n```\n"
+
+	tests := []struct {
+		name           string
+		payload        data.Payload
+		wantResult     gemara.Result
+		wantMsgPart    string
+		wantConfidence gemara.ConfidenceLevel
+	}{
+		{
+			name:           "non-code repository is not applicable",
+			payload:        data.Payload{},
+			wantResult:     gemara.NotApplicable,
+			wantMsgPart:    "no code",
+			wantConfidence: gemara.High,
+		},
+		{
+			name:           "uncontradicted requirement passes",
+			payload:        escalationDocsPayload("GOVERNANCE.md", clearPolicy),
+			wantResult:     gemara.Passed,
+			wantMsgPart:    "GOVERNANCE.md",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name:           "negated requirement needs review",
+			payload:        escalationDocsPayload("GOVERNANCE.md", negatedPolicy),
+			wantResult:     gemara.NeedsReview,
+			wantMsgPart:    "does not state an uncontradicted requirement",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name:           "mention without obligation needs review",
+			payload:        escalationDocsPayload("README.md", mentionOnly),
+			wantResult:     gemara.NeedsReview,
+			wantMsgPart:    "does not state an uncontradicted requirement",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name:           "vocabulary split across sections is not a mention",
+			payload:        escalationDocsPayload("README.md", splitSections),
+			wantResult:     gemara.Failed,
+			wantMsgPart:    "No policy requiring review",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name:           "policy text inside a code fence is not credited",
+			payload:        escalationDocsPayload("README.md", fencedOnly),
+			wantResult:     gemara.Failed,
+			wantMsgPart:    "No policy requiring review",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name:           "governance file without policy language needs review",
+			payload:        escalationDocsPayload("GOVERNANCE.md", "# Governance\n\nTBD.\n"),
+			wantResult:     gemara.NeedsReview,
+			wantMsgPart:    "governance document (GOVERNANCE.md)",
+			wantConfidence: gemara.Low,
+		},
+		{
+			name:           "unreadable documentation needs review",
+			payload:        data.Payload{IsCodeRepo: true},
+			wantResult:     gemara.NeedsReview,
+			wantMsgPart:    "could not be fully read",
+			wantConfidence: gemara.Low,
+		},
+		{
+			name:           "no signals fails",
+			payload:        escalationDocsPayload("README.md", "# Hello\n\nA library.\n"),
+			wantResult:     gemara.Failed,
+			wantMsgPart:    "No policy requiring review",
+			wantConfidence: gemara.Medium,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, message, confidence := HasEscalatedPermissionsReviewPolicy(testCase.payload)
+			assert.Equal(t, testCase.wantResult, result, testCase.name)
+			assert.Contains(t, message, testCase.wantMsgPart, testCase.name)
+			assert.Equal(t, testCase.wantConfidence, confidence, testCase.name)
+		})
+	}
+}
+
+func TestHasEscalatedPermissionsReviewPolicySecurityInsightsFallback(t *testing.T) {
+	payload := escalationDocsPayload("README.md", "# Hello\n\nA library.\n")
+	payload.Insights.Repository = &si.Repository{
+		Documentation: &si.RepositoryDocumentation{Governance: stubURL("https://example.com/governance")},
+	}
+
+	result, message, confidence := HasEscalatedPermissionsReviewPolicy(payload)
+	assert.Equal(t, gemara.NeedsReview, result)
+	assert.Contains(t, message, "declared in Security Insights")
+	assert.Equal(t, gemara.Medium, confidence)
+}
+
+func TestClassifyEscalationSection(t *testing.T) {
+	tests := []struct {
+		name        string
+		section     string
+		wantMention bool
+		wantPolicy  bool
+	}{
+		{"requirement", "new maintainers must be approved before write access", true, true},
+		{"only after", "write access is granted only after review by the tsc", true, true},
+		{"negated", "maintainers must be reviewed, but approval is not required for write access", true, false},
+		{"no obligation", "maintainers were reviewed when they got write access", true, false},
+		{"escalation only", "maintainers hold write access", false, false},
+		{"review only", "all changes must be reviewed and approved", false, false},
+		{"empty", "", false, false},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			mention, policy := classifyEscalationSection(testCase.section)
+			assert.Equal(t, testCase.wantMention, mention, "mention: "+testCase.name)
+			assert.Equal(t, testCase.wantPolicy, policy, "policy: "+testCase.name)
+		})
+	}
+}

--- a/evaluation_plans/osps/governance/steps_test.go
+++ b/evaluation_plans/osps/governance/steps_test.go
@@ -379,6 +379,10 @@ func TestHasEscalatedPermissionsReviewPolicy(t *testing.T) {
 	const fencedOnly = "# Setup\n\n```\nNew maintainers must be approved before receiving write access.\n```\n"
 	const pluralOnlyPolicy = "# Becoming a maintainer\n\nNew maintainers must be nominated and approved by a vote of existing maintainers.\n"
 	const reviewOfChangesOnly = "# Contributing\n\nEvery pull request requires approval from a maintainer listed in CODEOWNERS.\n"
+	const unterminatedFence = "# Setup\n\n```\nNew maintainers must be approved before receiving write access.\n"
+	const tildeFence = "# Setup\n\n~~~\nNew maintainers must be approved before receiving write access.\n~~~\n"
+	const quotedRequirement = "# Compliance\n\n> While active, the project documentation MUST have a policy that code contributors are reviewed prior to granting escalated permissions to sensitive resources.\n"
+	const calloutPolicy = "# Governance\n\n> Note: New maintainers must be approved before receiving write access.\n"
 
 	tests := []struct {
 		name           string
@@ -441,6 +445,34 @@ func TestHasEscalatedPermissionsReviewPolicy(t *testing.T) {
 			payload:        data.Payload{IsCodeRepo: true},
 			wantResult:     gemara.NeedsReview,
 			wantMsgPart:    "could not be completely inspected",
+			wantConfidence: gemara.Low,
+		},
+		{
+			name:           "policy inside an unterminated code fence is not credited",
+			payload:        escalationDocsPayload("README.md", unterminatedFence),
+			wantResult:     gemara.Failed,
+			wantMsgPart:    "No policy requiring review",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name:           "policy inside a tilde code fence is not credited",
+			payload:        escalationDocsPayload("README.md", tildeFence),
+			wantResult:     gemara.Failed,
+			wantMsgPart:    "No policy requiring review",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name:           "blockquoted requirement text is not credited as a policy",
+			payload:        escalationDocsPayload("README.md", quotedRequirement),
+			wantResult:     gemara.Failed,
+			wantMsgPart:    "No policy requiring review",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name:           "policy stated only in a blockquote defers to governance-file review",
+			payload:        escalationDocsPayload("GOVERNANCE.md", calloutPolicy),
+			wantResult:     gemara.NeedsReview,
+			wantMsgPart:    "governance document (GOVERNANCE.md)",
 			wantConfidence: gemara.Low,
 		},
 		{

--- a/evaluation_plans/osps/governance/steps_test.go
+++ b/evaluation_plans/osps/governance/steps_test.go
@@ -377,6 +377,8 @@ func TestHasEscalatedPermissionsReviewPolicy(t *testing.T) {
 	const mentionOnly = "# Roles\n\nNew maintainers typically get write access after a review by the core team.\n"
 	const splitSections = "# Roles\n\nMaintainers hold write access.\n\n# Reviews\n\nAll pull requests must be reviewed and approved.\n"
 	const fencedOnly = "# Setup\n\n```\nNew maintainers must be approved before receiving write access.\n```\n"
+	const pluralOnlyPolicy = "# Becoming a maintainer\n\nNew maintainers must be nominated and approved by a vote of existing maintainers.\n"
+	const reviewOfChangesOnly = "# Contributing\n\nEvery pull request requires approval from a maintainer listed in CODEOWNERS.\n"
 
 	tests := []struct {
 		name           string
@@ -438,7 +440,32 @@ func TestHasEscalatedPermissionsReviewPolicy(t *testing.T) {
 			name:           "unreadable documentation needs review",
 			payload:        data.Payload{IsCodeRepo: true},
 			wantResult:     gemara.NeedsReview,
-			wantMsgPart:    "could not be fully read",
+			wantMsgPart:    "could not be completely inspected",
+			wantConfidence: gemara.Low,
+		},
+		{
+			name:           "plural role nouns without an access phrase still pass",
+			payload:        escalationDocsPayload("GOVERNANCE.md", pluralOnlyPolicy),
+			wantResult:     gemara.Passed,
+			wantMsgPart:    "GOVERNANCE.md",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name:           "review of changes is not a policy about vetting people",
+			payload:        escalationDocsPayload("CONTRIBUTING.md", reviewOfChangesOnly),
+			wantResult:     gemara.Failed,
+			wantMsgPart:    "No policy requiring review",
+			wantConfidence: gemara.Medium,
+		},
+		{
+			name: "unparseable security insights needs review instead of failing",
+			payload: func() data.Payload {
+				payload := escalationDocsPayload("README.md", "# Hello\n\nA library.\n")
+				payload.InsightsError = true
+				return payload
+			}(),
+			wantResult:     gemara.NeedsReview,
+			wantMsgPart:    "could not be completely inspected",
 			wantConfidence: gemara.Low,
 		},
 		{


### PR DESCRIPTION
Closes #21

## What/Why

Implements OSPS-GV-04.01: project documentation must have a policy that code collaborators are reviewed prior to receiving escalated permissions to sensitive resources. The new `HasEscalatedPermissionsReviewPolicy` step scans repository documentation prose per markdown section for escalation vocabulary (maintainer, committer, write access, elevated permissions) paired with review vocabulary (reviewed, approved, nominated, vote): an uncontradicted requirement passes at Medium confidence; a pairing without obligation language, a negated requirement, a declared Security Insights `governance` URL, or a bare governance file all route to `NeedsReview` with distinct messages; and an observed absence of every signal fails, mirroring the GV-03.02 terminal. Code fences are stripped before analysis, vocabulary must co-occur within one section, negated or optional phrasing is never credited (the lesson from the VM-05 prose checks), and unreadable documentation is never reported as a violation.

## Proof it works

- 9-case step table asserting result, message, and confidence for every branch: non-code gating, clear policy, negated policy, mention without obligation, split-section isolation, fenced-code exclusion, governance-file fallback, unreadable docs, and observed absence.
- Security Insights fallback test plus a 7-case section-classifier table.
- `go test ./...` across all packages and `go test -race` on the governance package pass locally.

## Risk + AI role

Low: a new single-step check plus wiring; no existing control logic modified. AI-generated end to end with maintainer-approved design; allowing a `Passed` path guarded by negation screening (rather than a never-pass check) was an explicit maintainer decision.

## Review focus

- Vocabulary breadth: are the escalation and obligation patterns wide enough for real governance docs without inviting false passes?
- Whether `Passed` at Medium from a prose heuristic is the right ceiling for this MUST control.

Note: this will take a one-line mechanical README conflict against #445 for whichever merges second (both bump the implemented-controls count from 42).
