### PR TITLE
docs: describe step behavior instead of naming requirement IDs

### DIFF
--- a/evaluation_plans/osps/access_control/steps.go
+++ b/evaluation_plans/osps/access_control/steps.go
@@ -237,10 +237,9 @@ func summarizeFileList(files []string) string {
 	return fmt.Sprintf("%s, and %d more", strings.Join(files[:max], ", "), len(files)-max)
 }
 
-// WorkflowJobPermissionsLeastPrivilege implements OSPS-AC-04.02: when a job is
-// assigned permissions in a CI/CD pipeline, the source code or configuration
-// must only assign the minimum privileges necessary for the corresponding
-// activity.
+// WorkflowJobPermissionsLeastPrivilege assesses whether a CI/CD job that is
+// assigned permissions is granted only the minimum privileges necessary for the
+// corresponding activity.
 //
 // It inspects the workflow-level and job-level `permissions:` blocks of every
 // GitHub Actions workflow. A `write-all` grant gives the job's GITHUB_TOKEN

--- a/evaluation_plans/osps/build_release/steps.go
+++ b/evaluation_plans/osps/build_release/steps.go
@@ -137,8 +137,8 @@ func CicdSanitizedInputParameters(payload data.Payload) (gemara.Result, string, 
 		"GitHub Workflows variables do not contain untrusted inputs")
 }
 
-// CicdUntrustedCodeIsolation checks OSPS-BR-01.03: CI/CD pipelines that operate
-// on untrusted code snapshots must prevent access to privileged credentials.
+// CicdUntrustedCodeIsolation checks that CI/CD pipelines operating on untrusted
+// code snapshots prevent access to privileged credentials.
 //
 // The requirement is broad and only partly decidable by static analysis, so the
 // result is tiered to ensure a privileged workflow is never silently passed:
@@ -227,7 +227,7 @@ type namedWorkflow struct {
 }
 
 // classifyUntrustedCodeIsolation aggregates the per-workflow findings into the
-// tiered OSPS-BR-01.03 verdict documented on CicdUntrustedCodeIsolation. It is
+// tiered verdict documented on CicdUntrustedCodeIsolation. It is
 // separated from workflow decoding so the tiering logic is unit-testable without
 // a payload fixture.
 func classifyUntrustedCodeIsolation(workflows []namedWorkflow) (gemara.Result, string) {
@@ -744,8 +744,8 @@ func isHashManifest(lowerName string) bool {
 	return false
 }
 
-// ReleasesAreSignedOrAttested evaluates OSPS-BR-06.01: released assets must be
-// signed, or accounted for in a signed manifest. Evidence comes from a
+// ReleasesAreSignedOrAttested evaluates whether released assets are signed, or
+// accounted for in a signed manifest. Evidence comes from a
 // self-declared SLSA attestation in Security Insights or the signature assets
 // published with the release; a bare checksum manifest is flagged for review.
 //
@@ -884,9 +884,9 @@ func SecretsManagementPolicy(payload data.Payload) (result gemara.Result, messag
 	return gemara.NeedsReview, "No documented policy for managing secrets and credentials was found in the repository's security policy; manual review is required to confirm one exists elsewhere", gemara.Low
 }
 
-// DependenciesUseStandardizedTooling implements OSPS-BR-05.01: when a build and
-// release pipeline ingests dependencies, it MUST use standardized tooling where
-// available. GitHub's dependency graph only detects manifests produced by
+// DependenciesUseStandardizedTooling checks whether a build and release
+// pipeline that ingests dependencies uses standardized tooling where available.
+// GitHub's dependency graph only detects manifests produced by
 // standardized ecosystem tooling (e.g. go.mod, package.json, requirements.txt,
 // Cargo.toml, pom.xml), so the presence of at least one detected manifest is a
 // strong signal that dependencies are ingested through standardized tooling.
@@ -899,14 +899,15 @@ func DependenciesUseStandardizedTooling(payload data.Payload) (result gemara.Res
 	return gemara.NeedsReview, "No dependency manifests found in the GitHub dependency graph. Review the project to confirm that any dependencies ingested by the build and release pipeline use standardized tooling.", confidence
 }
 
-// CicdSanitizesCollaboratorInput implements OSPS-BR-01.04: CI/CD pipelines
-// which accept trusted collaborator input MUST sanitize and validate that
-// input prior to use in the pipeline.
+// CicdSanitizesCollaboratorInput checks that CI/CD pipelines accepting trusted
+// collaborator input sanitize and validate that input prior to use in the
+// pipeline.
 //
 // "Trusted collaborator input" here is workflow_dispatch inputs: values a
 // collaborator with write access types in when manually triggering a
-// workflow. Unlike OSPS-BR-01.01's fixed list of GitHub-controlled untrusted
-// metadata, workflow_dispatch input names are workflow-specific, so this
+// workflow. Unlike CicdSanitizedInputParameters, which works from a fixed list
+// of GitHub-controlled untrusted metadata, workflow_dispatch input names are
+// workflow-specific, so this
 // check derives the sensitive expressions from each workflow's own declared
 // inputs, then flags any of them interpolated directly into a run: step's
 // script body - both a single named field (inputs.<name> or
@@ -925,7 +926,7 @@ func DependenciesUseStandardizedTooling(payload data.Payload) (result gemara.Res
 //
 //   - An input assigned to a step-level env: var and referenced as a shell
 //     variable (e.g. "$TARGET") is not flagged, matching the convention used
-//     by CicdSanitizedInputParameters (OSPS-BR-01.01): that indirection is
+//     by CicdSanitizedInputParameters: that indirection is
 //     the recommended mitigation. This is a static, syntactic boundary
 //     rather than a dataflow proof - re-interpolating the env context back
 //     into a run: script (${{ env.TARGET }}) reintroduces the same

--- a/evaluation_plans/osps/docs/steps.go
+++ b/evaluation_plans/osps/docs/steps.go
@@ -70,11 +70,11 @@ func HasDependencyManagementPolicy(payload data.Payload) (result gemara.Result, 
 	return gemara.Failed, "Dependency management policy was NOT specified in Security Insights data", gemara.Medium
 }
 
-// DocumentsSecurityUpdatePolicy evaluates OSPS-DO-05.01: once a project has made
-// a release, its documentation must describe when releases or versions will no
-// longer receive security updates.
+// DocumentsSecurityUpdatePolicy evaluates whether a project that has made a
+// release documents when releases or versions will no longer receive security
+// updates.
 //
-// The requirement is conditional on a release existing, so a project with no
+// The assessment is conditional on a release existing, so a project with no
 // releases is NotApplicable rather than a failure. Security Insights'
 // support-policy field is the explicit, machine-readable signal; a SUPPORT.md
 // (or README "Support" section) is a weaker fallback that warrants review since

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -133,9 +133,9 @@ func NoBinariesInRepo(payload data.Payload) (result gemara.Result, message strin
 	return gemara.Failed, fmt.Sprintf("Suspected binaries found in the repository: %s", strings.Join(suspectedBinaries, ", ")), confidence
 }
 
-// NoUnreviewableBinariesInRepo is the assessment step for OSPS-QA-05.02.
-// It checks that the version control system does not contain unreviewable binary
-// artifacts such as compiled executables, shared libraries, or archive binaries.
+// NoUnreviewableBinariesInRepo checks that the version control system does not
+// contain unreviewable binary artifacts such as compiled executables, shared
+// libraries, or archive binaries.
 // Acceptable binary content (images, audio, video, fonts, PDFs) is not flagged.
 func NoUnreviewableBinariesInRepo(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	unreviewableBinaries := payload.Binaries.Unreviewable
@@ -300,9 +300,9 @@ func recordAIAssessment(payload data.Payload, controlID, fallbackMessage string,
 	return response.GemaraResult(), response.Summary(), response.GemaraConfidence()
 }
 
-// TestExecutionDocumentation assesses OSPS-QA-06.02: whether the project
-// documents when and how tests are run. Uses AI when configured, otherwise
-// falls back to manual review.
+// TestExecutionDocumentation assesses whether the project documents when and
+// how tests are run. Uses AI when configured, otherwise falls back to manual
+// review.
 func TestExecutionDocumentation(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if payload.Config == nil {
 		return gemara.NeedsReview, testExecutionDocumentationFallbackMessage, gemara.Low
@@ -333,9 +333,9 @@ func TestExecutionDocumentation(payload data.Payload) (result gemara.Result, mes
 	return recordAIAssessment(payload, "OSPS-QA-06.02", testExecutionDocumentationFallbackMessage, response, aiEvidence, sources)
 }
 
-// DocumentsTestMaintenancePolicy assesses OSPS-QA-06.03: whether the project
-// documents a policy requiring major changes to add or update tests. Uses AI
-// when configured, otherwise falls back to manual review.
+// DocumentsTestMaintenancePolicy assesses whether the project documents a
+// policy requiring major changes to add or update tests. Uses AI when
+// configured, otherwise falls back to manual review.
 func DocumentsTestMaintenancePolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	if payload.Config == nil {
 		return gemara.NeedsReview, documentsTestMaintenancePolicyFallbackMessage, gemara.Low
@@ -366,9 +366,9 @@ func DocumentsTestMaintenancePolicy(payload data.Payload) (result gemara.Result,
 	return recordAIAssessment(payload, "OSPS-QA-06.03", documentsTestMaintenancePolicyFallbackMessage, response, aiEvidence, sources)
 }
 
-// ReleasesHaveSBOM assesses OSPS-QA-02.02: when the project has made a release,
-// all compiled released software assets MUST be delivered with a software bill
-// of materials (SBOM).
+// ReleasesHaveSBOM assesses whether a project that has made a release delivers
+// every compiled released software asset with a software bill of materials
+// (SBOM).
 //
 // Evidence comes from the assets attached to GitHub releases. Security Insights
 // has no SBOM field, so the published assets are the only observable evidence.
@@ -675,8 +675,8 @@ func isSignatureOrChecksumAsset(lower string) bool {
 }
 
 // testExecutionDocumentationEvidence gathers README and CONTRIBUTING content
-// as AI input for OSPS-QA-06.02. Only these two files are included because the
-// control targets contributor-facing test guidance.
+// as AI input for TestExecutionDocumentation. Only these two files are included
+// because the assessment targets contributor-facing test guidance.
 func testExecutionDocumentationEvidence(payload data.Payload) (material string, sources []string, err error) {
 	var parts []string
 

--- a/evaluation_plans/osps/sec_assessment/steps.go
+++ b/evaluation_plans/osps/sec_assessment/steps.go
@@ -109,9 +109,9 @@ var InterfaceDocDirectories = []string{
 	"proto",
 }
 
-// HasExternalInterfaceDocumentation assesses OSPS-SA-02.01: when the project has
-// made a release, its documentation must describe all external software
-// interfaces (APIs) of the released assets.
+// HasExternalInterfaceDocumentation assesses whether a project that has made a
+// release documents all external software interfaces (APIs) of the released
+// assets.
 func HasExternalInterfaceDocumentation(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	// The requirement only applies once a release exists.
 	released, observable := reusable_steps.HasPublishedRelease(payload)
@@ -275,9 +275,9 @@ func securityAssessments(payload data.Payload) si.SecurityPosture {
 	return payload.Insights.Repository.SecurityPosture
 }
 
-// HasSecurityAssessment implements OSPS-SA-03.01: when the project has made a
-// release, it MUST perform a security assessment to understand the most likely
-// and impactful potential security problems in the software.
+// HasSecurityAssessment assesses whether a project that has made a release has
+// performed a security assessment covering the most likely and impactful
+// potential security problems in the software.
 func HasSecurityAssessment(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	released, observable := reusable_steps.HasPublishedRelease(payload)
 	if !observable {
@@ -314,10 +314,9 @@ func HasSecurityAssessment(payload data.Payload) (result gemara.Result, message 
 	return gemara.Failed, "Project has published releases but no security assessment was found in Security Insights", gemara.Medium
 }
 
-// HasThreatModelAnalysis implements OSPS-SA-03.02: when the project has made a
-// release, it MUST perform threat modeling and attack surface analysis to
-// understand and protect against attacks on critical code paths, functions,
-// and interactions within the system.
+// HasThreatModelAnalysis assesses whether a project that has made a release has
+// performed threat modeling and attack surface analysis covering attacks on
+// critical code paths, functions, and interactions within the system.
 func HasThreatModelAnalysis(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	released, observable := reusable_steps.HasPublishedRelease(payload)
 	if !observable {

--- a/evaluation_plans/osps/vuln_management/steps.go
+++ b/evaluation_plans/osps/vuln_management/steps.go
@@ -575,9 +575,9 @@ func requiredCheckMatchesSast(requiredContexts []string, sastSources []sastSourc
 	return matched, withPolicy
 }
 
-// SastEnforcedOnChanges implements OSPS-VM-06.02: all changes to the codebase
-// must be automatically evaluated for security weaknesses and blocked on
-// violations. It confirms both that a SAST tool runs on changes (in CI, per
+// SastEnforcedOnChanges checks that all changes to the codebase are
+// automatically evaluated for security weaknesses and blocked on violations.
+// It confirms both that a SAST tool runs on changes (in CI, per
 // Security Insights or a workflow triggered by pull_request/push) and that it is
 // enforced as a required status check that blocks merges to the default branch.
 func SastEnforcedOnChanges(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
@@ -623,7 +623,7 @@ func SastEnforcedOnChanges(payload data.Payload) (result gemara.Result, message 
 	return evaluateSastEnforcement(detection, requiredContexts, adminObservable)
 }
 
-// evaluateSastEnforcement applies the OSPS-VM-06.02 decision matrix to the
+// evaluateSastEnforcement applies the SastEnforcedOnChanges decision matrix to the
 // gathered signals, kept separate from data access so it can be unit tested with
 // plain inputs.
 func evaluateSastEnforcement(detection sastDetection, requiredContexts []string, adminObservable bool) (gemara.Result, string, gemara.ConfidenceLevel) {
@@ -714,8 +714,8 @@ func hasDisclosurePolicySignal(payload data.Payload) bool {
 	return false
 }
 
-// PublishesVulnerabilityData assesses OSPS-VM-04.01: the project must publicly
-// publish data about discovered vulnerabilities. A published GitHub Security
+// PublishesVulnerabilityData assesses whether the project publicly publishes
+// data about discovered vulnerabilities. A published GitHub Security
 // Advisory (GHSA) is direct, public evidence of that. When none are observable
 // the check never fails — a project may simply have had no vulnerabilities to
 // disclose yet — and instead defers to human review.
@@ -739,8 +739,8 @@ func PublishesVulnerabilityData(payload data.Payload) (result gemara.Result, mes
 	return gemara.NeedsReview, "No published GitHub security advisories were found; confirm manually whether the project publicly publishes data about discovered vulnerabilities", gemara.Low
 }
 
-// HasVexDocument assesses OSPS-VM-04.02: vulnerabilities in software components
-// not affecting the project must be accounted for in a VEX document. GitHub
+// HasVexDocument assesses whether vulnerabilities in software components that
+// do not affect the project are accounted for in a VEX document. GitHub
 // exposes no VEX signal, so the check looks for a VEX document published in the
 // repository. Absence cannot confirm a violation — the project may have no
 // non-affecting vulnerabilities to account for — so it defers to human review.
@@ -1604,8 +1604,9 @@ func findSCARepositoryPolicy(files []data.DocumentationFile) scaRepositoryPolicy
 	return policy
 }
 
-// HasSCARemediationThresholdPolicy evaluates OSPS-VM-05.01 using the text of
-// repository documentation. Security Insights pointers and dependency tooling
+// HasSCARemediationThresholdPolicy evaluates whether the project documents a
+// severity threshold at which SCA findings must be remediated, using the text
+// of repository documentation. Security Insights pointers and dependency tooling
 // are signals only because neither exposes the required threshold language.
 func HasSCARemediationThresholdPolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
 	files, docsErr := repositoryDocumentation(payload)
@@ -1633,7 +1634,8 @@ func HasSCARemediationThresholdPolicy(payload data.Payload) (result gemara.Resul
 	return gemara.Failed, "Repository documentation was completely inspected and no SCA remediation threshold covering vulnerabilities and licenses was found", gemara.Medium
 }
 
-// HasSCAReleasePolicy evaluates OSPS-VM-05.02 using explicit repository policy
+// HasSCAReleasePolicy evaluates whether the project documents that SCA
+// violations must be resolved before release, using explicit repository policy
 // language. Tool and workflow integrations remain NeedsReview signals because
 // they do not themselves state that violations must be resolved before release.
 func HasSCAReleasePolicy(payload data.Payload) (result gemara.Result, message string, confidence gemara.ConfidenceLevel) {
@@ -1663,7 +1665,7 @@ func HasSCAReleasePolicy(payload data.Payload) (result gemara.Result, message st
 	return gemara.Failed, "Repository documentation and release workflows were completely inspected and no policy requiring SCA violations to be addressed before release was found", gemara.Medium
 }
 
-// EnforcesSCAOnChanges evaluates OSPS-VM-05.03 end to end: a vulnerability or
+// EnforcesSCAOnChanges evaluates SCA enforcement end to end: a vulnerability or
 // malicious-dependency scanner must actively cover changes, its actual workflow
 // check context must exactly match a required check, and a documented policy
 // (including the non-exploitable-finding exception) must govern that gate.


### PR DESCRIPTION
Step doc comments had drifted into declaring which single requirement each step implements. That binding belongs in the dispatch map, which is already keyed by ID; a step that names one ID in its doc reads as though it may only ever serve that one, which is the opposite of the intent.

Comments only; every line in this diff begins with //.

Part of #448