### PR TITLE
fix: install the binary in ~/.privateer/bin folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,4 +77,6 @@ release-mac:
 	$(BUILD_MAC) -ldflags="$(BUILD_FLAGS) -X 'main.VersionPostfix=darwin'"
 
 bin:
-	@mv $(PACKNAME)* ~/privateer/bin
+	@echo "  >  Copying binary to ~/.privateer/bin ..."
+	@mkdir -p ~/.privateer/bin
+	@mv $(PACKNAME)* ~/.privateer/bin


### PR DESCRIPTION
Fix typo in the destination folder (missing dot). The plugin should be installed into ~/.privateer/bin folder. Make sure the destination folder is created.