### PR TITLE
fix(quality): observe classic stale-review dismissal in the approval gap

### DIFF
--- a/data/graphql-data.go
+++ b/data/graphql-data.go
@@ -31,6 +31,7 @@ type GraphqlRepoData struct {
 				RequiresCommitSignatures    bool
 				RequiresStatusChecks        bool
 				RequireLastPushApproval     bool
+				DismissesStaleReviews       bool
 				RequiredStatusCheckContexts []string
 			}
 

--- a/evaluation_plans/osps/quality/steps.go
+++ b/evaluation_plans/osps/quality/steps.go
@@ -152,7 +152,10 @@ func NoUnreviewableBinariesInRepo(payload data.Payload) (result gemara.Result, m
 
 // RequiresNonAuthorApproval checks that changes require at least one
 // non-author approving review before merging to the default branch. GitHub
-// forbids self-approval, so a required count >= 1 satisfies the catalog.
+// forbids self-approval, so a required count >= 1 meets the catalog text;
+// the verdict still routes to a human when the stale-approval gap below is
+// open, because the count alone does not prove post-approval commits are
+// reviewed.
 //
 // Rulesets are publicly readable and aggregated across every applying rule.
 // Classic branch protection is admin-only and reads as zero values otherwise,
@@ -170,12 +173,12 @@ func RequiresNonAuthorApproval(payload data.Payload) (result gemara.Result, mess
 
 	classicRequires := false
 	classicCount := 0
-	classicLastPush := false
+	classicStaleGapClosed := false
 	if payload.GraphqlRepoData != nil {
 		protection := payload.Repository.DefaultBranchRef.BranchProtectionRule
 		classicRequires = protection.RequiresApprovingReviews
 		classicCount = payload.Repository.DefaultBranchRef.RefUpdateRule.RequiredApprovingReviewCount
-		classicLastPush = protection.RequireLastPushApproval
+		classicStaleGapClosed = protection.RequireLastPushApproval || protection.DismissesStaleReviews
 	}
 
 	if ruleset.RequiredApprovals >= 1 || (classicRequires && classicCount >= 1) {
@@ -183,7 +186,7 @@ func RequiresNonAuthorApproval(payload data.Payload) (result gemara.Result, mess
 		if classicRequires && classicCount > approvals {
 			approvals = classicCount
 		}
-		staleGapClosed := ruleset.RequireLastPushApproval || ruleset.DismissStaleReviews || classicLastPush
+		staleGapClosed := ruleset.RequireLastPushApproval || ruleset.DismissStaleReviews || classicStaleGapClosed
 		if staleGapClosed {
 			return gemara.Passed, fmt.Sprintf("The default branch requires %d non-author approving review(s), and commits pushed after an approval cannot merge unreviewed", approvals), gemara.High
 		}

--- a/evaluation_plans/osps/quality/steps_test.go
+++ b/evaluation_plans/osps/quality/steps_test.go
@@ -1160,6 +1160,11 @@ func TestRequiresNonAuthorApproval(t *testing.T) {
 		g.Repository.DefaultBranchRef.RefUpdateRule.RequiredApprovingReviewCount = count
 		return g
 	}
+	classicDismissOnly := func(count int) *data.GraphqlRepoData {
+		g := classic(true, count, false)
+		g.Repository.DefaultBranchRef.BranchProtectionRule.DismissesStaleReviews = true
+		return g
+	}
 
 	tests := []struct {
 		name           string
@@ -1283,6 +1288,22 @@ func TestRequiresNonAuthorApproval(t *testing.T) {
 			},
 			wantResult:     gemara.Passed,
 			wantMsgPart:    "requires 1 non-author approving review(s)",
+			wantConfidence: gemara.High,
+		},
+		{
+			// Classic branch protection can close the stale-approval gap with
+			// dismissal alone; the ruleset arm already credits this, and the
+			// classic arm must observe the same field.
+			name: "classic stale-review dismissal closes the gap",
+			payload: data.Payload{
+				GraphqlRepoData: classicDismissOnly(2),
+				RepositoryMetadata: &fakeReviewRulesMetadata{
+					rules: data.PullRequestReviewRules{Observed: true},
+					admin: true,
+				},
+			},
+			wantResult:     gemara.Passed,
+			wantMsgPart:    "requires 2 non-author approving review(s)",
 			wantConfidence: gemara.High,
 		},
 		{


### PR DESCRIPTION
Follow-up to the two in-diff non-blocking items from the approval review on #447.

## What/Why

The classic branch protection arm of `RequiresNonAuthorApproval` read `RequireLastPushApproval` but not `DismissesStaleReviews`, so a classic-BP repo that closes the stale-approval gap with dismissal alone landed in `NeedsReview` while the ruleset arm credits the identical setting. The field now rides the existing GraphQL `BranchProtectionRule` selection and folds into the gap check. The step doc is also reworded: it claimed a required count >= 1 satisfies the catalog, while the code routes that case to review when the stale gap is open.

## Proof it works

- Red-first matrix row: classic protection with dismissal only, no last-push approval, passes at High; it failed before the field was observed.
- Full `go test ./...` green across all packages.

## Risk + AI role

Low. One GraphQL field on an already admin-gated selection, one boolean fold, comment wording. Both items were surfaced in the reviewer's approval pass on #447. AI-assisted, human-reviewed.

## Review focus

Non-admin behavior: `DismissesStaleReviews` decodes to zero for non-admin tokens like its neighboring fields, so the unobservable-classic path is unchanged. The third item from that review (`DefaultBranchRequiresPRReviews` reading only `PullRequest[0]`) is deliberately not here, since it intersects the in-flight #459 rewrite of that file.