### PR TITLE
chore: describe data-layer behavior instead of naming requirement IDs

### DIFF
--- a/data/graphql-binary-check.go
+++ b/data/graphql-binary-check.go
@@ -72,7 +72,7 @@ type binaryChecker struct {
 	branch     string
 }
 
-// check determines whether a file is a suspected executable binary per OSPS-QA-05.01.
+// check determines whether a file is a suspected executable binary artifact.
 // It uses GitHub's IsBinary field combined with Unix execute permission bits to identify
 // generated executable artifacts. Non-executable binaries (e.g. images) are not flagged.
 func (bc *binaryChecker) check(isBinaryPtr *bool, isTruncated bool, path string, mode int) (bool, error) {
@@ -85,12 +85,12 @@ func (bc *binaryChecker) check(isBinaryPtr *bool, isTruncated bool, path string,
 			// Git only uses mode 100755 for executables, but the bitwise check is more
 			// robust against non-standard modes from other Git implementations.
 			// Non-executable binaries (e.g. PNG, PDF) are not "generated executable artifacts"
-			// per OSPS-QA-05.01 and should not be flagged.
+			// and should not be flagged.
 			return false, nil
 		}
 		// File is binary with an execute bit set. Acceptable binary formats (images,
-		// audio, video, fonts, documents) are not "generated executable artifacts" per
-		// OSPS-QA-05.01 even when a stray execute bit is present — a common artifact of
+		// audio, video, fonts, documents) are not "generated executable artifacts"
+		// even when a stray execute bit is present — a common artifact of
 		// checkouts from filesystems without Unix permissions — so they are not flagged.
 		if acceptableBinaryExtension(path) {
 			return false, nil
@@ -205,7 +205,7 @@ func commonAcceptableFileExtension(path string) bool {
 // acceptableBinaryExtension returns true for binary file types that are considered
 // reviewable or acceptable in a repository, such as images, audio, video, fonts,
 // documents, and design-tool source files.
-// These are excluded from OSPS-QA-05.02 "unreviewable binary artifacts" checks.
+// These are excluded from "unreviewable binary artifacts" checks.
 func acceptableBinaryExtension(path string) bool {
 	ext := fileExtension(path)
 	if ext == "" {
@@ -229,8 +229,8 @@ func acceptableBinaryExtension(path string) bool {
 	return slices.Contains(extensions, ext)
 }
 
-// checkUnreviewable determines whether a file is an unreviewable binary artifact
-// per OSPS-QA-05.02. Unlike check(), which only flags executable binaries,
+// checkUnreviewable determines whether a file is an unreviewable binary artifact.
+// Unlike check(), which only flags executable binaries,
 // this flags all binary files except those with acceptable extensions (images,
 // audio, video, fonts, documents, design assets) that are legitimately stored
 // in binary format.
@@ -322,7 +322,7 @@ func walkTree(tree *GraphqlRepoTree, fn blobCheckFn) (flagged []string, err erro
 }
 
 // checkTreeForUnreviewableBinaries returns file names that are unreviewable binary
-// artifacts (OSPS-QA-05.02), excluding acceptable formats like images, audio, and fonts.
+// artifacts, excluding acceptable formats like images, audio, and fonts.
 func checkTreeForUnreviewableBinaries(tree *GraphqlRepoTree, bc *binaryChecker) ([]string, error) {
 	return walkTree(tree, func(isBinary *bool, isTruncated bool, path string, _ int) (bool, error) {
 		return bc.checkUnreviewable(isBinary, isTruncated, path)

--- a/data/payload.go
+++ b/data/payload.go
@@ -39,8 +39,8 @@ type Payload struct {
 
 // BinaryAnalysis holds information about binaries found in the repo
 type BinaryAnalysis struct {
-	Suspected    []string // OSPS-QA-05.01: suspected executable binary artifacts
-	Unreviewable []string // OSPS-QA-05.02: unreviewable binary artifacts
+	Suspected    []string // suspected executable binary artifacts
+	Unreviewable []string // unreviewable binary artifacts
 	Err          error
 }
 

--- a/data/rest-data.go
+++ b/data/rest-data.go
@@ -207,7 +207,7 @@ func (r *RestData) checkFile(filename string) (filepath string) {
 // checkFileInSubdir returns the path to filename within the given subdirectory
 // (case-insensitive), or "" when the directory or file is absent. It lets build
 // documentation stored outside the root and .github (e.g. docs/BUILDING.md) be
-// discovered per OSPS-DO-07.01.
+// discovered.
 func (r *RestData) checkFileInSubdir(dir, filename string) string {
 	subdir, err := r.getSubdirContents(dir)
 	if err != nil {
@@ -277,10 +277,10 @@ func (r *RestData) HasSupportMarkdown() bool {
 }
 
 // buildInstructionFiles are well-known files whose presence indicates the
-// project documents how to build the software from source, satisfying
-// OSPS-DO-07.01 as developer task documentation or build automation. Matching
-// is case-insensitive (see checkFile), so a single canonical spelling covers
-// common variants such as "makefile" or "MAKEFILE".
+// project documents how to build the software from source, as developer task
+// documentation or build automation. Matching is case-insensitive (see
+// checkFile), so a single canonical spelling covers common variants such as
+// "makefile" or "MAKEFILE".
 var buildInstructionFiles = []string{
 	"Makefile",
 	"GNUmakefile",
@@ -294,8 +294,8 @@ var buildInstructionFiles = []string{
 }
 
 // buildInstructionHeadings are documentation section headings that indicate the
-// project explains how to build or set up the software from source per
-// OSPS-DO-07.01. Matching is case-insensitive and substring-based (see
+// project explains how to build or set up the software from source.
+// Matching is case-insensitive and substring-based (see
 // hasBuildInstructionHeading), so short roots such as "build" and "compil"
 // intentionally cover their variants ("building", "build from source",
 // "compiling", "compilation", etc.).
@@ -319,7 +319,7 @@ var buildInstructionHeadingExclusions = []string{
 }
 
 // hasBuildInstructionHeading reports whether any of the provided document
-// headings references build-from-source instructions per OSPS-DO-07.01.
+// headings references build-from-source instructions.
 func hasBuildInstructionHeading(headings []string) bool {
 	for _, heading := range headings {
 		normalized := strings.ToLower(strings.TrimSpace(heading))
@@ -347,7 +347,7 @@ func isExcludedBuildHeading(normalized string) bool {
 }
 
 // HasBuildInstructions returns true when the repository documents how to build
-// the software from source per OSPS-DO-07.01. It is satisfied by a well-known
+// the software from source. It is satisfied by a well-known
 // build automation or build documentation file (e.g. Makefile, BUILDING.md) in
 // the repository root, .github, or docs directory, or by a build-related
 // section heading in the README or CONTRIBUTING guide.

--- a/data/vex.go
+++ b/data/vex.go
@@ -74,7 +74,7 @@ func hasVexDirSegment(dir string) bool {
 // detectVexDocuments walks the already-fetched repository tree and returns the
 // repo-root-relative paths of files that look like VEX documents. It reuses the
 // tree gathered for binary analysis, so it adds no extra API calls. Paths (not
-// bare names) are collected so the OSPS-VM-04.02 evidence message is unambiguous
+// bare names) are collected so the evidence message is unambiguous
 // when a VEX file lives in a subdirectory (e.g. security/vex/bom.json).
 func detectVexDocuments(tree *GraphqlRepoTree) []string {
 	if tree == nil {

--- a/data/vuln_reporting.go
+++ b/data/vuln_reporting.go
@@ -68,7 +68,7 @@ func (r *RestData) getPrivateVulnReporting() {
 // loadSecurityPolicy locates SECURITY.md and, when present, fetches its content.
 // Presence alone is answered from already-cached directory listings; the content
 // fetch is the only added API call, and it happens only when the file exists so
-// that its body can back the SECURITY.md contact fallback in OSPS-VM-02.
+// that its body can back the SECURITY.md contact fallback.
 func (r *RestData) loadSecurityPolicy() {
 	path := r.checkFile("security.md")
 	if path == "" {
@@ -99,7 +99,7 @@ type securityAdvisory struct {
 // getSecurityAdvisories queries the repository security advisories endpoint for
 // published advisories and records how many were found on RestData. A published
 // GitHub Security Advisory (GHSA) is public evidence that the project publishes
-// data about discovered vulnerabilities (OSPS-VM-04.01).
+// data about discovered vulnerabilities.
 //
 // Any failure — including the 403/404 GitHub returns when the advisory database
 // is unavailable for a repository or the token lacks access — leaves Known false

--- a/evaluation_plans/osps/legal/steps.go
+++ b/evaluation_plans/osps/legal/steps.go
@@ -172,7 +172,7 @@ func releaseLabel(release data.ReleaseData) string {
 }
 
 // ReleasesLicensed assesses whether released software assets include their
-// license (OSPS-LE-03.02, and the license-presence half of OSPS-LE-02.02).
+// license.
 //
 // The assessment is scoped to the latest published release, which reflects the
 // project's current licensing posture. Two release-time hazards drive the


### PR DESCRIPTION
## Summary
- Continues the #451 cleanup for the ID-to-logic coupling described in #448: reworded doc comments that named a specific OSPS requirement ID to describe the assessed behavior instead.
- Scope: the `data/` package (`payload.go`, `graphql-binary-check.go`, `rest-data.go`, `vex.go`, `vuln_reporting.go`) plus `evaluation_plans/osps/legal/steps.go`'s `ReleasesLicensed`.
- The dispatch map in `evaluation_plans/evaluation-plans.go` already owns the ID-to-logic binding; the `data/` payload layer in particular gathers GitHub data that isn't catalog-specific to begin with, so naming a specific control there is the same drift #451 fixed elsewhere.
- Note: #448's checklist lists 14 references in `data/`, but `vuln_reporting.go` actually has 2 (not 1 as counted there), so this PR rewords 15 in `data/` plus 1 in `legal/steps.go` — 16 total.
- Comment-only change; no behavior change.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./data/... ./evaluation_plans/osps/legal/...`
